### PR TITLE
fix: keep pipeline statuses out of new candidates

### DIFF
--- a/apps/api/src/routes/candidate-status.ts
+++ b/apps/api/src/routes/candidate-status.ts
@@ -9,6 +9,7 @@ import { config } from "../services/config.js";
 import { workspaceConfigService } from "../services/workspace-config-service.js";
 import { logger } from "../services/logger.js";
 import { getAuthenticatedActorId, requireWorkspaceUser } from "../middleware/auth.js";
+import { CandidateStatusEnumSchema } from "../schemas/index.js";
 
 const app = new OpenAPIHono();
 
@@ -20,28 +21,11 @@ app.use("/api/candidate-status", async (c, next) => {
 });
 
 
-const CandidateStatusEnum = z.enum([
-  "new",
-  "shortlisted",
-  "rejected",
-  "contacted",
-  "interviewing",
-  "interviewed_pass",
-  "interviewed_reject",
-  "appeal_submitted",
-  "human_review",
-  "upheld",
-  "reversed",
-  "offer",
-  "hired",
-  "withdrawn",
-]);
-
 const CandidateStatusSchema = z.object({
   _id: z.string(),
   identityKey: z.string(),
   workspaceSlug: z.string(),
-  status: CandidateStatusEnum,
+  status: CandidateStatusEnumSchema,
   notes: z.string().optional(),
   updatedBy: z.string().optional(),
   updatedAt: z.number(),
@@ -59,7 +43,7 @@ const ListResponseSchema = z.object({
 
 const UpdateRequestSchema = z.object({
   identityKey: z.string(),
-  status: CandidateStatusEnum,
+  status: CandidateStatusEnumSchema,
   notes: z.string().optional(),
   updatedBy: z.string().optional(),
 });

--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -382,6 +382,7 @@ describe("resume routes", () => {
             { _id: "d1", resumeId: "resume-visible-new", source: "seek", sourceKey: "seek", searchText: "cnc sales", isArchived: false },
             { _id: "d2", resumeId: "resume-blocked-new", source: "seek", sourceKey: "seek", searchText: "cnc sales", isArchived: false },
             { _id: "d3", resumeId: "resume-visible-rejected", source: "seek", sourceKey: "seek", searchText: "cnc sales", isArchived: false },
+            { _id: "d4", resumeId: "k172rcvmvqj4hhn98r74r3brps82v28b", source: "seek", sourceKey: "seek", searchText: "cnc sales", isArchived: false },
           ],
           isDone: true,
           cursor: null,
@@ -414,6 +415,14 @@ describe("resume routes", () => {
             searchText: "cnc sales",
             isArchived: false,
           },
+          {
+            ...buildConvexResumeRecord("k172rcvmvqj4hhn98r74r3brps82v28b", {
+              identityKey: "ik-interviewed-pass",
+              name: "周先生",
+            }),
+            searchText: "cnc sales",
+            isArchived: false,
+          },
         ]);
       }
 
@@ -421,6 +430,7 @@ describe("resume routes", () => {
         expect(call.args).toEqual(expect.objectContaining({ workspaceSlug: "hr" }));
         return convexSuccess([
           { identityKey: "ik-visible-rejected", status: "rejected" },
+          { identityKey: "ik-interviewed-pass", status: "interviewed_pass" },
         ]);
       }
 
@@ -443,10 +453,11 @@ describe("resume routes", () => {
 
     expect(response.status).toBe(200);
     const payload = await response.json();
-    expect(payload.summary.statusCounts).toEqual({
+    expect(payload.summary.statusCounts).toMatchObject({
       new: 1,
       shortlisted: 0,
       rejected: 1,
+      interviewed_pass: 1,
     });
     expect(calls.some((call) => call.pathName === "candidate_blocks:list")).toBe(true);
   });

--- a/apps/api/src/routes/resumes_search.ts
+++ b/apps/api/src/routes/resumes_search.ts
@@ -20,6 +20,7 @@ import {
   ResumeKeywordExpansionQuerySchema,
   ResumeKeywordExpansionResponseSchema,
   ResumeSamplesResponseSchema,
+  CANDIDATE_STATUS_VALUES,
 } from "../schemas/index.js";
 import { resolveResumeId } from "../services/resume-id.js";
 import { callConvexAction, callConvexQuery, isConvexPaginatedQueryPage } from "../services/convex-utils.js";
@@ -82,6 +83,36 @@ const searchEventLogger = new SearchEventLogger(config.projectRoot);
 
 const DEFAULT_CONVEX_RESUME_PAGE_SIZE = 50;
 const MAX_SAFE_CONVEX_POST_FILTER_SCAN = 250;
+type CandidateStatus = typeof CANDIDATE_STATUS_VALUES[number];
+type CandidateStatusCounts = Record<CandidateStatus, number>;
+const CANDIDATE_STATUS_SET: ReadonlySet<string> = new Set(CANDIDATE_STATUS_VALUES);
+
+function createCandidateStatusCounts(): CandidateStatusCounts {
+  return {
+    new: 0,
+    shortlisted: 0,
+    rejected: 0,
+    contacted: 0,
+    interviewing: 0,
+    interviewed_pass: 0,
+    interviewed_reject: 0,
+    appeal_submitted: 0,
+    human_review: 0,
+    upheld: 0,
+    reversed: 0,
+    offer: 0,
+    hired: 0,
+    withdrawn: 0,
+  };
+}
+
+function isCandidateStatus(value: string): value is CandidateStatus {
+  return CANDIDATE_STATUS_SET.has(value);
+}
+
+function resolveCandidateStatus(value: string | undefined): CandidateStatus {
+  return value && isCandidateStatus(value) ? value : "new";
+}
 
 export function scorePreparedCandidates(
   prepared: PreparedResumeCandidate[],
@@ -961,7 +992,7 @@ app.openapi(getResumesRoute, (c) => {
           : pagedWorking.map((item) => item.resume);
 
         // Compute status counts from working set identityKeys
-        let statusCounts: { new: number; shortlisted: number; rejected: number } | undefined;
+        let statusCounts: CandidateStatusCounts | undefined;
         try {
           const [statusList, blockList] = await Promise.all([
             callConvexQuery("candidate_status:list", {
@@ -985,7 +1016,7 @@ app.openapi(getResumesRoute, (c) => {
               blockedIdentities.add(String(block.identityKey));
             }
           }
-          const counts: Record<string, number> = { new: 0, shortlisted: 0, rejected: 0 };
+          const counts = createCandidateStatusCounts();
           const sourceItems = (usesPrePagedMatchResults || isSourcePaginated) ? working : pagedWorking;
           for (const item of sourceItems) {
             const resume = item.resume as Record<string, unknown> | undefined;
@@ -993,17 +1024,11 @@ app.openapi(getResumesRoute, (c) => {
             if (identityKey && blockedIdentities.has(identityKey)) {
               continue;
             }
-            // Match Convex countResumesByStatus: missing identityKey → "new";
-            // non-standard statuses (contacted, interviewing, etc.) → "new"
             const status = identityKey ? (statusMap.get(identityKey) ?? "new") : "new";
-            const bucket = status in counts ? status : "new";
-            counts[bucket] = (counts[bucket] ?? 0) + 1;
+            const bucket = resolveCandidateStatus(status);
+            counts[bucket] += 1;
           }
-          statusCounts = {
-            new: counts.new ?? 0,
-            shortlisted: counts.shortlisted ?? 0,
-            rejected: counts.rejected ?? 0,
-          };
+          statusCounts = counts;
         } catch {
           statusCounts = undefined;
         }
@@ -1160,7 +1185,7 @@ app.openapi(getResumesRoute, (c) => {
           total: 0,
           returned: 0,
           query: keyword,
-          statusCounts: { new: 0, shortlisted: 0, rejected: 0 },
+          statusCounts: createCandidateStatusCounts(),
         },
         data: [],
       }, 200);

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -1,6 +1,6 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 
-import { ResumeFiltersSchema } from "../schemas/index.js";
+import { CandidateStatusEnumSchema, ResumeFiltersSchema } from "../schemas/index.js";
 import { config } from "../services/config.js";
 import { SessionManager } from "../services/session-manager.js";
 
@@ -8,28 +8,12 @@ const app = new OpenAPIHono();
 const sessionManager = new SessionManager(config.projectRoot);
 
 const SessionStatusSchema = z.enum(["active", "completed", "archived"]);
-const CandidateStatusSchema = z.enum([
-  "new",
-  "shortlisted",
-  "rejected",
-  "contacted",
-  "interviewing",
-  "interviewed_pass",
-  "interviewed_reject",
-  "appeal_submitted",
-  "human_review",
-  "upheld",
-  "reversed",
-  "offer",
-  "hired",
-  "withdrawn",
-]);
 const SessionFiltersSchema = ResumeFiltersSchema.extend({
   minRoleYears: z.number().min(0).optional(),
   roleFilterType: z.string().optional(),
   minAge: z.number().min(0).optional(),
   maxAge: z.number().min(0).optional(),
-  status: z.array(CandidateStatusSchema).optional(),
+  status: z.array(CandidateStatusEnumSchema).optional(),
   showBlocked: z.boolean().optional(),
   showRejected: z.boolean().optional(),
 });

--- a/apps/api/src/schemas/resumes.ts
+++ b/apps/api/src/schemas/resumes.ts
@@ -358,25 +358,46 @@ export const CandidateActionBackupSchema = z
   })
   .openapi("CandidateActionBackup");
 
+export const CANDIDATE_STATUS_VALUES = [
+  "new",
+  "shortlisted",
+  "rejected",
+  "contacted",
+  "interviewing",
+  "interviewed_pass",
+  "interviewed_reject",
+  "appeal_submitted",
+  "human_review",
+  "upheld",
+  "reversed",
+  "offer",
+  "hired",
+  "withdrawn",
+] as const;
+
+export const CandidateStatusEnumSchema = z.enum(CANDIDATE_STATUS_VALUES);
+
+const CandidateStatusCountsSchema = z.object({
+  new: z.number().int(),
+  shortlisted: z.number().int(),
+  rejected: z.number().int(),
+  contacted: z.number().int(),
+  interviewing: z.number().int(),
+  interviewed_pass: z.number().int(),
+  interviewed_reject: z.number().int(),
+  appeal_submitted: z.number().int(),
+  human_review: z.number().int(),
+  upheld: z.number().int(),
+  reversed: z.number().int(),
+  offer: z.number().int(),
+  hired: z.number().int(),
+  withdrawn: z.number().int(),
+});
+
 export const CandidateStatusBackupSchema = z
   .object({
     identityKey: z.string().openapi({ example: "profileUrl:https://hr.job5156.com/resume/view/123" }),
-    status: z.enum([
-      "new",
-      "shortlisted",
-      "rejected",
-      "contacted",
-      "interviewing",
-      "interviewed_pass",
-      "interviewed_reject",
-      "appeal_submitted",
-      "human_review",
-      "upheld",
-      "reversed",
-      "offer",
-      "hired",
-      "withdrawn",
-    ]).openapi({ example: "interviewing" }),
+    status: CandidateStatusEnumSchema.openapi({ example: "interviewing" }),
     notes: z.string().optional().openapi({ example: "Strong candidate" }),
     updatedBy: z.string().optional().openapi({ example: "hr.lead" }),
     updatedAt: z.number().openapi({ example: 1710489600000 }),
@@ -690,11 +711,7 @@ export const ResumesResponseSchema = z
         keywordGroups: z.array(KeywordGroupSchema).optional(),
         sourceMapping: z.record(z.string(), z.string()).optional(),
         searchMode: z.enum(["bm25", "bm25_fallback", "bm25_only_no_vectors", "hybrid"]).optional(),
-        statusCounts: z.object({
-          new: z.number().int(),
-          shortlisted: z.number().int(),
-          rejected: z.number().int(),
-        }).optional(),
+        statusCounts: CandidateStatusCountsSchema.optional(),
       })
       .optional(),
     data: z.array(ResumeItemSchema),

--- a/apps/web/src/hooks/resume-filter-helpers.test.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.test.ts
@@ -203,10 +203,25 @@ describe('toStatusFilterList', () => {
     expect(result).toEqual(['contacted', 'hired', 'new'])
   })
 
-  it('accepts all valid statuses', () => {
-    const all = ['new', 'contacted', 'interviewing', 'interviewed_pass', 'interviewed_reject', 'offer', 'hired', 'withdrawn'] as const
-    const result = toStatusFilterList([...all])
-    expect(result).toHaveLength(8)
+  it('accepts every valid candidate status', () => {
+    const all = [
+      'new',
+      'shortlisted',
+      'rejected',
+      'contacted',
+      'interviewing',
+      'interviewed_pass',
+      'interviewed_reject',
+      'appeal_submitted',
+      'human_review',
+      'upheld',
+      'reversed',
+      'offer',
+      'hired',
+      'withdrawn',
+    ] as const satisfies readonly CandidateStatus[]
+
+    expect(toStatusFilterList([...all])).toEqual([...all].sort())
   })
 })
 

--- a/apps/web/src/hooks/resume-filter-helpers.ts
+++ b/apps/web/src/hooks/resume-filter-helpers.ts
@@ -3,7 +3,7 @@ import { formatKeywordQuery, formatLocationHierarchySearchText, getVerifiedRoleS
 import { resolveResumeAnalysisSourceKey } from '@trends/shared'
 import type { ExperienceLevelFilter, UrlSearchState } from '@/hooks/useUrlSearchState'
 
-import type { CandidateStatus, ResumeFilters } from '@/types/resume'
+import { CANDIDATE_STATUS_VALUES, type CandidateStatus, type ResumeFilters } from '@/types/resume'
 import type { CollectionSource } from '@/lib/search-profile-sources'
 
 const EDUCATION_KEYWORDS: Record<string, string[]> = {
@@ -13,6 +13,8 @@ const EDUCATION_KEYWORDS: Record<string, string[]> = {
   master: ['硕士', '研究生', 'master'],
   phd: ['博士', 'phd', 'doctor'],
 }
+
+const CANDIDATE_STATUS_SET = new Set<CandidateStatus>(CANDIDATE_STATUS_VALUES)
 
 export function normalizeFilterToken(value: string): string {
   return value.trim().toLowerCase()
@@ -76,16 +78,7 @@ export function toStatusFilterList(values: CandidateStatus[] | undefined): Candi
 
   const unique = new Set<CandidateStatus>()
   values.forEach((value) => {
-    if (
-      value === 'new'
-      || value === 'contacted'
-      || value === 'interviewing'
-      || value === 'interviewed_pass'
-      || value === 'interviewed_reject'
-      || value === 'offer'
-      || value === 'hired'
-      || value === 'withdrawn'
-    ) {
+    if (CANDIDATE_STATUS_SET.has(value)) {
       unique.add(value)
     }
   })

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -6,6 +6,7 @@ import { api } from '../../../../packages/convex/convex/_generated/api'
 import type { Doc } from '../../../../packages/convex/convex/_generated/dataModel'
 import { withRetry } from '@/lib/retry'
 import { rawApiClient } from '@/lib/api-helpers'
+import type { CandidateStatus } from '@/types/resume'
 import type { ResumeItem } from './useResumes'
 
 export const DEFAULT_CONVEX_RESUME_LIMIT = 200
@@ -798,7 +799,7 @@ type BffAndModeResult = {
   total: number
   expansion: KeywordExpansionSummary | null
   loading: boolean
-  statusCounts?: { new: number; shortlisted: number; rejected: number }
+  statusCounts?: Partial<Record<CandidateStatus, number>>
 }
 
 function useBffAndModeSearch(
@@ -868,7 +869,7 @@ function useBffAndModeSearch(
             keywordGroups?: Array<{ original: string; variants: string[] }>
             expandedTo?: string[]
             sourceMapping?: Record<string, string>
-            statusCounts?: { new: number; shortlisted: number; rejected: number }
+            statusCounts?: Partial<Record<CandidateStatus, number>>
           }
           data?: Array<Record<string, unknown>>
         }>('/api/resumes', {

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -1926,7 +1926,7 @@ describe('useResumeSearchState', () => {
     expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-1'])
   })
 
-  it('treats pipeline-only statuses as part of the new triage bucket', () => {
+  it('excludes explicit pipeline statuses from the default new triage bucket', () => {
     Object.assign(parsedStateMock, createParsedState({
       query: 'CNC 销售',
       keywords: ['CNC', '销售'],
@@ -1940,16 +1940,31 @@ describe('useResumeSearchState', () => {
     )
     statusByIdentityMock['identity-1'] = createStatusRecord('identity-1', 'new')
     statusByIdentityMock['identity-2'] = createStatusRecord('identity-2', 'contacted')
-    statusByIdentityMock['identity-3'] = createStatusRecord('identity-3', 'interviewing')
+    statusByIdentityMock['identity-3'] = createStatusRecord('identity-3', 'interviewed_pass')
     statusByIdentityMock['identity-4'] = createStatusRecord('identity-4', 'rejected')
 
     const { result } = renderHook(() => useResumeSearchState())
 
-    expect(result.current.filteredResults.map((item) => item.key)).toEqual([
-      'resume-1',
-      'resume-2',
-      'resume-3',
-    ])
+    expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-1'])
+  })
+
+  it('includes interviewed_pass resumes when explicitly filtered', () => {
+    Object.assign(parsedStateMock, createParsedState({
+      query: 'CNC 销售',
+      keywords: ['CNC', '销售'],
+      filters: { status: ['interviewed_pass'] },
+    }))
+
+    resumesMock.push(
+      createResume(1, { primaryRuleScore: 95 }),
+      createResume(2, { primaryRuleScore: 90 }),
+    )
+    statusByIdentityMock['identity-1'] = createStatusRecord('identity-1', 'new')
+    statusByIdentityMock['identity-2'] = createStatusRecord('identity-2', 'interviewed_pass')
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    expect(result.current.filteredResults.map((item) => item.key)).toEqual(['resume-2'])
   })
 
   it('hides blocked new resumes from results and status facets by default', () => {
@@ -1994,6 +2009,7 @@ describe('useResumeSearchState', () => {
           new: 797,
           shortlisted: 0,
           rejected: 1,
+          interviewed_pass: 3,
           total: 798,
           overflow: false,
         }
@@ -2009,6 +2025,7 @@ describe('useResumeSearchState', () => {
 
     expect(result.current.facetCounts.statuses).toEqual([
       { value: 'new', count: 797, label: 'New candidate' },
+      { value: 'interviewed_pass', count: 3 },
       { value: 'rejected', count: 1 },
     ])
   })
@@ -2038,13 +2055,14 @@ describe('useResumeSearchState', () => {
       loading: false,
       loadingMore: false,
       isAndModeBff: true,
-      bffStatusCounts: { new: 797, shortlisted: 0, rejected: 1 },
+      bffStatusCounts: { new: 797, shortlisted: 0, rejected: 1, interviewed_pass: 3 },
     }))
 
     const { result } = renderHook(() => useResumeSearchState())
 
     expect(result.current.facetCounts.statuses).toEqual([
       { value: 'new', count: 797, label: 'New candidate' },
+      { value: 'interviewed_pass', count: 3 },
       { value: 'rejected', count: 1 },
     ])
   })

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -52,11 +52,12 @@ import {
 import { parseExperienceYears } from '@/lib/resume-filtering'
 import { getCollectionSourceMarket, resolveCollectionSource, getSourceLabelFromHostname } from '@/lib/search-profile-sources'
 import type { SearchHistoryItem } from '@/hooks/useSession'
-import type {
-  CandidateActionType,
-  CandidateStatus,
-  ResumeExportFormat,
-  ResumeFilters,
+import {
+  CANDIDATE_STATUS_VALUES,
+  type CandidateActionType,
+  type CandidateStatus,
+  type ResumeExportFormat,
+  type ResumeFilters,
 } from '@/types/resume'
 import type {
   FacetCounts,
@@ -68,7 +69,7 @@ import type {
 const INITIAL_RESUME_LIMIT = 200
 const RESUME_PAGE_INCREMENT = 200
 const SESSION_KEY_PREFIX = 'trends.resume.search.sessionKey'
-const SERVER_STATUS_FACET_VALUES = ['new', 'shortlisted', 'rejected'] as const
+const SERVER_STATUS_FACET_VALUES = CANDIDATE_STATUS_VALUES
 
 type JobDescriptionApiResponse = {
   success: boolean
@@ -466,16 +467,11 @@ function buildSearchExportEntry(
 }
 
 const DEFAULT_STATUS_WHEN_EMPTY: CandidateStatus = 'new'
-const PRIMARY_STATUS_BUCKETS = new Set<CandidateStatus>(SERVER_STATUS_FACET_VALUES)
 
 const ACTION_TO_STATUS: Partial<Record<CandidateActionType, CandidateStatus>> = {
   shortlist: 'shortlisted',
   reject: 'rejected',
   star: 'new',
-}
-
-function getPrimaryStatusBucket(status: CandidateStatus): typeof SERVER_STATUS_FACET_VALUES[number] {
-  return status === 'shortlisted' || status === 'rejected' ? status : 'new'
 }
 
 function matchesBlockVisibility(
@@ -559,7 +555,6 @@ function matchesLocalFilters(
   const education = item.resume.education?.trim().toLowerCase() ?? ''
   const experienceLevel = normalizeExperienceLevel(item.resume.ingestData?.experienceLevel)
   const minScore = state.filters.minMatchScore
-  const statusBucket = getPrimaryStatusBucket(item.status)
 
   if (!matchesBlockVisibility(item, state.filters)) {
     return false
@@ -623,15 +618,11 @@ function matchesLocalFilters(
 
   // Default: show only new (untriaged) resumes unless user explicitly filters for a status
   if (normalizedStatuses.length > 0) {
-    const matchesSelectedStatus = normalizedStatuses.some((status) =>
-      PRIMARY_STATUS_BUCKETS.has(status)
-        ? getPrimaryStatusBucket(status) === statusBucket
-        : item.status === status,
-    )
+    const matchesSelectedStatus = normalizedStatuses.some((status) => item.status === status)
     if (!matchesSelectedStatus) {
       return false
     }
-  } else if (statusBucket !== DEFAULT_STATUS_WHEN_EMPTY) {
+  } else if (item.status !== DEFAULT_STATUS_WHEN_EMPTY && !(state.filters.showRejected === true && item.status === 'rejected')) {
     return false
   }
 

--- a/apps/web/src/hooks/useStatusCounts.test.ts
+++ b/apps/web/src/hooks/useStatusCounts.test.ts
@@ -42,6 +42,7 @@ describe("useStatusCounts", () => {
       new: 42,
       shortlisted: 7,
       rejected: 3,
+      interviewed_pass: 2,
       total: 52,
       overflow: false,
     });
@@ -56,6 +57,7 @@ describe("useStatusCounts", () => {
     expect(result.current.new).toBe(42);
     expect(result.current.shortlisted).toBe(7);
     expect(result.current.rejected).toBe(3);
+    expect(result.current).toMatchObject({ interviewed_pass: 2 });
     expect(result.current.total).toBe(52);
     expect(result.current.overflow).toBe(false);
   });
@@ -90,12 +92,13 @@ describe("useStatusCounts", () => {
 
     const { useStatusCounts } = await import("@/hooks/useStatusCounts");
     const filters: ConvexResumeFilters = {};
+    const bffStatusCounts = { new: 100, shortlisted: 20, rejected: 10, interviewed_pass: 2 };
     const { result } = renderHook(() =>
       useStatusCounts({
         filters,
         workspaceSlug: "test",
         useAndModeBff: true,
-        bffStatusCounts: { new: 100, shortlisted: 20, rejected: 10 },
+        bffStatusCounts,
       })
     );
 
@@ -103,6 +106,8 @@ describe("useStatusCounts", () => {
     expect(result.current.new).toBe(100);
     expect(result.current.shortlisted).toBe(20);
     expect(result.current.rejected).toBe(10);
+    expect(result.current).toMatchObject({ interviewed_pass: 2 });
+    expect(result.current.total).toBe(132);
     // useQuery is called unconditionally (rules of hooks) but with "skip" for BFF path
     expect(useQueryMock).toHaveBeenCalledWith("resumes:countResumesByStatus", "skip");
   });

--- a/apps/web/src/hooks/useStatusCounts.ts
+++ b/apps/web/src/hooks/useStatusCounts.ts
@@ -2,15 +2,15 @@ import { useQuery } from "convex/react";
 import { useMemo } from "react";
 import { api } from "../../../../packages/convex/convex/_generated/api";
 import type { ConvexResumeFilters } from "./useConvexResumes";
+import { CANDIDATE_STATUS_VALUES, type CandidateStatus } from "@/types/resume";
 
-export interface StatusCounts {
-  new: number;
-  shortlisted: number;
-  rejected: number;
+export type CandidateStatusCounts = Record<CandidateStatus, number>;
+
+export type StatusCounts = CandidateStatusCounts & {
   total: number;
   overflow: boolean;
   loading: boolean;
-}
+};
 
 export type StatusCountFilters = ConvexResumeFilters & {
   showBlocked?: boolean;
@@ -21,15 +21,58 @@ interface UseStatusCountsParams {
   filters: StatusCountFilters;
   workspaceSlug: string;
   useAndModeBff: boolean;
-  bffStatusCounts?: { new: number; shortlisted: number; rejected: number };
+  bffStatusCounts?: Partial<CandidateStatusCounts>;
 }
 
-interface CountResumesByStatusResult {
-  new: number;
-  shortlisted: number;
-  rejected: number;
+type CountResumesByStatusResult = CandidateStatusCounts & {
   total: number;
   overflow: boolean;
+};
+
+function createEmptyStatusCounts(): CandidateStatusCounts {
+  return {
+    new: 0,
+    shortlisted: 0,
+    rejected: 0,
+    contacted: 0,
+    interviewing: 0,
+    interviewed_pass: 0,
+    interviewed_reject: 0,
+    appeal_submitted: 0,
+    human_review: 0,
+    upheld: 0,
+    reversed: 0,
+    offer: 0,
+    hired: 0,
+    withdrawn: 0,
+  };
+}
+
+function normalizeStatusCounts(input: Partial<CandidateStatusCounts> | undefined): CandidateStatusCounts {
+  const counts = createEmptyStatusCounts();
+  if (!input) {
+    return counts;
+  }
+  CANDIDATE_STATUS_VALUES.forEach((status) => {
+    counts[status] = input[status] ?? 0;
+  });
+  return counts;
+}
+
+function sumStatusCounts(counts: CandidateStatusCounts): number {
+  return CANDIDATE_STATUS_VALUES.reduce((total, status) => total + counts[status], 0);
+}
+
+function withMetadata(
+  counts: CandidateStatusCounts,
+  metadata: { total?: number; overflow: boolean; loading: boolean },
+): StatusCounts {
+  return {
+    ...counts,
+    total: metadata.total ?? sumStatusCounts(counts),
+    overflow: metadata.overflow,
+    loading: metadata.loading,
+  };
 }
 
 export function useStatusCounts(params: UseStatusCountsParams): StatusCounts {
@@ -61,35 +104,27 @@ export function useStatusCounts(params: UseStatusCountsParams): StatusCounts {
   const result = useQuery(api.resumes.countResumesByStatus, queryArgs as never) as CountResumesByStatusResult | undefined;
 
   if (!enabled) {
-    return { new: 0, shortlisted: 0, rejected: 0, total: 0, overflow: false, loading: false };
+    return withMetadata(createEmptyStatusCounts(), { total: 0, overflow: false, loading: false });
   }
 
   // BFF path: counts come from the BFF response
   if (useAndModeBff) {
     if (bffStatusCounts) {
-      return {
-        new: bffStatusCounts.new,
-        shortlisted: bffStatusCounts.shortlisted,
-        rejected: bffStatusCounts.rejected,
-        total: bffStatusCounts.new + bffStatusCounts.shortlisted + bffStatusCounts.rejected,
-        overflow: false,
-        loading: false,
-      };
+      const counts = normalizeStatusCounts(bffStatusCounts);
+      return withMetadata(counts, { overflow: false, loading: false });
     }
-    return { new: 0, shortlisted: 0, rejected: 0, total: 0, overflow: false, loading: true };
+    return withMetadata(createEmptyStatusCounts(), { total: 0, overflow: false, loading: true });
   }
 
   // Convex direct path
   if (result === undefined) {
-    return { new: 0, shortlisted: 0, rejected: 0, total: 0, overflow: false, loading: true };
+    return withMetadata(createEmptyStatusCounts(), { total: 0, overflow: false, loading: true });
   }
 
-  return {
-    new: result.new ?? 0,
-    shortlisted: result.shortlisted ?? 0,
-    rejected: result.rejected ?? 0,
+  const counts = normalizeStatusCounts(result);
+  return withMetadata(counts, {
     total: result.total ?? 0,
     overflow: result.overflow ?? false,
     loading: false,
-  };
+  });
 }

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -13215,6 +13215,17 @@ export interface components {
                     new: number;
                     shortlisted: number;
                     rejected: number;
+                    contacted: number;
+                    interviewing: number;
+                    interviewed_pass: number;
+                    interviewed_reject: number;
+                    appeal_submitted: number;
+                    human_review: number;
+                    upheld: number;
+                    reversed: number;
+                    offer: number;
+                    hired: number;
+                    withdrawn: number;
                 };
             };
             data: components["schemas"]["ResumeItem"][];

--- a/apps/web/src/lib/search-analytics.test.ts
+++ b/apps/web/src/lib/search-analytics.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { afterAll, describe, expect, it, vi, beforeEach } from 'vitest'
 import { logSearchEvent } from '@/lib/search-analytics'
 
 describe('logSearchEvent', () => {
@@ -7,6 +7,11 @@ describe('logSearchEvent', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    document.cookie = 'trends_csrf=; Max-Age=0; path=/'
+  })
+
+  afterAll(() => {
+    vi.unstubAllGlobals()
   })
 
   it('sends POST with query and resultCount', () => {
@@ -41,6 +46,15 @@ describe('logSearchEvent', () => {
     mockFetch.mockResolvedValue({ ok: true })
     logSearchEvent({ query: 'test', resultCount: 1 })
     expect(mockFetch.mock.calls[0][1].keepalive).toBe(true)
+  })
+
+  it('sends CSRF token when present', () => {
+    document.cookie = 'trends_csrf=csrf-token-analytics; path=/'
+    mockFetch.mockResolvedValue({ ok: true })
+
+    logSearchEvent({ query: 'test', resultCount: 1 })
+
+    expect(mockFetch.mock.calls[0][1].headers['X-CSRF-Token']).toBe('csrf-token-analytics')
   })
 
   it('silently ignores network errors', () => {

--- a/apps/web/src/lib/search-analytics.ts
+++ b/apps/web/src/lib/search-analytics.ts
@@ -1,5 +1,19 @@
 import { apiBaseUrl } from './api-client'
 
+const csrfCookieName = 'trends_csrf'
+
+function readCookie(name: string): string | null {
+  if (typeof document === 'undefined') {
+    return null
+  }
+  const prefix = `${name}=`
+  const match = document.cookie
+    .split(';')
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(prefix))
+  return match ? decodeURIComponent(match.slice(prefix.length)) : null
+}
+
 /**
  * Log a search query event to the BFF analytics endpoint.
  * Fire-and-forget — errors are silently ignored.
@@ -12,14 +26,20 @@ export function logSearchEvent(params: {
   const workspace = document.querySelector<HTMLMetaElement>('meta[name="workspace-slug"]')?.content
     ?? window.location.pathname.split('/')[1]
     ?? 'default'
+  const csrfToken = readCookie(csrfCookieName)
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'X-Workspace-Slug': workspace,
+  }
+  if (csrfToken) {
+    headers['X-CSRF-Token'] = csrfToken
+  }
 
   fetch(`${apiBaseUrl}/api/search-analytics/log`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Workspace-Slug': workspace,
-    },
+    headers,
     body: JSON.stringify(params),
+    credentials: 'include',
     keepalive: true,
   }).catch(() => {
     // Fire-and-forget — ignore network errors

--- a/apps/web/src/types/resume.ts
+++ b/apps/web/src/types/resume.ts
@@ -59,21 +59,24 @@ export type TaggingEnvelope = {
 export type Recommendation = 'strong_match' | 'match' | 'potential' | 'no_match'
 export type ScoreSource = 'rule' | 'ai'
 export type ResumeExportFormat = 'csv' | 'xlsx'
-export type CandidateStatus =
-  | 'new'
-  | 'shortlisted'
-  | 'rejected'
-  | 'contacted'
-  | 'interviewing'
-  | 'interviewed_pass'
-  | 'interviewed_reject'
-  | 'appeal_submitted'
-  | 'human_review'
-  | 'upheld'
-  | 'reversed'
-  | 'offer'
-  | 'hired'
-  | 'withdrawn'
+export const CANDIDATE_STATUS_VALUES = [
+  'new',
+  'shortlisted',
+  'rejected',
+  'contacted',
+  'interviewing',
+  'interviewed_pass',
+  'interviewed_reject',
+  'appeal_submitted',
+  'human_review',
+  'upheld',
+  'reversed',
+  'offer',
+  'hired',
+  'withdrawn',
+] as const
+
+export type CandidateStatus = typeof CANDIDATE_STATUS_VALUES[number]
 
 export type MatchBreakdown = Record<string, number>
 

--- a/packages/convex/__tests__/count-resumes-by-status-convex-test.test.ts
+++ b/packages/convex/__tests__/count-resumes-by-status-convex-test.test.ts
@@ -172,6 +172,52 @@ describe("countResumesByStatus", () => {
     expect(result.rejected).toBe(0);
   });
 
+  it("counts explicit interviewed_pass separately from new", async () => {
+    const source = "test-count-interviewed-pass";
+    const ws = "test-count-interviewed-pass-ws";
+    await test.run(async (ctx) => {
+      await ctx.db.insert("resumes", {
+        externalId: "ext-zs-new",
+        identityKey: "ik-zs-new",
+        content: { name: "New Candidate" },
+        hash: "hash-zs-new",
+        tags: [],
+        crawledAt: Date.now(),
+        source,
+        sourceKey: source,
+      });
+      await ctx.db.insert("resumes", {
+        externalId: "k172rcvmvqj4hhn98r74r3brps82v28b",
+        identityKey: "ik-zs-interviewed",
+        content: { name: "周先生" },
+        hash: "hash-zs-interviewed",
+        tags: [],
+        crawledAt: Date.now(),
+        source,
+        sourceKey: source,
+      });
+      await ctx.db.insert("candidate_status", {
+        workspaceSlug: ws,
+        identityKey: "ik-zs-interviewed",
+        status: "interviewed_pass",
+        updatedAt: Date.now(),
+      });
+    });
+
+    const result = await test.query(api.resumes.countResumesByStatus, {
+      workspaceSlug: ws,
+      sources: [source],
+    });
+
+    expect(result).toMatchObject({
+      new: 1,
+      shortlisted: 0,
+      rejected: 0,
+      interviewed_pass: 1,
+      total: 2,
+    });
+  });
+
   it("excludes archived resumes", async () => {
     const source = "test-count-archived";
     const ws = "test-count-archived-ws";

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -46,6 +46,54 @@ import {
     normalizeResumeBackupArgs,
 } from "./lib/resumes_backup.js";
 
+const CANDIDATE_STATUS_VALUES = [
+    "new",
+    "shortlisted",
+    "rejected",
+    "contacted",
+    "interviewing",
+    "interviewed_pass",
+    "interviewed_reject",
+    "appeal_submitted",
+    "human_review",
+    "upheld",
+    "reversed",
+    "offer",
+    "hired",
+    "withdrawn",
+] as const;
+
+type CandidateStatus = typeof CANDIDATE_STATUS_VALUES[number];
+type CandidateStatusCounts = Record<CandidateStatus, number>;
+const CANDIDATE_STATUS_SET: ReadonlySet<string> = new Set(CANDIDATE_STATUS_VALUES);
+
+function createCandidateStatusCounts(): CandidateStatusCounts {
+    return {
+        new: 0,
+        shortlisted: 0,
+        rejected: 0,
+        contacted: 0,
+        interviewing: 0,
+        interviewed_pass: 0,
+        interviewed_reject: 0,
+        appeal_submitted: 0,
+        human_review: 0,
+        upheld: 0,
+        reversed: 0,
+        offer: 0,
+        hired: 0,
+        withdrawn: 0,
+    };
+}
+
+function isCandidateStatus(value: string): value is CandidateStatus {
+    return CANDIDATE_STATUS_SET.has(value);
+}
+
+function resolveCandidateStatus(value: string | undefined): CandidateStatus {
+    return value && isCandidateStatus(value) ? value : "new";
+}
+
 // Re-export for backward compatibility
 export {
     toStringValue,
@@ -676,7 +724,7 @@ export const countResumesByStatus = query({
     // 3. Fetch non-archived resumes in a single paginated query.
     // Convex only supports ONE .paginate() call per function (no loops).
     const MAX_MATCHES = 5000;
-    const counts: Record<string, number> = { new: 0, shortlisted: 0, rejected: 0 };
+    const counts = createCandidateStatusCounts();
     let totalMatched = 0;
     let overflow = false;
 
@@ -700,8 +748,8 @@ export const countResumesByStatus = query({
           continue;
         }
         const status = statusByIdentity.get(identityKey) ?? "new";
-        const bucket = status === "shortlisted" || status === "rejected" ? status : "new";
-        counts[bucket] = (counts[bucket] ?? 0) + 1;
+        const bucket = resolveCandidateStatus(status);
+        counts[bucket] += 1;
         totalMatched += 1;
       }
     }
@@ -712,12 +760,9 @@ export const countResumesByStatus = query({
     }
 
     return {
-      new: counts.new ?? 0,
-      shortlisted: counts.shortlisted ?? 0,
-      rejected: counts.rejected ?? 0,
+      ...counts,
       total: totalMatched,
       overflow,
     };
   },
 });
-


### PR DESCRIPTION
## Summary
- Treat the default resume status queue as literal new only: missing status or explicit new.
- Count explicit pipeline statuses under their own keys across Convex, BFF AND-mode, web facets, and OpenAPI-generated web types.
- Preserve explicit advanced status filtering such as status=interviewed_pass and add CSRF headers to search analytics logging observed during browser verification.

## Test Plan
- [x] npm --workspace @trends/web test -- src/hooks/useResumeSearchState.test.tsx src/hooks/useStatusCounts.test.ts src/hooks/resume-filter-helpers.test.ts src/lib/search-analytics.test.ts
- [x] npm test -- packages/convex/__tests__/count-resumes-by-status-convex-test.test.ts apps/api/src/routes/resumes.test.ts apps/api/src/routes/candidate-status.test.ts apps/api/src/routes/sessions.test.ts
- [x] make check
- [x] Browser verification: local /dev route default rendered 0 条结果 with 已入围188 facet; explicit status=shortlisted rendered 188 条结果 and showed 周先生; console errors/warnings 0.

## Notes
- Exact preview candidate k172rcvmvqj4hhn98r74r3brps82v28b is not present in local HR seed data; automated tests cover the exact interviewed_pass regression and browser verification used an equivalent local explicit-status fixture.
- Wiki work item was updated and direct wiki-s3 object reads confirmed spec.md, plan.md, and log.md are present with completed status.