### PR TITLE
fix(api): handle invalid explanation resume ids

### DIFF
--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -4,6 +4,7 @@ import { createApp } from "../app";
 import { MatchStorage, type StoredMatch } from "../services/match-storage";
 import { ResumeService } from "../services/resume-service";
 import { SessionManager } from "../services/session-manager";
+import { logger } from "../services/logger";
 import { createAuthContext } from "./test-auth-helpers";
 
 type ConvexCall = {
@@ -1891,6 +1892,41 @@ describe("resume routes", () => {
       expect(payload.data).toBeNull();
     });
 
+    it("returns null data when Convex rejects an invalid resume id", async () => {
+      const loggerWarnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+        const call = parseConvexCall(input, init);
+        expect(call.pathName).toBe("audit:getExplanationForCandidate");
+        expect(call.args).toEqual({ resumeId: "seek-profile-001", workspaceSlug: "dev" });
+        return new Response(
+          JSON.stringify({
+            status: "error",
+            errorMessage: 'Value does not match validator. Path: .resumeId Validator: v.id("resumes")',
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      });
+
+      const app = createTestApp();
+      const response = await app.request("/api/resumes/explanation", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ resumeId: "seek-profile-001", workspaceSlug: "dev" }),
+      });
+
+      expect(response.status).toBe(200);
+      const payload = await response.json();
+      expect(payload.success).toBe(true);
+      expect(payload.data).toBeNull();
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        "Candidate explanation requested with a non-Convex resume id",
+        { route: "resumes" },
+      );
+    });
+
     it("returns 400 when resumeId is missing", async () => {
       const app = createTestApp();
       const response = await app.request("/api/resumes/explanation", {
@@ -1918,6 +1954,7 @@ describe("resume routes", () => {
     });
 
     it("returns 500 when Convex call fails", async () => {
+      const loggerErrorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
       vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
         return new Response(JSON.stringify({ status: "error", errorMessage: "Not found" }), {
           status: 200,
@@ -1933,6 +1970,11 @@ describe("resume routes", () => {
       });
 
       expect(response.status).toBe(500);
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        "Failed to load candidate explanation",
+        expect.any(Error),
+        { route: "resumes" },
+      );
     });
   });
 

--- a/apps/api/src/routes/resumes.ts
+++ b/apps/api/src/routes/resumes.ts
@@ -123,6 +123,11 @@ const actionStorage = new ActionStorage(config.projectRoot);
 
 const DEFAULT_AI_TOP_N = 20;
 const DEFAULT_CONVEX_RESUME_PAGE_SIZE = 50;
+
+function isConvexResumeIdValidationError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("Path: .resumeId") && message.includes('v.id("resumes")');
+}
 const MAX_SAFE_CONVEX_POST_FILTER_SCAN = 250;
 
 type MatchMode = "rules_only" | "hybrid" | "ai_only";
@@ -1370,6 +1375,12 @@ app.openapi(explanationRoute, async (c) => {
 
     return c.json({ success: true as const, data: explanation as z.infer<typeof ExplanationDataSchema> | null }, 200);
   } catch (error) {
+    if (isConvexResumeIdValidationError(error)) {
+      logger.warn("Candidate explanation requested with a non-Convex resume id", { route: "resumes" });
+      return c.json({ success: true as const, data: null }, 200);
+    }
+
+    logger.error("Failed to load candidate explanation", error, { route: "resumes" });
     const message = error instanceof Error ? error.message : String(error);
     return c.json({ success: false, error: message }, 500);
   }


### PR DESCRIPTION
## Summary
- return the candidate explanation no-data success shape when Convex rejects a stale/source-specific resumeId as not matching v.id("resumes")
- keep unrelated Convex failures as 500s and log them
- add route tests for the invalid-id no-data path and logging behavior

## Verification
- bunx vitest run apps/api/src/routes/resumes.test.ts -t "returns null data when Convex rejects an invalid resume id"
- bunx vitest run apps/api/src/routes/resumes.test.ts -t "POST /api/resumes/explanation"
- bunx vitest run apps/api/src/routes/resumes.test.ts
- make check

## Docker
- Not required; all verification was non-Docker.