### PR TITLE
fix: avoid forced Convex upgrades by default

### DIFF
--- a/deploy/systemd/trends-convex.service
+++ b/deploy/systemd/trends-convex.service
@@ -20,7 +20,7 @@ ExecStartPre=/usr/bin/bash /opt/trends/scripts/prefetch-convex-backend.sh
 # deadline (available in Convex CLI >= 1.36.0); prewarm remains useful to
 # reduce perceived startup latency from ~30s to ~5s.
 ExecStartPre=/usr/bin/bash /opt/trends/scripts/convex-prewarm.sh
-ExecStart=/usr/bin/npx convex dev --local --local-force-upgrade
+ExecStart=/usr/bin/npx convex dev --local
 Restart=on-failure
 RestartSec=5
 StandardOutput=journal

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "env -u TZ convex dev --local --local-force-upgrade",
-    "predev": "env -u TZ convex dev --once --local --local-force-upgrade",
+    "dev": "env -u TZ convex dev --local",
+    "predev": "env -u TZ convex dev --once --local",
     "build": "convex codegen",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/scripts/benchmark-dev-resume-latency.ts
+++ b/scripts/benchmark-dev-resume-latency.ts
@@ -415,7 +415,7 @@ function collectHostSnapshot(): HostSnapshot {
         swapUsedMiB: swapTotalMiB !== null && swapFreeMiB !== null ? swapTotalMiB - swapFreeMiB : null,
         swapFreeMiB,
         swapTotalMiB,
-        convexRssMiB: sumProcessRssMiB([/convex-local-backend/, /node .*\/convex dev --local --local-force-upgrade/]),
+        convexRssMiB: sumProcessRssMiB([/convex-local-backend/, /convex dev --local/]),
         chromeRssMiB: sumProcessRssMiB([/chrome/]),
         convexStateSizeMiB: readConvexStateSizeMiB(),
     };

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1228,7 +1228,7 @@ start_convex() {
     local root_env_local="$PROJECT_ROOT/.env.local"
     local selected_backend_version=""
     local cached_backend_version=""
-    local force_upgrade_raw="${CONVEX_LOCAL_FORCE_UPGRADE:-true}"
+    local force_upgrade_raw="${CONVEX_LOCAL_FORCE_UPGRADE:-false}"
     local force_upgrade_enabled="false"
     local prefetch_script="$SCRIPT_DIR/prefetch-convex-backend.sh"
     local startup_retries_raw="${CONVEX_STARTUP_RETRIES:-1}"
@@ -1238,7 +1238,7 @@ start_convex() {
     local total_attempts=2
     local attempt=1
     local use_force_upgrade_for_attempt="false"
-    local local_mode_requested="false"
+    local local_mode_requested="true"
     local command_str=""
     local timeout="${CONVEX_STARTUP_TIMEOUT:-120}"
     local convex_log=""
@@ -1369,8 +1369,8 @@ start_convex() {
             force_upgrade_enabled="false"
             ;;
         *)
-            log "CONVEX" "$YELLOW" "Invalid CONVEX_LOCAL_FORCE_UPGRADE='$force_upgrade_raw'. Expected true or false; defaulting to true."
-            force_upgrade_enabled="true"
+            log "CONVEX" "$YELLOW" "Invalid CONVEX_LOCAL_FORCE_UPGRADE='$force_upgrade_raw'. Expected true or false; defaulting to false."
+            force_upgrade_enabled="false"
             ;;
     esac
 
@@ -1672,7 +1672,7 @@ print_usage() {
     echo "  CONVEX_STARTUP_RETRIES Additional Convex startup retries after first failure (default: 1)"
     echo "  CONVEX_RETRY_DELAY_SECS Delay between Convex startup attempts in seconds (default: 2)"
     echo "  CONVEX_LOCAL_BACKEND_VERSION Explicit Convex local backend version override"
-    echo "  CONVEX_LOCAL_FORCE_UPGRADE Enable --local-force-upgrade on first attempt: true|false (default: true)"
+    echo "  CONVEX_LOCAL_FORCE_UPGRADE Enable --local-force-upgrade on first attempt: true|false (default: false)"
     echo "  CONVEX_SKIP_PREWARM  Skip the pre-startup backend prewarm step (true|1 to opt out; auto-skipped when CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS >= 120)"
     echo "  CONVEX_PREWARM_TIMEOUT Max seconds prewarm waits for port 3210 to bind (default: 120)"
     echo "  GITHUB_TOKEN / GH_TOKEN Optional GitHub token for Convex startup and prefetch metadata requests"

--- a/scripts/install-deploy-safety.test.ts
+++ b/scripts/install-deploy-safety.test.ts
@@ -7,6 +7,10 @@ import { beforeAll, describe, expect, it } from "vitest";
 
 const makefile = readFileSync(new URL("../Makefile", import.meta.url), "utf8");
 const installScript = readFileSync(new URL("./install.sh", import.meta.url), "utf8");
+const devScript = readFileSync(new URL("./dev.sh", import.meta.url), "utf8");
+const convexPackageJson = JSON.parse(
+  readFileSync(new URL("../packages/convex/package.json", import.meta.url), "utf8"),
+) as { scripts: Record<string, string | undefined> };
 const setupPreviewScript = readFileSync(new URL("../deploy/setup-preview.sh", import.meta.url), "utf8");
 const restorePreviewScript = readFileSync(new URL("../deploy/restore-preview-from-prod.sh", import.meta.url), "utf8");
 const restorePreviewFullStateScript = readFileSync(new URL("../deploy/restore-preview-full-state-from-prod.sh", import.meta.url), "utf8");
@@ -15,6 +19,7 @@ const previewDoctorScript = readFileSync(new URL("../deploy/preview-doctor.sh", 
 const previewMcpDockerfile = readFileSync(new URL("../deploy/docker/Dockerfile.mcp", import.meta.url), "utf8");
 const previewCompose = readFileSync(new URL("../deploy/docker/docker-compose.preview.yml", import.meta.url), "utf8");
 const previewConvexStartScript = readFileSync(new URL("../deploy/docker/start-convex.sh", import.meta.url), "utf8");
+const productionConvexService = readFileSync(new URL("../deploy/systemd/trends-convex.service", import.meta.url), "utf8");
 const removedSeedEnvVar = "SEED_" + "RESUMES";
 
 function getTargetRecipe(target: string): string {
@@ -179,6 +184,35 @@ describe("production deploy readiness checks", () => {
 
     expect(restorePreviewFullStateScript).toContain("run_preview_ai_smoke");
     expect(restorePreviewFullStateScript).toContain("SKIP_PREVIEW_AI_SMOKE");
+  });
+});
+
+describe("non-Docker Convex startup safety", () => {
+  it("does not force-upgrade local Convex package scripts", () => {
+    expect(convexPackageJson.scripts.dev).toContain("convex dev --local");
+    expect(convexPackageJson.scripts.predev).toContain("convex dev --once --local");
+    expect(convexPackageJson.scripts.dev).not.toContain("--local-force-upgrade");
+    expect(convexPackageJson.scripts.predev).not.toContain("--local-force-upgrade");
+  });
+
+  it("does not force-upgrade the production Convex systemd service", () => {
+    expect(productionConvexService).toContain("ExecStart=/usr/bin/npx convex dev --local");
+    expect(productionConvexService).not.toContain("--local-force-upgrade");
+  });
+
+  it("does not force-upgrade the install-time Convex schema push", () => {
+    const setupConvexLocal = extractShellFunction(installScript, "setup_convex_local");
+
+    expect(setupConvexLocal).toContain("npx convex dev --local --once");
+    expect(setupConvexLocal).not.toContain("--local-force-upgrade");
+  });
+
+  it("keeps dev-script force upgrade opt-in only", () => {
+    expect(devScript).toContain('local local_mode_requested="true"');
+    expect(devScript).toContain('CONVEX_LOCAL_FORCE_UPGRADE:-false');
+    expect(devScript).toContain(
+      "CONVEX_LOCAL_FORCE_UPGRADE Enable --local-force-upgrade on first attempt: true|false (default: false)",
+    );
   });
 });
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1256,7 +1256,7 @@ setup_convex_local() {
     systemctl stop trends-convex.service 2>/dev/null || true
 
     log_info "Pushing Convex schema/functions to local backend..."
-    run_as_service_user "set -a && [ -f '$CONFIG_DIR/env' ] && source '$CONFIG_DIR/env' && set +a && cd '$convex_dir' && export CONVEX_AGENT_MODE=anonymous && env -u TZ npx convex dev --local --once --local-force-upgrade"
+    run_as_service_user "set -a && [ -f '$CONFIG_DIR/env' ] && source '$CONFIG_DIR/env' && set +a && cd '$convex_dir' && export CONVEX_AGENT_MODE=anonymous && env -u TZ npx convex dev --local --once"
 
     # Now start the persistent backend service.
     log_info "Starting Convex local backend service..."


### PR DESCRIPTION
## Summary
- remove default --local-force-upgrade from local Convex package scripts, production systemd startup, and install-time schema push
- keep scripts/dev.sh explicitly local by default while making CONVEX_LOCAL_FORCE_UPGRADE opt-in
- update dev latency RSS detection and add deployment safety tests for non-Docker Convex startup paths

## Verification
- bunx vitest run scripts/install-deploy-safety.test.ts
- bash -n scripts/dev.sh
- bash -n scripts/install.sh
- bunx tsc --noEmit --allowImportingTsExtensions --moduleResolution bundler --module esnext --target es2022 --types node scripts/benchmark-dev-resume-latency.ts
- make check
- CONVEX_STARTUP_RETRIES=0 CONVEX_LOCAL_FORCE_UPGRADE=false make dev-fast ARGS=--no-seed, then curl probes: Convex :3210/version responded, API /health returned healthy, web / returned 200 text/html
