### PR TITLE
fix: report BM25-only fallback when embeddings are disabled

### DIFF
--- a/packages/convex/__tests__/embeddings-convex-test.test.ts
+++ b/packages/convex/__tests__/embeddings-convex-test.test.ts
@@ -9,7 +9,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { api } from "../convex/_generated/api.js";
 import { internal } from "../convex/_generated/api.js";
 import type { Doc, Id } from "../convex/_generated/dataModel.js";
-import { rrfMerge, isEmbeddingEnabled } from "../convex/embeddings.js";
+import { rrfMerge, isEmbeddingEnabled, resolveBm25OnlySearchMode } from "../convex/embeddings.js";
 
 
 describe("embeddings (convex-test)", () => {
@@ -504,6 +504,23 @@ describe("embeddings (convex-test)", () => {
       vi.unstubAllEnvs();
     });
   });
+
+  describe("hybridSearchResumes — BM25 fallback contract", () => {
+    it("reports bm25_only_no_vectors when semantic search is requested but EMBEDDING_ENABLED is false", async () => {
+      const t = createTest();
+      vi.stubEnv("EMBEDDING_ENABLED", "false");
+
+      const result = await t.action(api.embeddings.hybridSearchResumes, {
+        query: "CNC 销售",
+        keywordGroups: [],
+        enableSemantic: true,
+      });
+
+      expect(result.searchMode).toBe("bm25_only_no_vectors");
+
+      vi.unstubAllEnvs();
+    });
+  });
 });
 
 describe("isEmbeddingEnabled (unit)", () => {
@@ -534,6 +551,32 @@ describe("isEmbeddingEnabled (unit)", () => {
   it("returns false when EMBEDDING_ENABLED is '0'", () => {
     vi.stubEnv("EMBEDDING_ENABLED", "0");
     expect(isEmbeddingEnabled()).toBe(false);
+  });
+});
+
+describe("resolveBm25OnlySearchMode (unit)", () => {
+  it("reports bm25_only_no_vectors when semantic search was requested but embeddings are disabled", () => {
+    expect(resolveBm25OnlySearchMode({
+      embeddingEnabled: false,
+      enableSemanticRequested: true,
+      hasQuery: true,
+    })).toBe("bm25_only_no_vectors");
+  });
+
+  it("reports bm25 when semantic search was not requested", () => {
+    expect(resolveBm25OnlySearchMode({
+      embeddingEnabled: false,
+      enableSemanticRequested: false,
+      hasQuery: true,
+    })).toBe("bm25");
+  });
+
+  it("reports bm25 when there is no keyword query", () => {
+    expect(resolveBm25OnlySearchMode({
+      embeddingEnabled: false,
+      enableSemanticRequested: true,
+      hasQuery: false,
+    })).toBe("bm25");
   });
 });
 

--- a/packages/convex/convex/embeddings.ts
+++ b/packages/convex/convex/embeddings.ts
@@ -38,6 +38,18 @@ export function isEmbeddingEnabled(): boolean {
     return value === "true" || value === "1";
 }
 
+export function resolveBm25OnlySearchMode(params: {
+    embeddingEnabled: boolean;
+    enableSemanticRequested: boolean;
+    hasQuery: boolean;
+}): "bm25" | "bm25_only_no_vectors" {
+    if (params.hasQuery && params.enableSemanticRequested && !params.embeddingEnabled) {
+        return "bm25_only_no_vectors";
+    }
+
+    return "bm25";
+}
+
 // ---------------------------------------------------------------------------
 // RRF (Reciprocal Rank Fusion) merge — exported for testing
 // ---------------------------------------------------------------------------
@@ -467,10 +479,13 @@ export const hybridSearchResumes = action({
     },
     handler: async (ctx, args): Promise<HybridSearchResult> => {
         // System-level gate: embedding disabled means semantic search is off regardless of client request
-        const enableSemantic = isEmbeddingEnabled() && (args.enableSemantic ?? true);
+        const embeddingEnabled = isEmbeddingEnabled();
+        const enableSemanticRequested = args.enableSemantic ?? true;
+        const enableSemantic = embeddingEnabled && enableSemanticRequested;
         const semanticWeight = args.semanticWeight ?? 0.5;
         const semanticLimit = Math.min(args.semanticLimit ?? 50, 256);
         const bm25Weight = 1 - semanticWeight;
+        const hasQuery = Boolean(args.query.trim());
 
         // 1. Run existing BM25 search
         const bm25Result = (await ctx.runAction(api.resumes_search.searchWithTagExpansionAndMode, {
@@ -497,10 +512,14 @@ export const hybridSearchResumes = action({
         })) as unknown as HybridSearchResult;
 
         // If semantic search disabled or query empty, return BM25 results as-is
-        if (!enableSemantic || !args.query.trim()) {
+        if (!enableSemantic || !hasQuery) {
             return {
                 ...bm25Result,
-                searchMode: "bm25" as const,
+                searchMode: resolveBm25OnlySearchMode({
+                    embeddingEnabled,
+                    enableSemanticRequested,
+                    hasQuery,
+                }),
             };
         }
 


### PR DESCRIPTION
## Summary
- report `searchMode: bm25_only_no_vectors` when semantic search was requested but `EMBEDDING_ENABLED` disables embeddings
- add unit coverage for the search-mode resolver and action-level coverage for `hybridSearchResumes`

## Verification
- RED: `rtk npx vitest run packages/convex/__tests__/embeddings-convex-test.test.ts` failed with `resolveBm25OnlySearchMode is not a function`
- GREEN: `rtk npx vitest run packages/convex/__tests__/embeddings-convex-test.test.ts`
- `rtk npx vitest run apps/api/src/routes/resumes_search.test.ts`
- `rtk make check`