### PR TITLE
fix: harden candidate status backfill

### DIFF
--- a/apps/api/src/routes/manual-resume-import.test.ts
+++ b/apps/api/src/routes/manual-resume-import.test.ts
@@ -1,6 +1,6 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import JSZip from "jszip";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { workspaceMiddleware } from "../middleware/workspace";
 import { createAuthContext } from "./test-auth-helpers";
@@ -103,6 +103,37 @@ ${paragraphs}
   return new File([buffer], name, { type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document" });
 }
 
+function decodeTestDocxXml(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+async function extractGeneratedDocxText(buffer: Buffer): Promise<string> {
+  const zip = await JSZip.loadAsync(buffer);
+  const documentXml = await zip.file("word/document.xml")?.async("string");
+  if (!documentXml) {
+    return "";
+  }
+
+  return Array.from(documentXml.matchAll(/<w:t[^>]*>([\s\S]*?)<\/w:t>/g))
+    .map((match) => decodeTestDocxXml(match[1] ?? "").trim())
+    .filter(Boolean)
+    .join("\n");
+}
+
+function mockMammothDocxExtraction() {
+  vi.doMock("mammoth", () => ({
+    extractRawText: vi.fn(async ({ buffer }: { buffer: Buffer }) => ({
+      value: await extractGeneratedDocxText(buffer),
+      messages: [],
+    })),
+  }));
+}
+
 const DEFAULT_CONVEX_SUBMIT_RESULT = {
   submitted: 1,
   deduped: 0,
@@ -183,6 +214,10 @@ async function expectUnreadablePdfUploadFailure(options: {
 }
 
 describe("manual resume import route", () => {
+  beforeEach(() => {
+    mockMammothDocxExtraction();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
     vi.doUnmock("mammoth");

--- a/scripts/backfill-candidate-status.test.ts
+++ b/scripts/backfill-candidate-status.test.ts
@@ -1,0 +1,165 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type BackfillModule = typeof import("./backfill-candidate-status.ts");
+
+async function loadModule(): Promise<BackfillModule> {
+  return await import("./backfill-candidate-status.ts");
+}
+
+describe("candidate status backfill helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it("is import-safe and exposes pure planning helpers", async () => {
+    const module = await loadModule();
+
+    expect(process.exitCode).toBeUndefined();
+    expect(module.createBackfillPlan).toBeTypeOf("function");
+    expect(module.writeBackfillReport).toBeTypeOf("function");
+    expect(module.runCandidateStatusWrites).toBeTypeOf("function");
+  });
+
+  it("keeps only the latest supported action per resume", async () => {
+    const { createBackfillPlan } = await loadModule();
+
+    const plan = createBackfillPlan([
+      { resume_id: "r1", action_type: "shortlist", created_at: "2026-01-01T00:00:00.000Z" },
+      { resume_id: "r1", action_type: "reject", created_at: "2026-02-01T00:00:00.000Z" },
+      { resume_id: "r2", action_type: "star", created_at: "2026-01-15T00:00:00.000Z" },
+      { resume_id: "r3", action_type: "note", created_at: "2026-01-20T00:00:00.000Z" },
+      { resume_id: "   ", action_type: "reject", created_at: "2026-01-22T00:00:00.000Z" },
+    ], { maxRows: 10 });
+
+    expect(plan.intended).toBe(2);
+    expect(plan.skipped).toEqual({ unsupportedAction: 1, missingResumeId: 1 });
+    expect(plan.byAction).toEqual({ reject: 1, star: 1 });
+    expect(plan.byStatus).toEqual({ rejected: 1, new: 1 });
+    expect(plan.candidates).toEqual([
+      {
+        identityKey: "r1",
+        actionType: "reject",
+        status: "rejected",
+        actedAt: "2026-02-01T00:00:00.000Z",
+      },
+      {
+        identityKey: "r2",
+        actionType: "star",
+        status: "new",
+        actedAt: "2026-01-15T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("rejects plans above the max-row sanity limit", async () => {
+    const { createBackfillPlan } = await loadModule();
+
+    expect(() =>
+      createBackfillPlan([
+        { resume_id: "r1", action_type: "shortlist", created_at: "2026-01-01T00:00:00.000Z" },
+        { resume_id: "r2", action_type: "reject", created_at: "2026-01-02T00:00:00.000Z" },
+      ], { maxRows: 1 }),
+    ).toThrow(/max rows/i);
+  });
+
+  it("writes a JSON dry-run report", async () => {
+    const { createBackfillPlan, writeBackfillReport } = await loadModule();
+    const root = mkdtempSync(path.join(tmpdir(), "trends-candidate-status-backfill-"));
+
+    try {
+      const plan = createBackfillPlan([
+        { resume_id: "r1", action_type: "shortlist", created_at: "2026-01-01T00:00:00.000Z" },
+      ], { maxRows: 10 });
+
+      const report = writeBackfillReport({
+        outputDir: root,
+        timestamp: "2026-06-08T06:00:00.000Z",
+        dryRun: true,
+        workspaceSlug: "dev",
+        plan,
+        writes: 0,
+        errors: 0,
+      });
+
+      const payload = JSON.parse(readFileSync(report.path, "utf8"));
+      expect(payload).toMatchObject({
+        dryRun: true,
+        workspaceSlug: "dev",
+        intended: 1,
+        writes: 0,
+        errors: 0,
+        byAction: { shortlist: 1 },
+        byStatus: { shortlisted: 1 },
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("writes candidates in chunks and passes the Convex write secret", async () => {
+    const { runCandidateStatusWrites } = await loadModule();
+    const mutate = vi.fn().mockResolvedValue("ok");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const result = await runCandidateStatusWrites({
+      candidates: [
+        { identityKey: "r1", actionType: "shortlist", status: "shortlisted", actedAt: "2026-01-01T00:00:00.000Z" },
+        { identityKey: "r2", actionType: "reject", status: "rejected", actedAt: "2026-01-02T00:00:00.000Z" },
+        { identityKey: "r3", actionType: "star", status: "new", actedAt: "2026-01-03T00:00:00.000Z" },
+      ],
+      workspaceSlug: "hr",
+      writeSecret: "secret-1",
+      batchSize: 2,
+      sleepMs: 100,
+      mutate,
+      sleep,
+    });
+
+    expect(result).toEqual({ writes: 3, errors: 0, skippedExisting: 0 });
+    expect(mutate).toHaveBeenCalledTimes(3);
+    expect(mutate).toHaveBeenCalledWith({
+      workspaceSlug: "hr",
+      identityKey: "r1",
+      status: "shortlisted",
+      updatedBy: "backfill-script",
+      writeSecret: "secret-1",
+    });
+    expect(sleep).toHaveBeenCalledOnce();
+    expect(sleep).toHaveBeenCalledWith(100);
+  });
+
+  it("skips live writes when the Convex status is newer than the SQLite action", async () => {
+    const { runCandidateStatusWrites } = await loadModule();
+    const mutate = vi.fn().mockResolvedValue("ok");
+    const getExistingStatus = vi.fn().mockResolvedValue({
+      status: "shortlisted",
+      updatedAt: Date.parse("2026-02-01T00:00:00.000Z"),
+    });
+
+    const result = await runCandidateStatusWrites({
+      candidates: [
+        { identityKey: "r1", actionType: "reject", status: "rejected", actedAt: "2026-01-01T00:00:00.000Z" },
+      ],
+      workspaceSlug: "hr",
+      writeSecret: "secret-1",
+      batchSize: 50,
+      sleepMs: 100,
+      mutate,
+      getExistingStatus,
+    });
+
+    expect(result).toEqual({ writes: 0, errors: 0, skippedExisting: 1 });
+    expect(getExistingStatus).toHaveBeenCalledWith({
+      identityKey: "r1",
+      actionType: "reject",
+      status: "rejected",
+      actedAt: "2026-01-01T00:00:00.000Z",
+    });
+    expect(mutate).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/backfill-candidate-status.ts
+++ b/scripts/backfill-candidate-status.ts
@@ -5,8 +5,8 @@
  * For each resume_id in SQLite candidate_actions, finds the latest action,
  * maps it to a Convex status, and upserts into Convex candidate_status.
  *
- * Idempotent — safe to run multiple times. Existing Convex entries are
- * overwritten only if the SQLite action is newer.
+ * Idempotent — safe to run multiple times. Existing Convex entries are skipped
+ * when their updatedAt is newer than the SQLite action timestamp.
  *
  * Usage:
  *   npx tsx scripts/backfill-candidate-status.ts [--dry-run] [--workspace dev]
@@ -14,13 +14,19 @@
 
 import Database from "better-sqlite3";
 import { ConvexHttpClient } from "convex/browser";
-import { readFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { api } from "../packages/convex/convex/_generated/api.js";
+import { parsePositiveInteger } from "./resume/operator-utils.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = path.resolve(__dirname, "..");
+const DEFAULT_WORKSPACE_SLUG = "dev";
+const DEFAULT_MAX_ROWS = 10_000;
+const DEFAULT_BATCH_SIZE = 50;
+const DEFAULT_SLEEP_MS = 100;
+const DEFAULT_REPORT_DIR = path.join(PROJECT_ROOT, "output", "backfill-reports");
 
 const ACTION_TO_STATUS: Record<string, "new" | "shortlisted" | "rejected"> = {
   shortlist: "shortlisted",
@@ -28,10 +34,151 @@ const ACTION_TO_STATUS: Record<string, "new" | "shortlisted" | "rejected"> = {
   star: "new",
 };
 
-interface LatestAction {
+export interface LatestAction {
   resume_id: string;
   action_type: string;
   created_at: string;
+}
+
+export interface BackfillCandidate {
+  identityKey: string;
+  actionType: keyof typeof ACTION_TO_STATUS;
+  status: (typeof ACTION_TO_STATUS)[keyof typeof ACTION_TO_STATUS];
+  actedAt: string;
+}
+
+interface BackfillSkipped {
+  unsupportedAction: number;
+  missingResumeId: number;
+}
+
+export interface BackfillPlan {
+  candidates: BackfillCandidate[];
+  intended: number;
+  skipped: BackfillSkipped;
+  byAction: Partial<Record<keyof typeof ACTION_TO_STATUS, number>>;
+  byStatus: Partial<Record<BackfillCandidate["status"], number>>;
+}
+
+export interface BackfillReportOptions {
+  outputDir: string;
+  timestamp: string;
+  dryRun: boolean;
+  workspaceSlug: string;
+  plan: BackfillPlan;
+  writes: number;
+  errors: number;
+  skippedExisting?: number;
+}
+
+export interface BackfillWriteOptions {
+  candidates: BackfillCandidate[];
+  workspaceSlug: string;
+  writeSecret: string;
+  batchSize: number;
+  sleepMs: number;
+  mutate: CandidateStatusMutate;
+  getExistingStatus?: CandidateStatusLookup;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+interface CliOptions {
+  dryRun: boolean;
+  workspaceSlug: string;
+  maxRows: number;
+  batchSize: number;
+  sleepMs: number;
+  dbPath: string;
+  reportDir: string;
+}
+
+interface CandidateStatusMutationArgs {
+  workspaceSlug: string;
+  identityKey: string;
+  status: BackfillCandidate["status"];
+  updatedBy: string;
+  writeSecret: string;
+}
+
+interface ExistingCandidateStatus {
+  status?: string;
+  updatedAt?: number;
+}
+
+export type CandidateStatusMutate = (args: CandidateStatusMutationArgs) => Promise<unknown>;
+export type CandidateStatusLookup = (candidate: BackfillCandidate) => Promise<ExistingCandidateStatus | null | undefined>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readStringField(row: Record<string, unknown>, field: keyof LatestAction): string | undefined {
+  const value = row[field];
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return String(value);
+  }
+  return undefined;
+}
+
+function parseLatestActionRow(row: unknown): LatestAction | undefined {
+  if (!isRecord(row)) {
+    return undefined;
+  }
+  const resumeId = readStringField(row, "resume_id");
+  const actionType = readStringField(row, "action_type");
+  const createdAt = readStringField(row, "created_at");
+  if (!resumeId || !actionType || !createdAt) {
+    return undefined;
+  }
+  return {
+    resume_id: resumeId,
+    action_type: actionType,
+    created_at: createdAt,
+  };
+}
+
+function timestampOf(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function incrementCounter<T extends string>(counter: Partial<Record<T, number>>, key: T): void {
+  counter[key] = (counter[key] ?? 0) + 1;
+}
+
+function isSupportedAction(value: string): value is keyof typeof ACTION_TO_STATUS {
+  return value in ACTION_TO_STATUS;
+}
+
+function readCliValue(argv: string[], name: string): string | undefined {
+  const index = argv.indexOf(name);
+  if (index < 0) {
+    return undefined;
+  }
+  return argv[index + 1];
+}
+
+function parseRequiredPositiveInteger(raw: string | undefined, fallback: number, label: string): number {
+  const parsed = parsePositiveInteger(raw ?? String(fallback));
+  if (parsed === undefined) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseCliOptions(argv: string[]): CliOptions {
+  return {
+    dryRun: argv.includes("--dry-run"),
+    workspaceSlug: readCliValue(argv, "--workspace") ?? DEFAULT_WORKSPACE_SLUG,
+    maxRows: parseRequiredPositiveInteger(readCliValue(argv, "--max-rows"), DEFAULT_MAX_ROWS, "--max-rows"),
+    batchSize: parseRequiredPositiveInteger(readCliValue(argv, "--batch-size"), DEFAULT_BATCH_SIZE, "--batch-size"),
+    sleepMs: parseRequiredPositiveInteger(readCliValue(argv, "--sleep-ms"), DEFAULT_SLEEP_MS, "--sleep-ms"),
+    dbPath: readCliValue(argv, "--db") ?? path.join(PROJECT_ROOT, "output", "resume_screening.db"),
+    reportDir: readCliValue(argv, "--report-dir") ?? DEFAULT_REPORT_DIR,
+  };
 }
 
 function resolveConvexUrl(): string {
@@ -49,87 +196,241 @@ function resolveConvexUrl(): string {
   throw new Error("CONVEX_URL not found in env or .env files");
 }
 
-async function main() {
-  const dryRun = process.argv.includes("--dry-run");
-  const workspaceIdx = process.argv.indexOf("--workspace");
-  const workspaceSlug = workspaceIdx >= 0 ? process.argv[workspaceIdx + 1] : "dev";
+function resolveWriteSecret(): string {
+  const writeSecret = process.env.CONVEX_WRITE_SECRET?.trim();
+  if (!writeSecret) {
+    throw new Error("CONVEX_WRITE_SECRET is required for live candidate_status writes");
+  }
+  return writeSecret;
+}
 
-  const dbPath = path.join(PROJECT_ROOT, "output", "resume_screening.db");
+function parseExistingCandidateStatus(value: unknown): ExistingCandidateStatus | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const status = typeof value.status === "string" ? value.status : undefined;
+  const updatedAt = typeof value.updatedAt === "number" ? value.updatedAt : undefined;
+  return { status, updatedAt };
+}
+
+function readLatestActions(dbPath: string): LatestAction[] {
   const db = new Database(dbPath, { readonly: true });
 
-  const latestActions = db
-    .prepare(
-      `SELECT resume_id, action_type, created_at
-       FROM candidate_actions
-       WHERE action_type IN ('shortlist', 'reject', 'star')
-       ORDER BY created_at DESC`
-    )
-    .all() as LatestAction[];
+  try {
+    return db
+      .prepare(
+        `SELECT resume_id, action_type, created_at
+         FROM candidate_actions
+         ORDER BY created_at DESC`
+      )
+      .all()
+      .map((row) => parseLatestActionRow(row))
+      .filter((row): row is LatestAction => row !== undefined);
+  } finally {
+    db.close();
+  }
+}
 
+export function createBackfillPlan(
+  latestActions: LatestAction[],
+  options: { maxRows: number },
+): BackfillPlan {
   // Deduplicate: keep only the latest action per resume_id
   const byResume = new Map<string, LatestAction>();
   for (const row of latestActions) {
-    if (!byResume.has(row.resume_id)) {
-      byResume.set(row.resume_id, row);
+    const identityKey = row.resume_id.trim();
+    if (!identityKey) {
+      continue;
+    }
+    const previous = byResume.get(identityKey);
+    if (!previous || timestampOf(row.created_at) > timestampOf(previous.created_at)) {
+      byResume.set(identityKey, row);
     }
   }
 
-  const candidates = [...byResume.values()].filter(
-    (r) => ACTION_TO_STATUS[r.action_type]
-  );
+  const candidates: BackfillCandidate[] = [];
+  const skipped: BackfillSkipped = {
+    unsupportedAction: 0,
+    missingResumeId: latestActions.filter((row) => row.resume_id.trim().length === 0).length,
+  };
+  const byAction: BackfillPlan["byAction"] = {};
+  const byStatus: BackfillPlan["byStatus"] = {};
 
-  console.log(`Found ${candidates.length} candidates with actions to backfill.`);
-  console.log(`Workspace: ${workspaceSlug}, Dry-run: ${dryRun}`);
-
-  if (candidates.length === 0) {
-    console.log("Nothing to backfill.");
-    db.close();
-    return;
-  }
-
-  if (dryRun) {
-    for (const c of candidates) {
-      console.log(`  [dry-run] ${c.resume_id}: ${c.action_type} → ${ACTION_TO_STATUS[c.action_type]}`);
+  for (const [identityKey, row] of byResume) {
+    if (!isSupportedAction(row.action_type)) {
+      skipped.unsupportedAction += 1;
+      continue;
     }
-    db.close();
-    console.log(`\nDry-run complete. ${candidates.length} candidates would be backfilled.`);
-    return;
+    const status = ACTION_TO_STATUS[row.action_type];
+    incrementCounter(byAction, row.action_type);
+    incrementCounter(byStatus, status);
+    candidates.push({
+      identityKey,
+      actionType: row.action_type,
+      status,
+      actedAt: row.created_at,
+    });
   }
 
-  const convexUrl = resolveConvexUrl();
-  const client = new ConvexHttpClient(convexUrl);
+  candidates.sort((a, b) => a.identityKey.localeCompare(b.identityKey));
 
-  let upserted = 0;
-  let errors = 0;
-
-  for (const candidate of candidates) {
-    const status = ACTION_TO_STATUS[candidate.action_type];
-    if (!status) continue;
-
-    try {
-      await client.mutation(api.candidate_status.upsert, {
-        identityKey: candidate.resume_id,
-        status,
-        workspaceSlug,
-        updatedBy: "backfill-script",
-      });
-      upserted++;
-      if (upserted % 10 === 0) {
-        console.log(`  Progress: ${upserted}/${candidates.length}`);
-      }
-    } catch (error) {
-      console.error(
-        `  Error: ${candidate.resume_id}: ${error instanceof Error ? error.message : error}`
-      );
-      errors++;
-    }
+  if (candidates.length > options.maxRows) {
+    throw new Error(`Backfill exceeds max rows sanity limit: ${candidates.length} > ${options.maxRows}`);
   }
 
-  db.close();
-  console.log(`\nBackfill complete: ${upserted} upserted, ${errors} errors.`);
+  return {
+    candidates,
+    intended: candidates.length,
+    skipped,
+    byAction,
+    byStatus,
+  };
 }
 
-main().catch((error) => {
-  console.error("Fatal:", error);
-  process.exit(1);
-});
+export function writeBackfillReport(options: BackfillReportOptions): { path: string } {
+  mkdirSync(options.outputDir, { recursive: true });
+  const timestampSlug = options.timestamp.replace(/[:.]/g, "-");
+  const reportPath = path.join(options.outputDir, `candidate-status-${timestampSlug}.json`);
+  const payload = {
+    generatedAt: options.timestamp,
+    dryRun: options.dryRun,
+    workspaceSlug: options.workspaceSlug,
+    intended: options.plan.intended,
+    writes: options.writes,
+    errors: options.errors,
+    skippedExisting: options.skippedExisting ?? 0,
+    skipped: options.plan.skipped,
+    byAction: options.plan.byAction,
+    byStatus: options.plan.byStatus,
+    candidates: options.plan.candidates,
+  };
+  writeFileSync(reportPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  return { path: reportPath };
+}
+
+async function defaultSleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function shouldSkipExisting(candidate: BackfillCandidate, existing: ExistingCandidateStatus | null | undefined): boolean {
+  if (!existing) {
+    return false;
+  }
+  const actedAt = timestampOf(candidate.actedAt);
+  if (typeof existing.updatedAt === "number" && existing.updatedAt >= actedAt) {
+    return true;
+  }
+  return actedAt === 0 && existing.status === candidate.status;
+}
+
+export async function runCandidateStatusWrites(options: BackfillWriteOptions): Promise<{ writes: number; errors: number; skippedExisting: number }> {
+  let writes = 0;
+  let errors = 0;
+  let skippedExisting = 0;
+  const sleep = options.sleep ?? defaultSleep;
+
+  for (let index = 0; index < options.candidates.length; index += options.batchSize) {
+    const chunk = options.candidates.slice(index, index + options.batchSize);
+    for (const candidate of chunk) {
+      try {
+        if (options.getExistingStatus) {
+          const existing = await options.getExistingStatus(candidate);
+          if (shouldSkipExisting(candidate, existing)) {
+            skippedExisting += 1;
+            continue;
+          }
+        }
+
+        await options.mutate({
+          workspaceSlug: options.workspaceSlug,
+          identityKey: candidate.identityKey,
+          status: candidate.status,
+          updatedBy: "backfill-script",
+          writeSecret: options.writeSecret,
+        });
+        writes += 1;
+      } catch (error) {
+        console.error(
+          `candidate_status backfill failed for ${candidate.identityKey}: ${error instanceof Error ? error.message : String(error)}`
+        );
+        errors += 1;
+      }
+    }
+
+    const hasMore = index + options.batchSize < options.candidates.length;
+    if (hasMore && options.sleepMs > 0) {
+      await sleep(options.sleepMs);
+    }
+  }
+
+  return { writes, errors, skippedExisting };
+}
+
+async function main(): Promise<void> {
+  const options = parseCliOptions(process.argv.slice(2));
+  const latestActions = readLatestActions(options.dbPath);
+  const plan = createBackfillPlan(latestActions, { maxRows: options.maxRows });
+
+  let writes = 0;
+  let errors = 0;
+  let skippedExisting = 0;
+
+  if (!options.dryRun && plan.intended > 0) {
+    const convexUrl = resolveConvexUrl();
+    const writeSecret = resolveWriteSecret();
+    const client = new ConvexHttpClient(convexUrl);
+    const result = await runCandidateStatusWrites({
+      candidates: plan.candidates,
+      workspaceSlug: options.workspaceSlug,
+      writeSecret,
+      batchSize: options.batchSize,
+      sleepMs: options.sleepMs,
+      mutate: async (args) => await client.mutation(api.candidate_status.upsert, args),
+      getExistingStatus: async (candidate) => parseExistingCandidateStatus(await client.query(api.candidate_status.getByIdentity, {
+        workspaceSlug: options.workspaceSlug,
+        identityKey: candidate.identityKey,
+      })),
+    });
+    writes = result.writes;
+    errors = result.errors;
+    skippedExisting = result.skippedExisting;
+  }
+
+  const report = writeBackfillReport({
+    outputDir: options.reportDir,
+    timestamp: new Date().toISOString(),
+    dryRun: options.dryRun,
+    workspaceSlug: options.workspaceSlug,
+    plan,
+    writes,
+    errors,
+    skippedExisting,
+  });
+
+  console.log(JSON.stringify({
+    success: errors === 0,
+    dryRun: options.dryRun,
+    workspaceSlug: options.workspaceSlug,
+    intended: plan.intended,
+    writes,
+    errors,
+    skippedExisting,
+    skipped: plan.skipped,
+    report: report.path,
+  }, null, 2));
+
+  if (errors > 0) {
+    process.exitCode = 1;
+  }
+}
+
+const isMainModule = process.argv[1]
+  ? path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))
+  : false;
+
+if (isMainModule) {
+  void main().catch((error) => {
+    console.error(error instanceof Error ? error.stack || error.message : String(error));
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- make candidate-status backfill import-safe and testable via pure planning/write helpers
- add dry-run JSON reports, max-row sanity limit, live write batching, and Convex write-secret propagation
- skip live writes when existing Convex candidate_status is newer than the SQLite action for idempotent reruns

## Verification
- bunx vitest run scripts/backfill-candidate-status.test.ts
- make backfill-candidate-status ARGS="--report-dir /tmp/trends-backfill-report --max-rows 10000"
- make check

## Docker
- Not used.