### PR TITLE
fix: prefer bunx for auth env validation

### DIFF
--- a/scripts/install-deploy-safety.test.ts
+++ b/scripts/install-deploy-safety.test.ts
@@ -142,6 +142,11 @@ describe("production deploy readiness checks", () => {
     expect(installScript).toContain("validate_auth_env()");
     expect(installScript).toContain("scripts/check-auth-env.ts");
     expect(installScript).toContain("--mode production");
+    expect(extractShellFunction(installScript, "validate_auth_env")).toContain("run_tsx_script");
+
+    const tsxRunner = extractShellFunction(installScript, "run_tsx_script");
+    expect(tsxRunner).toContain("command -v bun");
+    expectBefore(tsxRunner, "bunx tsx", "npx tsx");
 
     expectBefore(extractShellFunction(installScript, "install_flow"), "validate_auth_env", "deploy_env_file");
     expectBefore(extractShellFunction(installScript, "full_upgrade_steps"), "validate_auth_env", "deploy_env_file");

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1411,6 +1411,18 @@ deploy_env_file() {
     log_info "  - $system_env_path"
 }
 
+run_tsx_script() {
+    local script_path="$1"
+    shift
+
+    if command -v bun >/dev/null 2>&1; then
+        bunx tsx "$script_path" "$@"
+        return
+    fi
+
+    npx tsx "$script_path" "$@"
+}
+
 validate_auth_env() {
     local resolved_env_path=""
 
@@ -1426,7 +1438,7 @@ validate_auth_env() {
     fi
 
     log_info "Validating production auth environment from $resolved_env_path..."
-    if ! (cd "$INSTALL_DIR" && npx tsx scripts/check-auth-env.ts --mode production --env-file "$resolved_env_path"); then
+    if ! (cd "$INSTALL_DIR" && run_tsx_script scripts/check-auth-env.ts --mode production --env-file "$resolved_env_path"); then
         log_error "Production auth environment validation failed."
         exit 1
     fi


### PR DESCRIPTION
## Summary
- add a shell TSX runner in install.sh that prefers bunx when Bun is available and falls back to npx
- route production auth env validation through that runner
- extend deploy-safety tests to lock the bunx-before-npx contract

## Verification
- bunx vitest run scripts/check-auth-env.test.ts scripts/install-deploy-safety.test.ts
- bash scripts/check-route-auth.test.sh
- bunx vitest run apps/api/src/services/auth-event-storage.test.ts apps/api/src/routes/auth.test.ts apps/api/src/middleware/auth.test.ts
- bunx vitest run scripts/auth/manage-user.test.ts
- make check

Note: go test ./packages/cli/cmd -run 'TestAuth' has no matching Go tests in this checkout.