### PR TITLE
feat(resume): add lite backup generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -409,6 +409,18 @@ restore-resumes:
 		npx tsx scripts/resume/restore-resumes.ts; \
 	fi
 
+# Derive a small restore-compatible backup from a full portable resume backup
+resume-lite-backup:
+	@COUNT="$${COUNT:-20}" \
+	FILE="$${FILE:-output/resume-backups/resumes-prod-dev-20260512-111129.tar.gz}" \
+	OUT="$${OUT:-output/resume-backups/resumes-prod-dev-lite-top$${COUNT}.tar.gz}"; \
+	export COUNT FILE OUT; \
+	if command -v bun >/dev/null 2>&1; then \
+		bun run scripts/resume/create-lite-backup.ts; \
+	else \
+		npx tsx scripts/resume/create-lite-backup.ts; \
+	fi
+
 # One-liner: SSH tunnel → backup prod workspace → close tunnel
 # Defaults: SSH_HOST=ptcloud, TUNNEL_PORT=13000, WORKSPACE=dev
 # OUT defaults to output/resume-backups/resumes-prod-<workspace>-<timestamp>.tar.gz

--- a/scripts/resume/create-lite-backup.test.ts
+++ b/scripts/resume/create-lite-backup.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { createLiteBackupPayload } from "./create-lite-backup.ts";
+
+describe("createLiteBackupPayload", () => {
+  it("keeps the first count resumes and matching candidate metadata", () => {
+    const payload = {
+      metadata: {
+        workspace: "dev",
+        generatedBy: "test",
+      },
+      resumes: [
+        {
+          _id: "convex-1",
+          resumeId: "resume-1",
+          externalId: "external-1",
+          content: { profileUrl: "https://example.com/1" },
+        },
+        {
+          id: "local-2",
+          content: { resumeId: "resume-2", profileUrl: "https://example.com/2" },
+        },
+        {
+          _id: "convex-3",
+          resumeId: "resume-3",
+          externalId: "external-3",
+          content: { profileUrl: "https://example.com/3" },
+        },
+      ],
+      candidateActions: [
+        { resumeId: "convex-1", action: "star" },
+        { resume_id: "resume-2", action: "note" },
+        { resumeKey: "external-3", action: "archive" },
+        { profileUrl: "https://example.com/2", action: "shortlist" },
+      ],
+      candidateStatus: [
+        { convexResumeId: "local-2", status: "shortlisted" },
+        { resumeId: "resume-3", status: "rejected" },
+      ],
+    };
+
+    const result = createLiteBackupPayload(payload, {
+      count: 2,
+      sourcePath: "output/resume-backups/full.tar.gz",
+      createdAt: "2026-06-08T05:00:00.000Z",
+    });
+
+    expect(result.resumes).toEqual(payload.resumes.slice(0, 2));
+    expect(result.candidateActions).toEqual([
+      payload.candidateActions[0],
+      payload.candidateActions[1],
+      payload.candidateActions[3],
+    ]);
+    expect(result.candidateStatus).toEqual([payload.candidateStatus[0]]);
+    expect(result.metadata).toMatchObject({
+      workspace: "dev",
+      generatedBy: "test",
+      liteBackup: {
+        sourcePath: "output/resume-backups/full.tar.gz",
+        originalResumeCount: 3,
+        count: 2,
+        createdAt: "2026-06-08T05:00:00.000Z",
+      },
+    });
+  });
+
+  it("rejects non-positive counts", () => {
+    expect(() =>
+      createLiteBackupPayload(
+        { metadata: {}, resumes: [{ resumeId: "resume-1" }] },
+        { count: 0, sourcePath: "full.json", createdAt: "2026-06-08T05:00:00.000Z" },
+      ),
+    ).toThrow("COUNT must be a positive integer");
+  });
+
+  it("converts legacy data payloads without carrying the full data array", () => {
+    const result = createLiteBackupPayload(
+      {
+        metadata: {},
+        data: [
+          { resumeId: "resume-1" },
+          { resumeId: "resume-2" },
+          { resumeId: "resume-3" },
+        ],
+      },
+      { count: 1, sourcePath: "full.json", createdAt: "2026-06-08T05:00:00.000Z" },
+    );
+
+    expect(result.resumes).toEqual([{ resumeId: "resume-1" }]);
+    expect(result).not.toHaveProperty("data");
+  });
+});

--- a/scripts/resume/create-lite-backup.ts
+++ b/scripts/resume/create-lite-backup.ts
@@ -1,0 +1,230 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  parsePositiveInteger,
+  readPortableBackupFile,
+  writePortableBackupFile,
+} from "./operator-utils.ts";
+
+type BackupPayload = {
+  metadata?: Record<string, unknown>;
+  resumes?: unknown[];
+  data?: unknown[];
+  candidateActions?: unknown[];
+  candidateStatus?: unknown[];
+};
+
+export type LiteBackupOptions = {
+  count: number;
+  sourcePath: string;
+  createdAt?: string;
+};
+
+type LiteBackupPayload = BackupPayload & {
+  metadata: Record<string, unknown>;
+  resumes: unknown[];
+  candidateActions: unknown[];
+  candidateStatus: unknown[];
+};
+
+const RESUME_ID_FIELDS = [
+  "_id",
+  "id",
+  "resumeId",
+  "resume_id",
+  "convexResumeId",
+  "resumeKey",
+  "identityKey",
+  "externalId",
+  "external_id",
+  "profileUrl",
+  "profile_url",
+] as const;
+
+const CONTENT_ID_FIELDS = [
+  "resumeId",
+  "resume_id",
+  "perUserId",
+  "profileId",
+  "externalId",
+  "external_id",
+  "profileUrl",
+  "profile_url",
+  "url",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readResumeArray(payload: BackupPayload): unknown[] {
+  if (Array.isArray(payload.resumes)) {
+    return payload.resumes;
+  }
+  if (Array.isArray(payload.data)) {
+    return payload.data;
+  }
+  return [];
+}
+
+function readMetadataArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function addStringValue(target: Set<string>, value: unknown): void {
+  if (typeof value !== "string") {
+    return;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length > 0) {
+    target.add(trimmed);
+  }
+}
+
+function collectResumeIdentityKeys(resume: unknown): Set<string> {
+  const keys = new Set<string>();
+  if (!isRecord(resume)) {
+    return keys;
+  }
+
+  for (const field of RESUME_ID_FIELDS) {
+    addStringValue(keys, resume[field]);
+  }
+
+  if (isRecord(resume.content)) {
+    for (const field of CONTENT_ID_FIELDS) {
+      addStringValue(keys, resume.content[field]);
+    }
+  }
+
+  return keys;
+}
+
+function collectSelectedResumeIdentityKeys(resumes: unknown[]): Set<string> {
+  const keys = new Set<string>();
+  for (const resume of resumes) {
+    for (const key of collectResumeIdentityKeys(resume)) {
+      keys.add(key);
+    }
+  }
+  return keys;
+}
+
+function metadataMatchesSelected(row: unknown, selectedKeys: Set<string>): boolean {
+  if (selectedKeys.size === 0 || !isRecord(row)) {
+    return false;
+  }
+
+  for (const field of RESUME_ID_FIELDS) {
+    const value = row[field];
+    if (typeof value === "string" && selectedKeys.has(value.trim())) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function parseBackupPayload(raw: string): BackupPayload {
+  const decoded: unknown = JSON.parse(raw);
+  if (!isRecord(decoded)) {
+    throw new Error("backup payload must be an object");
+  }
+  return decoded;
+}
+
+function parseCount(raw: string | undefined): number {
+  const parsed = parsePositiveInteger(raw ?? "20");
+  if (parsed === undefined) {
+    throw new Error("COUNT must be a positive integer");
+  }
+  return parsed;
+}
+
+function resolveInputPath(): string {
+  const filePath = process.env.FILE?.trim();
+  if (!filePath) {
+    throw new Error("FILE is required");
+  }
+  return filePath;
+}
+
+function resolveOutputPath(count: number): string {
+  return process.env.OUT?.trim()
+    || `output/resume-backups/resumes-prod-dev-lite-top${count}.tar.gz`;
+}
+
+export function createLiteBackupPayload(
+  payload: BackupPayload,
+  options: LiteBackupOptions,
+): LiteBackupPayload {
+  if (!Number.isInteger(options.count) || options.count < 1) {
+    throw new Error("COUNT must be a positive integer");
+  }
+
+  const resumes = readResumeArray(payload);
+  const selectedResumes = resumes.slice(0, options.count);
+  const selectedKeys = collectSelectedResumeIdentityKeys(selectedResumes);
+  const candidateActions = readMetadataArray(payload.candidateActions)
+    .filter((row) => metadataMatchesSelected(row, selectedKeys));
+  const candidateStatus = readMetadataArray(payload.candidateStatus)
+    .filter((row) => metadataMatchesSelected(row, selectedKeys));
+  const metadata = isRecord(payload.metadata) ? payload.metadata : {};
+  const payloadWithoutLegacyData: BackupPayload = { ...payload };
+  delete payloadWithoutLegacyData.data;
+
+  return {
+    ...payloadWithoutLegacyData,
+    metadata: {
+      ...metadata,
+      liteBackup: {
+        sourcePath: options.sourcePath,
+        originalResumeCount: resumes.length,
+        originalCandidateActionsCount: readMetadataArray(payload.candidateActions).length,
+        originalCandidateStatusCount: readMetadataArray(payload.candidateStatus).length,
+        count: selectedResumes.length,
+        candidateActionsCount: candidateActions.length,
+        candidateStatusCount: candidateStatus.length,
+        createdAt: options.createdAt ?? new Date().toISOString(),
+      },
+    },
+    resumes: selectedResumes,
+    candidateActions,
+    candidateStatus,
+  };
+}
+
+async function main(): Promise<void> {
+  const sourcePath = resolveInputPath();
+  const count = parseCount(process.env.COUNT);
+  const outputPath = resolveOutputPath(count);
+  const raw = await readPortableBackupFile(sourcePath);
+  const payload = parseBackupPayload(raw);
+  const litePayload = createLiteBackupPayload(payload, {
+    count,
+    sourcePath,
+  });
+  const bytes = await writePortableBackupFile(outputPath, litePayload);
+
+  console.log(JSON.stringify({
+    success: true,
+    source: sourcePath,
+    file: outputPath,
+    count: litePayload.resumes.length,
+    candidateActions: litePayload.candidateActions.length,
+    candidateStatus: litePayload.candidateStatus.length,
+    bytes,
+  }, null, 2));
+}
+
+const isMainModule = process.argv[1]
+  ? path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))
+  : false;
+
+if (isMainModule) {
+  void main().catch((error) => {
+    console.error(error instanceof Error ? error.stack || error.message : String(error));
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- add a portable resume lite-backup generator that slices a full backup to a small restore-compatible archive
- preserve metadata and matching candidate action/status rows for selected resumes
- expose the workflow through {
  "success": true,
  "source": "output/resume-backups/resumes-prod-dev-20260512-111129.tar.gz",
  "file": "output/resume-backups/resumes-prod-dev-lite-top20.tar.gz",
  "count": 20,
  "candidateActions": 0,
  "candidateStatus": 0,
  "bytes": 29270
}

## Verification
- 
 RUN  v4.1.7 /root/workspace


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  13:20:43
   Duration  123ms (transform 33ms, setup 0ms, import 43ms, tests 4ms, environment 0ms)
- {
  "success": true,
  "source": "output/resume-backups/resumes-prod-dev-20260512-111129.tar.gz",
  "file": "/tmp/trends-resume-lite-test.tar.gz",
  "count": 3,
  "candidateActions": 0,
  "candidateStatus": 0,
  "bytes": 5341
}
- Running Python checks...
  trendradar v0.4.6 OK
  mcp_server v3.1.7 OK
  apps.worker v0.4.6 OK
配置文件加载成功: config/config.yaml
通知渠道配置来源: Telegram(环境变量, 1个账号)
每个渠道最大账号数: 3
  config.yaml OK
Running Node.js checks...

> trends@0.4.6 check:resume-ai-prompts
> tsx scripts/resume/sync-ai-prompts.ts --check

Resume AI prompt artifact is up to date

> trends@0.4.6 check:resume-field-usage-policy
> tsx scripts/resume/sync-field-usage-policy.ts --check

Resume field usage policy artifact is up to date

> trends@0.4.6 check:search-profile-templates
> tsx scripts/resume/sync-search-profile-templates.ts --check

Search profile template artifact is up to date

> trends@0.4.6 check:resume-skills-locales
> tsx scripts/resume/check-skills-locales.ts

Resume skills locale files are structurally consistent

> @trends/web@0.4.6 gen:api
> npm --workspace @trends/shared run build && npm --workspace @trends/api run openapi:gen && openapi-typescript ../api/openapi.json -o src/lib/api-types.ts


> @trends/shared@0.4.6 build
> tsc


> @trends/api@0.4.6 openapi:gen
> tsx src/openapi.ts

✨ openapi-typescript 7.13.0
🚀 ../api/openapi.json → src/lib/api-types.ts [272.5ms]
Checking browser extension content.js is in sync...

> @trends/browser-extension@0.4.6 build
> node esbuild.config.mjs

Resume AI prompt artifact is up to date
Resume field usage policy artifact is up to date
Search profile template artifact is up to date
Resume skills locale files are structurally consistent
@trends/shared typecheck: Exited with code 0
@trends/browser-extension typecheck: Exited with code 0
@trends/convex typecheck: Exited with code 0
@trends/api typecheck: Exited with code 0
@trends/web typecheck: Exited with code 0
@trends/browser-extension lint: Exited with code 0
@trends/web lint: 
@trends/web lint: /root/workspace/apps/web/src/components/ui/badge.tsx
@trends/web lint:   35:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components
@trends/web lint: 
@trends/web lint: /root/workspace/apps/web/src/components/ui/button.tsx
@trends/web lint:   51:18  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components
@trends/web lint: 
@trends/web lint: /root/workspace/apps/web/src/contexts/AuthContext.tsx
@trends/web lint:   24:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components
@trends/web lint: 
@trends/web lint: ✖ 3 problems (0 errors, 3 warnings)
@trends/web lint: 
@trends/web lint: Exited with code 0
Project skills are in sync: browser-extension-dev, resume-qa-hybrid-mcp, resume-ai-scoring-audit, trends-agent-governance, trends-cli, refresh-sample-snapshots
Policy mirror is up to date
Skill validation passed: /root/workspace/dev-docs/skills/trends-agent-governance
Installed skill is up to date: /root/.codex/skills/trends-agent-governance
concept-drift: no scoring/search files changed — OK
OK: All API route files have auth middleware
All checks passed

## Notes
- Does not run Docker or restore runtime services; actual restore remains an operator action via existing restore targets.