### PR TITLE
fix: route Convex dev targets through dev script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,16 +91,7 @@ dev-crawl:
 
 # Start only local Convex dev backend
 dev-convex:
-	@if [ -d "packages/convex" ]; then \
-		if command -v bun >/dev/null 2>&1; then \
-			cd packages/convex && bun run dev; \
-		else \
-			cd packages/convex && npm run dev; \
-		fi; \
-	else \
-		echo "packages/convex not found."; \
-		exit 1; \
-	fi
+	@./scripts/dev.sh --convex-only --no-seed $(ARGS)
 
 # Stop only local Convex dev backend listeners
 dev-convex-stop:
@@ -172,7 +163,7 @@ dev-convex-refresh:
 	if tmux has-session -t "$$tmux_session" 2>/dev/null; then \
 		tmux kill-session -t "$$tmux_session" 2>/dev/null || true; \
 	fi; \
-	tmux new-session -d -s "$$tmux_session" "cd '$$project_root/packages/convex' && if command -v bun >/dev/null 2>&1; then bun run dev; else npm run dev; fi"; \
+	tmux new-session -d -s "$$tmux_session" "cd '$$project_root' && $(MAKE) dev-convex"; \
 	echo "Waiting up to $$refresh_wait_secs seconds for local Convex to become ready..."; \
 	for _ in $$(seq 1 "$$refresh_wait_secs"); do \
 		if curl -fsS "http://127.0.0.1:$$convex_port/version" >/dev/null 2>&1; then \

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1644,6 +1644,7 @@ print_usage() {
     echo "Usage: $0 [OPTIONS]"
     echo ""
     echo "Options:"
+    echo "  --convex-only Start only local Convex dev backend"
     echo "  --mcp-only    Start only MCP server"
     echo "  --crawl-only  Run crawler only (no long-running services)"
     echo "  --skip-crawl  Skip initial crawl and start servers immediately (default)"
@@ -1699,6 +1700,10 @@ main() {
 
     while [[ $# -gt 0 ]]; do
         case $1 in
+            --convex-only)
+                services=("convex")
+                shift
+                ;;
             --mcp-only)
                 services=("mcp")
                 shift

--- a/scripts/install-deploy-safety.test.ts
+++ b/scripts/install-deploy-safety.test.ts
@@ -188,6 +188,37 @@ describe("production deploy readiness checks", () => {
 });
 
 describe("non-Docker Convex startup safety", () => {
+  it("routes make dev-convex through the hardened non-Docker dev script path", () => {
+    const recipe = getTargetRecipe("dev-convex");
+
+    expect(recipe).toContain("./scripts/dev.sh --convex-only --no-seed");
+    expect(recipe).not.toContain("docker");
+    expect(recipe).not.toContain("compose");
+    expect(recipe).not.toContain("cd packages/convex");
+  });
+
+  it("routes detached Convex refresh through the same non-Docker dev script path", () => {
+    const recipe = getTargetRecipe("dev-convex-refresh");
+
+    expect(recipe).toContain("$(MAKE) dev-convex");
+    expect(recipe).not.toContain("cd '$$project_root/packages/convex'");
+    expect(recipe).not.toContain("bun run dev");
+    expect(recipe).not.toContain("npm run dev");
+    expect(recipe).not.toContain("docker");
+    expect(recipe).not.toContain("compose");
+  });
+
+  it("exposes a convex-only dev script mode without Docker compose", () => {
+    const optionStart = devScript.indexOf("--convex-only)");
+    const nextOptionStart = devScript.indexOf("--mcp-only)", optionStart);
+    const optionBranch = devScript.slice(optionStart, nextOptionStart);
+
+    expect(devScript).toContain("--convex-only");
+    expect(optionBranch).toContain('services=("convex")');
+    expect(optionBranch).not.toContain("docker");
+    expect(optionBranch).not.toContain("compose");
+  });
+
   it("does not force-upgrade local Convex package scripts", () => {
     expect(convexPackageJson.scripts.dev).toContain("convex dev --local");
     expect(convexPackageJson.scripts.predev).toContain("convex dev --once --local");


### PR DESCRIPTION
## Summary
- Route `make dev-convex` through `scripts/dev.sh --convex-only --no-seed` so it uses the hardened non-Docker Convex startup path.
- Route detached `make dev-convex-refresh` through the same `make dev-convex` entrypoint instead of bypassing the dev script in `packages/convex`.
- Add deploy-safety coverage for both Convex dev entrypoints and the `--convex-only` parser mode.

## Verification
- `rtk bunx vitest run scripts/install-deploy-safety.test.ts`
- `rtk make check`
- `rtk env CONVEX_REFRESH_WAIT_SECS=90 CONVEX_STARTUP_TIMEOUT=120 make dev-convex-refresh`
- `rtk make dev-convex-stop`
