### PR TITLE
Gate workspace operational reads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ dev-convex-status:
 				current="$$parent"; \
 			done; \
 		done; \
-	} | sort -u | tr '\n' ' ' )"; \
+	} | sed '/^[[:space:]]*$$/d' | sort -u | tr '\n' ' ' | xargs )"; \
 	if [ -n "$$pids" ]; then \
 		ps -o pid,ppid,pgid,rss,%mem,etime,cmd -p $$pids; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 		clear-resumes \
 		cli-build cli-install cli-test \
 		sync-agent-policy check-agent-policy sync-project-skills check-project-skills install-global-skills install-agent-skill check-agent-skill sync-agent-governance \
-		check-route-auth \
+		check-route-auth auth-workspace-smoke \
 		install-skill validate-skill check-skill-install install-test-plan-skill check-test-plan-skill \
 		install-browser-ext-skill check-browser-ext-skill \
 		sync-resume-ai-prompts check-resume-ai-prompts \
@@ -1302,6 +1302,10 @@ test-collect-url-smoke:                    ## Run quick smoke for Collect URL ke
 		npm run test:e2e:collect-url; \
 	fi
 
+auth-workspace-smoke:                      ## Run auth/session/CSRF workspace smoke (requires AUTH_SMOKE_EMAIL/PASSWORD)
+	@echo "Running auth workspace smoke check..."
+	@bunx tsx scripts/auth-workspace-smoke.ts
+
 test-coverage:                             ## Run Node.js tests with coverage
 	@echo "Running Node.js tests with coverage..."
 	@npm run --workspace @trends/shared build
@@ -1428,6 +1432,7 @@ help:
 	@echo "  test-api-search-profiles Run API route test for profile-run keyword dispatch"
 	@echo "  test-worker-resume-tasks Run worker keyword assembly tests"
 	@echo "  test-collect-url-smoke Run Collect button URL smoke check"
+	@echo "  auth-workspace-smoke Run auth/session/CSRF workspace smoke (requires AUTH_SMOKE_EMAIL/PASSWORD)"
 	@echo "  test-resume    Validate resume fixtures"
 	@echo "  clean-db       Clean local databases and environment (Convex state + SQLite)"
 	@echo "  fresh-env      Wipe everything and reinstall dependencies (nuclear option)"

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createAuthMiddleware } from "../middleware/auth.js";
 import { workspaceMiddleware } from "../middleware/workspace.js";
@@ -11,8 +11,9 @@ import { AuthSessionService } from "../services/auth-session-service.js";
 import { AuthEventStorage } from "../services/auth-event-storage.js";
 import { AuthStorage } from "../services/auth-storage.js";
 import { config } from "../services/config.js";
-import { resetResumeScreeningDb } from "../services/database.js";
+import { getResumeScreeningDb, resetResumeScreeningDb } from "../services/database.js";
 import { hashPassword } from "../services/local-password-provider.js";
+import { CasdoorOidcProvider } from "../services/oidc-provider.js";
 import { createAuthRoutes } from "./auth.js";
 
 // Helper to create app with event storage for event logging tests
@@ -46,14 +47,64 @@ async function seedLocalUser(storage: AuthStorage) {
   return user;
 }
 
-function createTestApp(storage: AuthStorage, eventStorage?: AuthEventStorage) {
+type AuthRouteOverrides = Omit<
+  NonNullable<Parameters<typeof createAuthRoutes>[0]>,
+  "storage" | "eventStorage" | "ttlSeconds"
+>;
+
+type AuthIdentityDetailsRow = {
+  provider?: unknown;
+  provider_subject?: unknown;
+  provider_tenant?: unknown;
+  raw_profile_json?: unknown;
+};
+
+function createTestApp(
+  storage: AuthStorage,
+  eventStorage?: AuthEventStorage,
+  routeOverrides: AuthRouteOverrides = {},
+) {
   const middleware = createAuthMiddleware({ storage, ttlSeconds: 3600, eventStorage });
   const app = new OpenAPIHono();
   app.use("*", workspaceMiddleware);
   app.use("*", middleware.optionalAuth);
   app.use("/api/*", middleware.requireCsrf);
-  app.route("/", createAuthRoutes({ storage, ttlSeconds: 3600, eventStorage }));
+  app.get("/api/test/workspace-gated", middleware.requireWorkspaceUser, (c) => {
+    return c.json({ success: true as const });
+  });
+  app.route("/", createAuthRoutes({
+    storage,
+    ttlSeconds: 3600,
+    eventStorage,
+    ...routeOverrides,
+  }));
   return app;
+}
+
+function createCasdoorProviderMock(input: {
+  providerSubject: string;
+  email: string;
+  displayName: string;
+}): CasdoorOidcProvider {
+  const oidcProvider = new CasdoorOidcProvider({
+    issuer: "https://casdoor.example.com",
+    clientId: "trends",
+    clientSecret: "secret",
+    redirectUri: "http://localhost:3000/api/auth/casdoor/callback",
+    scope: "openid profile email",
+  });
+  vi.spyOn(oidcProvider, "handleCallback").mockResolvedValue({
+    provider: "casdoor",
+    providerSubject: input.providerSubject,
+    providerTenant: "https://casdoor.example.com",
+    email: input.email,
+    displayName: input.displayName,
+    rawProfile: {
+      sub: input.providerSubject,
+      tenant: "wecom-tenant-1",
+    },
+  });
+  return oidcProvider;
 }
 
 function readCookie(response: Response, name: string): string {
@@ -123,6 +174,133 @@ describe("auth routes", () => {
     const response = await app.request("/api/auth/casdoor/login");
 
     expect(response.status).toBe(404);
+  });
+
+  it("creates a Casdoor session without workspace membership for unknown provider subjects", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-casdoor-callback-"));
+    const storage = new AuthStorage(root);
+    storage.saveOidcState({
+      state: "casdoor-state-1",
+      provider: "casdoor",
+      codeVerifier: "verifier-1",
+      nonce: "nonce-1",
+      redirectTo: "/resumes",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    const oidcProvider = createCasdoorProviderMock({
+      providerSubject: "casdoor-user-1",
+      email: "wecom-user@example.com",
+      displayName: "WeCom User",
+    });
+    const app = createTestApp(storage, undefined, {
+      oidcEnabled: true,
+      oidcProvider,
+    });
+
+    const callback = await app.request("/api/auth/casdoor/callback?state=casdoor-state-1&code=ok", {
+      headers: { "X-Workspace-Slug": "hr" },
+    });
+
+    expect(callback.status).toBe(302);
+    expect(callback.headers.get("Location")).toBe("/resumes");
+    const identity = storage.findIdentity(
+      "casdoor",
+      "casdoor-user-1",
+      "https://casdoor.example.com",
+    );
+    expect(identity).not.toBeNull();
+    if (!identity) {
+      throw new Error("Casdoor identity was not linked");
+    }
+    expect(storage.listMemberships(identity.userId)).toEqual([]);
+    const identityDetails = getResumeScreeningDb(root).prepare(`
+      SELECT provider, provider_subject, provider_tenant, raw_profile_json
+      FROM auth_identities
+      WHERE user_id = ?
+    `).get(identity.userId) as AuthIdentityDetailsRow | undefined;
+    expect(identityDetails).toMatchObject({
+      provider: "casdoor",
+      provider_subject: "casdoor-user-1",
+      provider_tenant: "https://casdoor.example.com",
+    });
+    expect(JSON.parse(String(identityDetails?.raw_profile_json))).toMatchObject({
+      sub: "casdoor-user-1",
+      tenant: "wecom-tenant-1",
+    });
+
+    const denied = await app.request("/api/test/workspace-gated", {
+      headers: {
+        "X-Workspace-Slug": "hr",
+        Cookie: readCookie(callback, config.auth.sessionCookieName),
+      },
+    });
+
+    expect(denied.status).toBe(403);
+  });
+
+  it("applies explicit Casdoor membership preapproval during callback", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-casdoor-preapproved-callback-"));
+    const storage = new AuthStorage(root);
+    storage.preapproveProviderMembership({
+      provider: "casdoor",
+      providerSubject: "casdoor-user-2",
+      providerTenant: "https://casdoor.example.com",
+      workspaceSlug: "hr",
+      role: "user",
+      operatorId: "operator@example.com",
+    });
+    storage.saveOidcState({
+      state: "casdoor-state-2",
+      provider: "casdoor",
+      codeVerifier: "verifier-2",
+      nonce: "nonce-2",
+      redirectTo: "/resumes",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    const oidcProvider = createCasdoorProviderMock({
+      providerSubject: "casdoor-user-2",
+      email: "approved-user@example.com",
+      displayName: "Approved WeCom User",
+    });
+    const app = createTestApp(storage, undefined, {
+      oidcEnabled: true,
+      oidcProvider,
+    });
+
+    const callback = await app.request("/api/auth/casdoor/callback?state=casdoor-state-2&code=ok", {
+      headers: { "X-Workspace-Slug": "hr" },
+    });
+
+    expect(callback.status).toBe(302);
+    const identity = storage.findIdentity(
+      "casdoor",
+      "casdoor-user-2",
+      "https://casdoor.example.com",
+    );
+    expect(identity).not.toBeNull();
+    if (!identity) {
+      throw new Error("Casdoor identity was not linked");
+    }
+    expect(storage.listMemberships(identity.userId)).toEqual([
+      { userId: identity.userId, workspaceSlug: "hr", role: "user" },
+    ]);
+    const sessionCookie = readCookie(callback, config.auth.sessionCookieName);
+
+    const allowed = await app.request("/api/test/workspace-gated", {
+      headers: {
+        "X-Workspace-Slug": "hr",
+        Cookie: sessionCookie,
+      },
+    });
+    const deniedOtherWorkspace = await app.request("/api/test/workspace-gated", {
+      headers: {
+        "X-Workspace-Slug": "dev",
+        Cookie: sessionCookie,
+      },
+    });
+
+    expect(allowed.status).toBe(200);
+    expect(deniedOtherWorkspace.status).toBe(403);
   });
 
   it("revokes the current session on logout", async () => {

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -449,6 +449,12 @@ export function createAuthRoutes(options: AuthRoutesOptions = {}) {
       displayName: identity.displayName,
       rawProfile: identity.rawProfile,
     });
+    authStorage.applyProviderMembershipPreapprovals({
+      userId: user.id,
+      provider: identity.provider,
+      providerSubject: identity.providerSubject,
+      providerTenant: identity.providerTenant,
+    });
 
     const session = getSessions().createSession(user.id);
     setSessionCookies(c, session);

--- a/apps/api/src/routes/resumes.latest-work-history.test.ts
+++ b/apps/api/src/routes/resumes.latest-work-history.test.ts
@@ -6,6 +6,7 @@ import { AIMatchingService } from '../services/ai-matching'
 import { MatchStorage } from '../services/match-storage'
 import { ResumeService } from '../services/resume-service'
 import { workspaceConfigService } from '../services/workspace-config-service'
+import { createAuthContext } from './test-auth-helpers'
 
 describe('resume routes latest work history', () => {
   afterEach(() => {
@@ -71,7 +72,9 @@ describe('resume routes latest work history', () => {
       indexes: new Map(),
     })
 
-    const app = createApp()
+    const app = createApp({
+      authContext: createAuthContext({ workspaceSlug: 'dev', role: 'user' }),
+    })
     const response = await app.request('/api/resumes/match', {
       method: 'POST',
       headers: {

--- a/apps/api/src/routes/resumes.search-integration.test.ts
+++ b/apps/api/src/routes/resumes.search-integration.test.ts
@@ -19,6 +19,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createApp } from "../app";
+import { createAuthContext } from "./test-auth-helpers";
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -148,6 +149,12 @@ function buildFilterableConvexResumeRecord(
     };
 }
 
+function createAuthenticatedApp() {
+    return createApp({
+        authContext: createAuthContext({ workspaceSlug: "dev", role: "user" }),
+    });
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────
 
 describe("BFF search dispatcher integration", () => {
@@ -174,7 +181,7 @@ describe("BFF search dispatcher integration", () => {
                 throw new Error(`Unexpected convex path: ${call.pathName}`);
             });
 
-            const app = createApp();
+            const app = createAuthenticatedApp();
             const response = await app.request("/api/resumes?source=convex&q=CNC%20销售&limit=5");
 
             expect(response.status).toBe(200);
@@ -213,7 +220,7 @@ describe("BFF search dispatcher integration", () => {
                 throw new Error(`Unexpected convex path: ${call.pathName}`);
             });
 
-            const app = createApp();
+            const app = createAuthenticatedApp();
             const response = await app.request("/api/resumes?source=convex&q=CNC%20销售&limit=5");
             expect(response.status).toBe(200);
 
@@ -238,7 +245,7 @@ describe("BFF search dispatcher integration", () => {
                 throw new Error(`Unexpected convex path: ${call.pathName}`);
             });
 
-            const app = createApp();
+            const app = createAuthenticatedApp();
             await app.request("/api/resumes?source=convex&q=CNC%20销售&limit=5");
 
             const digestCall = calls.find((c) => c.pathName === "resumes_search:scanResumeDigestPage");
@@ -262,7 +269,7 @@ describe("BFF search dispatcher integration", () => {
                 throw new Error(`Unexpected convex path: ${call.pathName}`);
             });
 
-            const app = createApp();
+            const app = createAuthenticatedApp();
             const response = await app.request("/api/resumes?source=convex&q=CNC%20销售&limit=5");
             expect(response.status).toBe(200);
 
@@ -287,7 +294,7 @@ describe("BFF search dispatcher integration", () => {
                 throw new Error(`Unexpected convex path: ${call.pathName}`);
             });
 
-            const app = createApp();
+            const app = createAuthenticatedApp();
             await app.request("/api/resumes?source=convex&q=CNC%20销售&minAge=25&maxAge=40");
 
             // Filters are applied BFF-side after scanResumeDigestPage
@@ -351,7 +358,7 @@ describe("BFF search dispatcher integration", () => {
                 throw new Error(`Unexpected convex path: ${call.pathName}`);
             });
 
-            const app = createApp();
+            const app = createAuthenticatedApp();
             const response = await app.request(
                 "/api/resumes?source=convex&q=CNC%20销售&limit=5&minRoleYears=1&roleFilterType=sales&minAge=25&maxAge=40&locations=China",
             );
@@ -410,7 +417,7 @@ describe("BFF search dispatcher integration", () => {
                 throw new Error(`Unexpected convex path: ${call.pathName}`);
             });
 
-            const app = createApp();
+            const app = createAuthenticatedApp();
             const response = await app.request(
                 "/api/resumes?source=convex&q=CNC%20销售&limit=5&minRoleYears=1&roleFilterType=sales&minAge=25&maxAge=40&locations=China",
             );
@@ -464,7 +471,7 @@ describe("BFF search dispatcher integration", () => {
                 throw new Error(`Unexpected convex path: ${call.pathName}`);
             });
 
-            const app = createApp();
+            const app = createAuthenticatedApp();
             const response = await app.request(
                 "/api/resumes?source=convex&q=CNC%20销售&limit=5&minRoleYears=1&roleType=sales&location=China",
             );
@@ -492,7 +499,7 @@ describe("BFF search dispatcher integration", () => {
                 throw new Error(`Unexpected convex path: ${call.pathName}`);
             });
 
-            const app = createApp();
+            const app = createAuthenticatedApp();
             await app.request("/api/resumes?source=convex&q=CNC%20销售&limit=100");
 
             for (const batchSize of batchSizes) {

--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -66,9 +66,9 @@ function convexSuccess(value: unknown): Response {
   );
 }
 
-function createTestApp() {
+function createTestApp(authContext = createAuthContext({ workspaceSlug: "dev", role: "admin" })) {
   return createApp({
-    authContext: createAuthContext({ workspaceSlug: "dev", role: "admin" }),
+    authContext,
   });
 }
 
@@ -445,7 +445,7 @@ describe("resume routes", () => {
       throw new Error(`Unexpected convex path: ${call.pathName}`);
     });
 
-    const app = createTestApp();
+    const app = createTestApp(createAuthContext({ workspaceSlug: "hr", role: "admin" }));
     const response = await app.request("/api/resumes?source=convex&q=cnc%20sales&limit=5", {
       headers: {
         "X-Workspace-Slug": "hr",

--- a/apps/api/src/routes/resumes_match.test.ts
+++ b/apps/api/src/routes/resumes_match.test.ts
@@ -5,10 +5,18 @@ import resumesMatchRoutes from "./resumes_match";
 import { workspaceMiddleware } from "../middleware/workspace";
 import { MatchStorage } from "../services/match-storage";
 import { SessionManager } from "../services/session-manager";
+import type { AuthContext } from "../services/auth-types";
+import { createAuthContext } from "./test-auth-helpers";
 
-function createTestApp() {
+function createTestApp(authContext: AuthContext | null = createAuthContext({ workspaceSlug: "dev", role: "user" })) {
   const app = new OpenAPIHono();
   app.use("*", workspaceMiddleware);
+  if (authContext) {
+    app.use("*", async (c, next) => {
+      c.set("auth", authContext);
+      await next();
+    });
+  }
   app.route("/", resumesMatchRoutes);
   return app;
 }
@@ -51,6 +59,33 @@ const JSON_HEADERS = { "Content-Type": "application/json" };
 describe("resumes_match", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  describe("workspace membership", () => {
+    it("rejects anonymous match run reads", async () => {
+      const app = createTestApp(null);
+      const response = await app.request("/api/resumes/match-runs");
+
+      expect(response.status).toBe(401);
+    });
+
+    it("rejects match run reads from users outside the selected workspace", async () => {
+      const app = createTestApp(createAuthContext({ workspaceSlug: "hr", role: "user" }));
+      const response = await app.request("/api/resumes/match-runs", {
+        headers: { "X-Workspace-Slug": "dev" },
+      });
+
+      expect(response.status).toBe(403);
+    });
+
+    it("allows workspace members to read match runs", async () => {
+      vi.spyOn(MatchStorage.prototype, "listMatchRuns").mockReturnValue([makeStoredMatchRun()]);
+
+      const app = createTestApp();
+      const response = await app.request("/api/resumes/match-runs");
+
+      expect(response.status).toBe(200);
+    });
   });
 
   describe("POST /api/resumes/match", () => {

--- a/apps/api/src/routes/resumes_match.ts
+++ b/apps/api/src/routes/resumes_match.ts
@@ -37,6 +37,7 @@ import {
   scorePreparedCandidates,
   prepareSampleCandidates,
 } from "./resumes_search.js";
+import { requireWorkspaceUser } from "../middleware/auth.js";
 
 const app = new OpenAPIHono();
 const resumeService = new ResumeService(config.projectRoot);
@@ -48,6 +49,11 @@ const ruleScoringService = new RuleScoringService(config.projectRoot);
 const searchEventLogger = new SearchEventLogger(config.projectRoot);
 
 const DEFAULT_AI_TOP_N = 20;
+
+app.use("/api/resumes/match", requireWorkspaceUser);
+app.use("/api/resumes/match-stream", requireWorkspaceUser);
+app.use("/api/resumes/matches", requireWorkspaceUser);
+app.use("/api/resumes/match-runs", requireWorkspaceUser);
 
 type ResumeSource = "sample" | "convex";
 type MatchMode = "rules_only" | "hybrid" | "ai_only";

--- a/apps/api/src/routes/resumes_search.test.ts
+++ b/apps/api/src/routes/resumes_search.test.ts
@@ -4,10 +4,18 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import resumesSearchRoutes from "./resumes_search";
 import { workspaceMiddleware } from "../middleware/workspace";
 import { ResumeService } from "../services/resume-service";
+import type { AuthContext } from "../services/auth-types";
+import { createAuthContext } from "./test-auth-helpers";
 
-function createTestApp() {
+function createTestApp(authContext: AuthContext | null = null) {
   const app = new OpenAPIHono();
   app.use("*", workspaceMiddleware);
+  if (authContext) {
+    app.use("*", async (c, next) => {
+      c.set("auth", authContext);
+      await next();
+    });
+  }
   app.route("/", resumesSearchRoutes);
   return app;
 }
@@ -57,7 +65,7 @@ describe("resumes_search", () => {
 });
 
 describe("ResumesQuerySchema semantic search params", () => {
-  it("accepts enableSemantic parameter", async () => {
+  it("rejects anonymous resume list requests", async () => {
     vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
       items: [],
       sample: undefined,
@@ -66,6 +74,36 @@ describe("ResumesQuerySchema semantic search params", () => {
     });
 
     const app = createTestApp();
+    const response = await app.request("/api/resumes");
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects resume list requests from users outside the selected workspace", async () => {
+    vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
+      items: [],
+      sample: undefined,
+      metadata: undefined,
+      indexes: [],
+    });
+
+    const app = createTestApp(createAuthContext({ workspaceSlug: "hr", role: "user" }));
+    const response = await app.request("/api/resumes", {
+      headers: { "X-Workspace-Slug": "dev" },
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("accepts enableSemantic parameter", async () => {
+    vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
+      items: [],
+      sample: undefined,
+      metadata: undefined,
+      indexes: [],
+    });
+
+    const app = createTestApp(createAuthContext({ workspaceSlug: "dev", role: "user" }));
     const response = await app.request("/api/resumes?enableSemantic=true");
 
     expect(response.status).toBe(200);
@@ -79,7 +117,7 @@ describe("ResumesQuerySchema semantic search params", () => {
       indexes: [],
     });
 
-    const app = createTestApp();
+    const app = createTestApp(createAuthContext({ workspaceSlug: "dev", role: "user" }));
     const response = await app.request("/api/resumes?semanticWeight=0.7");
 
     expect(response.status).toBe(200);
@@ -93,21 +131,21 @@ describe("ResumesQuerySchema semantic search params", () => {
       indexes: [],
     });
 
-    const app = createTestApp();
+    const app = createTestApp(createAuthContext({ workspaceSlug: "dev", role: "user" }));
     const response = await app.request("/api/resumes?semanticLimit=100");
 
     expect(response.status).toBe(200);
   });
 
   it("rejects semanticWeight outside 0-1 range", async () => {
-    const app = createTestApp();
+    const app = createTestApp(createAuthContext({ workspaceSlug: "dev", role: "user" }));
     const response = await app.request("/api/resumes?semanticWeight=2.0");
 
     expect(response.status).toBe(400);
   });
 
   it("rejects semanticLimit above 256", async () => {
-    const app = createTestApp();
+    const app = createTestApp(createAuthContext({ workspaceSlug: "dev", role: "user" }));
     const response = await app.request("/api/resumes?semanticLimit=500");
 
     expect(response.status).toBe(400);

--- a/apps/api/src/routes/resumes_search.ts
+++ b/apps/api/src/routes/resumes_search.ts
@@ -24,6 +24,7 @@ import {
 } from "../schemas/index.js";
 import { resolveResumeId } from "../services/resume-id.js";
 import { callConvexAction, callConvexQuery, isConvexPaginatedQueryPage } from "../services/convex-utils.js";
+import { requireWorkspaceUser } from "../middleware/auth.js";
 import {
   formatKeywordQuery,
   parseKeywordQuery,
@@ -630,6 +631,7 @@ const getResumesRoute = createRoute({
   method: "get",
   path: "/api/resumes",
   tags: ["resumes"],
+  middleware: [requireWorkspaceUser] as const,
   summary: "List resumes from a sample file",
   description: "Returns resume items from the latest or specified sample JSON",
   request: {

--- a/apps/api/src/routes/scoring-evaluation.test.ts
+++ b/apps/api/src/routes/scoring-evaluation.test.ts
@@ -5,12 +5,20 @@ import scoringEvalRoutes from './scoring-evaluation'
 import { workspaceMiddleware } from '../middleware/workspace'
 import { SearchEventAnalyzer } from '../services/search-event-analyzer'
 import { ScoringAutoTuner } from '../services/scoring-auto-tuner'
+import type { AuthContext } from '../services/auth-types'
 import { WeightHistoryService } from '../services/weight-history'
 import { workspaceConfigService } from '../services/workspace-config-service'
+import { createAuthContext } from './test-auth-helpers'
 
-function createTestApp() {
+function createTestApp(authContext: AuthContext | null = createAuthContext({ workspaceSlug: 'dev', role: 'user' })) {
   const app = new OpenAPIHono()
   app.use('*', workspaceMiddleware)
+  if (authContext) {
+    app.use('*', async (c, next) => {
+      c.set('auth', authContext)
+      await next()
+    })
+  }
   app.route('/api/scoring-evaluation', scoringEvalRoutes)
   return app
 }
@@ -85,6 +93,36 @@ const MOCK_HISTORY_ITEMS = [
 describe('scoring-evaluation routes', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+  })
+
+  describe('workspace membership', () => {
+    it('rejects anonymous scoring report reads', async () => {
+      const app = createTestApp(null)
+      const response = await app.request('/api/scoring-evaluation/report', {
+        headers: ADMIN_HEADERS,
+      })
+
+      expect(response.status).toBe(401)
+    })
+
+    it('rejects scoring report reads from users outside the selected workspace', async () => {
+      const app = createTestApp(createAuthContext({ workspaceSlug: 'hr', role: 'user' }))
+      const response = await app.request('/api/scoring-evaluation/report', {
+        headers: ADMIN_HEADERS,
+      })
+
+      expect(response.status).toBe(403)
+    })
+
+    it('allows workspace members to read scoring reports', async () => {
+      vi.spyOn(SearchEventAnalyzer.prototype, 'analyze').mockReturnValue(MOCK_REPORT as never)
+      const app = createTestApp()
+      const response = await app.request('/api/scoring-evaluation/report', {
+        headers: ADMIN_HEADERS,
+      })
+
+      expect(response.status).toBe(200)
+    })
   })
 
   describe('GET /api/scoring-evaluation/report', () => {

--- a/apps/api/src/routes/scoring-evaluation.ts
+++ b/apps/api/src/routes/scoring-evaluation.ts
@@ -1,5 +1,6 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 
+import { requireWorkspaceUser } from "../middleware/auth.js";
 import { config } from "../services/config.js";
 import { ScoringAutoTuner } from "../services/scoring-auto-tuner.js";
 import { SearchEventAnalyzer } from "../services/search-event-analyzer.js";
@@ -10,6 +11,8 @@ const app = new OpenAPIHono();
 const analyzer = new SearchEventAnalyzer(config.projectRoot);
 const autoTuner = new ScoringAutoTuner(config.projectRoot);
 const weightHistory = new WeightHistoryService(config.projectRoot);
+
+app.use("*", requireWorkspaceUser);
 
 const CategoryWeightsSchema = z.object({
   skillMatch: z.number().min(0),

--- a/apps/api/src/routes/search-alerts.test.ts
+++ b/apps/api/src/routes/search-alerts.test.ts
@@ -3,12 +3,20 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import searchAlertsRoutes from './search-alerts'
 import { workspaceMiddleware } from '../middleware/workspace'
+import type { AuthContext } from '../services/auth-types'
+import { createAuthContext } from './test-auth-helpers'
 
 // search-alerts uses a local convexQuery/convexMutation that calls resolveConvexUrl + fetch.
 // We mock the global fetch to intercept Convex HTTP API calls.
-function createTestApp() {
+function createTestApp(authContext: AuthContext | null = createAuthContext({ workspaceSlug: 'dev', role: 'user' })) {
   const app = new OpenAPIHono()
   app.use('*', workspaceMiddleware)
+  if (authContext) {
+    app.use('*', async (c, next) => {
+      c.set('auth', authContext)
+      await next()
+    })
+  }
   app.route('/', searchAlertsRoutes)
   return app
 }
@@ -57,6 +65,30 @@ const MOCK_ALERTS = [
 describe('search-alerts routes', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+  })
+
+  describe('workspace membership', () => {
+    it('rejects anonymous alert reads', async () => {
+      const app = createTestApp(null)
+      const response = await app.request('/', { headers: ADMIN_HEADERS })
+
+      expect(response.status).toBe(401)
+    })
+
+    it('rejects alert reads from users outside the selected workspace', async () => {
+      const app = createTestApp(createAuthContext({ workspaceSlug: 'hr', role: 'user' }))
+      const response = await app.request('/', { headers: ADMIN_HEADERS })
+
+      expect(response.status).toBe(403)
+    })
+
+    it('allows workspace members to read alerts', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockConvexResponse(MOCK_ALERTS) as never)
+      const app = createTestApp()
+      const response = await app.request('/', { headers: ADMIN_HEADERS })
+
+      expect(response.status).toBe(200)
+    })
   })
 
   describe('GET /api/search-alerts/', () => {
@@ -180,6 +212,7 @@ describe('search-alerts routes', () => {
       const callBody = JSON.parse(fetchSpy.mock.calls[0]?.[1]?.body as string ?? '{}')
       expect(callBody.path).toBe('search_alerts:toggle')
       expect(callBody.args.alertId).toBe('alert-1')
+      expect(callBody.args.workspaceSlug).toBe('dev')
       expect(callBody.args.enabled).toBe(true)
     })
 
@@ -216,6 +249,7 @@ describe('search-alerts routes', () => {
       })
       const callBody = JSON.parse(fetchSpy.mock.calls[0]?.[1]?.body as string ?? '{}')
       expect(callBody.path).toBe('search_alerts:remove')
+      expect(callBody.args.workspaceSlug).toBe('dev')
       expect(callBody.args.alertId).toBe('alert-1')
     })
   })

--- a/apps/api/src/routes/search-alerts.ts
+++ b/apps/api/src/routes/search-alerts.ts
@@ -1,7 +1,9 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { requireWorkspaceUser } from "../middleware/auth.js";
 import { resolveConvexUrl } from "../services/resume-import-service.js";
 
 const app = new OpenAPIHono();
+app.use("*", requireWorkspaceUser);
 
 const SearchAlertSchema = z.object({
     _id: z.string(),
@@ -71,7 +73,7 @@ const listRoute = createRoute({
 });
 
 app.openapi(listRoute, async (c) => {
-    const workspace = c.req.header("X-Workspace-Slug") ?? "default";
+    const workspace = c.var.workspaceSlug;
     const alerts = await convexQuery("search_alerts:list", {
         workspaceSlug: workspace,
     }) as z.infer<typeof SearchAlertSchema>[];
@@ -114,7 +116,7 @@ const createRoute_ = createRoute({
 
 app.openapi(createRoute_, async (c) => {
     const body = c.req.valid("json");
-    const workspace = c.req.header("X-Workspace-Slug") ?? "default";
+    const workspace = c.var.workspaceSlug;
     const alertId = await convexMutation("search_alerts:create", {
         workspaceSlug: workspace,
         searchProfileId: body.searchProfileId,
@@ -161,6 +163,7 @@ app.openapi(toggleRoute, async (c) => {
     const body = c.req.valid("json");
     await convexMutation("search_alerts:toggle", {
         alertId: id,
+        workspaceSlug: c.var.workspaceSlug,
         enabled: body.enabled,
     });
     return c.json({ success: true as const }, 200);
@@ -192,6 +195,7 @@ app.openapi(deleteRoute, async (c) => {
     const { id } = c.req.valid("param");
     await convexMutation("search_alerts:remove", {
         alertId: id,
+        workspaceSlug: c.var.workspaceSlug,
     });
     return c.json({ success: true as const }, 200);
 });

--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { createAuthContext } from "./test-auth-helpers";
+
 function createFixtureRoot(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "sessions-route-"));
   fs.mkdirSync(path.join(root, "output"), { recursive: true });
@@ -57,7 +59,7 @@ describe("session routes", () => {
   it("creates and rehydrates persisted share session state", async () => {
     root = createFixtureRoot();
     const { createApp } = await loadSessionModules(root);
-    const app = createApp();
+    const app = createApp({ authContext: createAuthContext({ workspaceSlug: "hr", role: "user" }) });
 
     const createResponse = await app.request("/api/sessions", {
       method: "POST",
@@ -164,7 +166,7 @@ describe("session routes", () => {
   it("updates and clears persisted share metadata within the workspace scope", async () => {
     root = createFixtureRoot();
     const { createApp } = await loadSessionModules(root);
-    const app = createApp();
+    const app = createApp({ authContext: createAuthContext({ workspaceSlug: "hr", role: "user" }) });
 
     const createResponse = await app.request("/api/sessions", {
       method: "POST",
@@ -229,6 +231,39 @@ describe("session routes", () => {
       },
     });
 
-    expect(missingWorkspaceResponse.status).toBe(404);
+    expect(missingWorkspaceResponse.status).toBe(403);
+  });
+
+  it("rejects anonymous session reads", async () => {
+    root = createFixtureRoot();
+    const { createApp } = await loadSessionModules(root);
+    const app = createApp();
+
+    const response = await app.request("/api/sessions/session-1", {
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects session creation from users outside the selected workspace", async () => {
+    root = createFixtureRoot();
+    const { createApp } = await loadSessionModules(root);
+    const app = createApp({ authContext: createAuthContext({ workspaceSlug: "hr", role: "user" }) });
+
+    const response = await app.request("/api/sessions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "dev",
+      },
+      body: JSON.stringify({
+        shareTitle: "Wrong workspace",
+      }),
+    });
+
+    expect(response.status).toBe(403);
   });
 });

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -1,11 +1,15 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 
 import { CandidateStatusEnumSchema, ResumeFiltersSchema } from "../schemas/index.js";
+import { requireWorkspaceUser } from "../middleware/auth.js";
 import { config } from "../services/config.js";
 import { SessionManager } from "../services/session-manager.js";
 
 const app = new OpenAPIHono();
 const sessionManager = new SessionManager(config.projectRoot);
+
+app.use("/api/sessions", requireWorkspaceUser);
+app.use("/api/sessions/*", requireWorkspaceUser);
 
 const SessionStatusSchema = z.enum(["active", "completed", "archived"]);
 const SessionFiltersSchema = ResumeFiltersSchema.extend({

--- a/apps/api/src/services/auth-event-types.ts
+++ b/apps/api/src/services/auth-event-types.ts
@@ -5,7 +5,9 @@ export type AuthEventType =
   | "csrf_reject"
   | "workspace_access_denied"
   | "admin_access_denied"
-  | "oidc_state_invalid";
+  | "oidc_state_invalid"
+  | "workspace_membership_granted"
+  | "workspace_membership_revoked";
 
 export type AuthEventInput = {
   type: AuthEventType;

--- a/apps/api/src/services/auth-storage.test.ts
+++ b/apps/api/src/services/auth-storage.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import { AuthEventStorage } from "./auth-event-storage.js";
 import { AuthStorage } from "./auth-storage.js";
 import { getResumeScreeningDb, resetResumeScreeningDb } from "./database.js";
 
@@ -28,6 +29,8 @@ describe("auth sqlite schema", () => {
         "auth_sessions",
         "auth_oidc_states",
         "workspace_memberships",
+        "auth_provider_membership_preapprovals",
+        "auth_provider_membership_grants",
       ]),
     );
   });
@@ -77,5 +80,117 @@ describe("auth sqlite schema", () => {
       expiresAt,
     });
     expect(storage.consumeOidcState("state-123")).toBeNull();
+  });
+
+  it("applies and revokes explicit Casdoor membership preapprovals with audit events", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-casdoor-preapproval-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(root);
+
+    storage.preapproveProviderMembership({
+      provider: "casdoor",
+      providerSubject: "casdoor-user-1",
+      providerTenant: "https://casdoor.example.com",
+      workspaceSlug: "hr",
+      role: "user",
+      operatorId: "operator@example.com",
+    });
+
+    const user = storage.createUser({
+      email: "wecom-user@example.com",
+      displayName: "WeCom User",
+    });
+    storage.linkIdentity({
+      userId: user.id,
+      provider: "casdoor",
+      providerSubject: "casdoor-user-1",
+      providerTenant: "https://casdoor.example.com",
+      email: user.email,
+      displayName: user.displayName,
+    });
+
+    expect(storage.applyProviderMembershipPreapprovals({
+      provider: "casdoor",
+      providerSubject: "casdoor-user-1",
+      providerTenant: "https://casdoor.example.com",
+      userId: user.id,
+    })).toEqual([
+      { userId: user.id, workspaceSlug: "hr", role: "user" },
+    ]);
+    expect(storage.listMemberships(user.id)).toEqual([
+      { userId: user.id, workspaceSlug: "hr", role: "user" },
+    ]);
+    expect(storage.listMemberships(user.id)).not.toContainEqual({
+      userId: user.id,
+      workspaceSlug: "dev",
+      role: "admin",
+    });
+
+    storage.revokeProviderMembershipPreapproval({
+      provider: "casdoor",
+      providerSubject: "casdoor-user-1",
+      providerTenant: "https://casdoor.example.com",
+      workspaceSlug: "hr",
+      operatorId: "operator@example.com",
+    });
+
+    expect(storage.listMemberships(user.id)).toEqual([]);
+    expect(eventStorage.listRecent({ limit: 10 })).toMatchObject([
+      {
+        type: "workspace_membership_revoked",
+        provider: "casdoor",
+        userId: user.id,
+        workspaceSlug: "hr",
+        metadata: {
+          operatorId: "operator@example.com",
+          providerSubject: "casdoor-user-1",
+          providerTenant: "https://casdoor.example.com",
+          role: "user",
+        },
+      },
+      {
+        type: "workspace_membership_granted",
+        provider: "casdoor",
+        userId: user.id,
+        workspaceSlug: "hr",
+        metadata: {
+          operatorId: "operator@example.com",
+          providerSubject: "casdoor-user-1",
+          providerTenant: "https://casdoor.example.com",
+          role: "user",
+        },
+      },
+    ]);
+  });
+
+  it("grants immediately when a Casdoor preapproval matches an existing identity", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-casdoor-existing-preapproval-"));
+    const storage = new AuthStorage(root);
+
+    const user = storage.createUser({
+      email: "linked-user@example.com",
+      displayName: "Linked User",
+    });
+    storage.linkIdentity({
+      userId: user.id,
+      provider: "casdoor",
+      providerSubject: "casdoor-existing-user",
+      providerTenant: "https://casdoor.example.com",
+      email: user.email,
+      displayName: user.displayName,
+    });
+
+    storage.preapproveProviderMembership({
+      provider: "casdoor",
+      providerSubject: "casdoor-existing-user",
+      providerTenant: "https://casdoor.example.com",
+      workspaceSlug: "hr",
+      role: "admin",
+      operatorId: "operator@example.com",
+    });
+
+    expect(storage.listMemberships(user.id)).toEqual([
+      { userId: user.id, workspaceSlug: "hr", role: "admin" },
+    ]);
   });
 });

--- a/apps/api/src/services/auth-storage.ts
+++ b/apps/api/src/services/auth-storage.ts
@@ -10,6 +10,7 @@ import type {
   WorkspaceMembership,
   WorkspaceRole,
 } from "./auth-types.js";
+import type { AuthEventInput } from "./auth-event-types.js";
 import type { PasswordCredential } from "./local-password-provider.js";
 
 type IdentityRow = {
@@ -20,6 +21,20 @@ type MembershipRow = {
   user_id: string;
   workspace_slug: string;
   role: WorkspaceRole;
+};
+
+type ProviderMembershipPreapprovalRow = {
+  id?: unknown;
+  workspace_slug?: unknown;
+  role?: unknown;
+  operator_id?: unknown;
+};
+
+type ProviderMembershipGrantRow = {
+  id?: unknown;
+  user_id?: unknown;
+  workspace_slug?: unknown;
+  role?: unknown;
 };
 
 type PasswordCredentialRow = {
@@ -72,8 +87,36 @@ type OidcStateRow = {
   expires_at?: unknown;
 };
 
+export type ProviderMembershipPreapprovalInput = {
+  provider: AuthProvider;
+  providerSubject: string;
+  providerTenant: string;
+  workspaceSlug: string;
+  role: WorkspaceRole;
+  operatorId: string;
+};
+
+export type ProviderMembershipApplyInput = {
+  provider: AuthProvider;
+  providerSubject: string;
+  providerTenant: string;
+  userId: string;
+};
+
+export type ProviderMembershipRevokeInput = {
+  provider: AuthProvider;
+  providerSubject: string;
+  providerTenant: string;
+  workspaceSlug: string;
+  operatorId: string;
+};
+
 function toIsoNow(): string {
   return formatIsoOffsetInTimezone(new Date(), config.timezone);
+}
+
+function isWorkspaceRole(value: unknown): value is WorkspaceRole {
+  return value === "user" || value === "admin";
 }
 
 export class AuthStorage {
@@ -191,6 +234,193 @@ export class AuthStorage {
     return typeof row?.user_id === "string" ? { userId: row.user_id } : null;
   }
 
+  preapproveProviderMembership(input: ProviderMembershipPreapprovalInput): void {
+    const now = toIsoNow();
+    this.db.prepare(`
+      INSERT INTO auth_provider_membership_preapprovals (
+        id,
+        provider,
+        provider_subject,
+        provider_tenant,
+        workspace_slug,
+        role,
+        operator_id,
+        created_at,
+        updated_at,
+        revoked_at,
+        revoked_by
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)
+      ON CONFLICT(provider, provider_subject, provider_tenant, workspace_slug)
+      DO UPDATE SET
+        role = excluded.role,
+        operator_id = excluded.operator_id,
+        updated_at = excluded.updated_at,
+        revoked_at = NULL,
+        revoked_by = NULL
+    `).run(
+      randomUUID(),
+      input.provider,
+      input.providerSubject,
+      input.providerTenant,
+      input.workspaceSlug,
+      input.role,
+      input.operatorId,
+      now,
+      now,
+    );
+
+    const existingIdentity = this.findIdentity(input.provider, input.providerSubject, input.providerTenant);
+    if (existingIdentity) {
+      this.applyProviderMembershipPreapprovals({
+        provider: input.provider,
+        providerSubject: input.providerSubject,
+        providerTenant: input.providerTenant,
+        userId: existingIdentity.userId,
+      });
+    }
+  }
+
+  applyProviderMembershipPreapprovals(input: ProviderMembershipApplyInput): WorkspaceMembership[] {
+    const rows = this.db.prepare(`
+      SELECT id, workspace_slug, role, operator_id
+      FROM auth_provider_membership_preapprovals
+      WHERE provider = ?
+        AND provider_subject = ?
+        AND provider_tenant = ?
+        AND revoked_at IS NULL
+      ORDER BY workspace_slug ASC
+    `).all(
+      input.provider,
+      input.providerSubject,
+      input.providerTenant,
+    ) as ProviderMembershipPreapprovalRow[];
+
+    const memberships: WorkspaceMembership[] = [];
+    for (const row of rows) {
+      if (
+        typeof row.id !== "string"
+        || typeof row.workspace_slug !== "string"
+        || !isWorkspaceRole(row.role)
+        || typeof row.operator_id !== "string"
+      ) {
+        continue;
+      }
+
+      const membership: WorkspaceMembership = {
+        userId: input.userId,
+        workspaceSlug: row.workspace_slug,
+        role: row.role,
+      };
+      const existingGrant = this.findActiveProviderMembershipGrant({
+        ...input,
+        workspaceSlug: row.workspace_slug,
+      });
+      const isNewGrant = !existingGrant || existingGrant.role !== row.role;
+
+      this.upsertMembership(membership);
+      if (isNewGrant) {
+        this.upsertProviderMembershipGrant({
+          ...input,
+          preapprovalId: row.id,
+          workspaceSlug: row.workspace_slug,
+          role: row.role,
+        });
+        this.appendAuthEvent({
+          type: "workspace_membership_granted",
+          userId: input.userId,
+          provider: input.provider,
+          workspaceSlug: row.workspace_slug,
+          metadata: {
+            operatorId: row.operator_id,
+            providerSubject: input.providerSubject,
+            providerTenant: input.providerTenant,
+            role: row.role,
+          },
+        });
+      }
+      memberships.push(membership);
+    }
+
+    return memberships;
+  }
+
+  revokeProviderMembershipPreapproval(input: ProviderMembershipRevokeInput): void {
+    const preapproval = this.db.prepare(`
+      SELECT id, role
+      FROM auth_provider_membership_preapprovals
+      WHERE provider = ?
+        AND provider_subject = ?
+        AND provider_tenant = ?
+        AND workspace_slug = ?
+        AND revoked_at IS NULL
+    `).get(
+      input.provider,
+      input.providerSubject,
+      input.providerTenant,
+      input.workspaceSlug,
+    ) as ProviderMembershipPreapprovalRow | undefined;
+
+    if (typeof preapproval?.id !== "string" || !isWorkspaceRole(preapproval.role)) {
+      return;
+    }
+
+    const now = toIsoNow();
+    const grants = this.db.prepare(`
+      SELECT id, user_id, workspace_slug, role
+      FROM auth_provider_membership_grants
+      WHERE provider = ?
+        AND provider_subject = ?
+        AND provider_tenant = ?
+        AND workspace_slug = ?
+        AND revoked_at IS NULL
+    `).all(
+      input.provider,
+      input.providerSubject,
+      input.providerTenant,
+      input.workspaceSlug,
+    ) as ProviderMembershipGrantRow[];
+
+    this.db.prepare(`
+      UPDATE auth_provider_membership_preapprovals
+      SET revoked_at = ?, revoked_by = ?, updated_at = ?
+      WHERE id = ?
+    `).run(now, input.operatorId, now, preapproval.id);
+
+    for (const grant of grants) {
+      if (
+        typeof grant.id !== "string"
+        || typeof grant.user_id !== "string"
+        || typeof grant.workspace_slug !== "string"
+        || !isWorkspaceRole(grant.role)
+      ) {
+        continue;
+      }
+
+      this.deleteProviderGrantedMembership({
+        userId: grant.user_id,
+        workspaceSlug: grant.workspace_slug,
+        role: grant.role,
+      });
+      this.db.prepare(`
+        UPDATE auth_provider_membership_grants
+        SET revoked_at = ?
+        WHERE id = ?
+      `).run(now, grant.id);
+      this.appendAuthEvent({
+        type: "workspace_membership_revoked",
+        userId: grant.user_id,
+        provider: input.provider,
+        workspaceSlug: grant.workspace_slug,
+        metadata: {
+          operatorId: input.operatorId,
+          providerSubject: input.providerSubject,
+          providerTenant: input.providerTenant,
+          role: grant.role,
+        },
+      });
+    }
+  }
+
   upsertMembership(input: WorkspaceMembership): void {
     const now = toIsoNow();
     this.db.prepare(`
@@ -214,6 +444,116 @@ export class AuthStorage {
       workspaceSlug: row.workspace_slug,
       role: row.role,
     }));
+  }
+
+  private findActiveProviderMembershipGrant(input: {
+    provider: AuthProvider;
+    providerSubject: string;
+    providerTenant: string;
+    workspaceSlug: string;
+    userId: string;
+  }): { role: WorkspaceRole } | null {
+    const row = this.db.prepare(`
+      SELECT role
+      FROM auth_provider_membership_grants
+      WHERE provider = ?
+        AND provider_subject = ?
+        AND provider_tenant = ?
+        AND workspace_slug = ?
+        AND user_id = ?
+        AND revoked_at IS NULL
+    `).get(
+      input.provider,
+      input.providerSubject,
+      input.providerTenant,
+      input.workspaceSlug,
+      input.userId,
+    ) as ProviderMembershipGrantRow | undefined;
+
+    return isWorkspaceRole(row?.role) ? { role: row.role } : null;
+  }
+
+  private upsertProviderMembershipGrant(input: {
+    preapprovalId: string;
+    provider: AuthProvider;
+    providerSubject: string;
+    providerTenant: string;
+    workspaceSlug: string;
+    role: WorkspaceRole;
+    userId: string;
+  }): void {
+    const now = toIsoNow();
+    this.db.prepare(`
+      INSERT INTO auth_provider_membership_grants (
+        id,
+        preapproval_id,
+        user_id,
+        provider,
+        provider_subject,
+        provider_tenant,
+        workspace_slug,
+        role,
+        granted_at,
+        revoked_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+      ON CONFLICT(provider, provider_subject, provider_tenant, workspace_slug, user_id)
+      DO UPDATE SET
+        preapproval_id = excluded.preapproval_id,
+        role = excluded.role,
+        granted_at = excluded.granted_at,
+        revoked_at = NULL
+    `).run(
+      randomUUID(),
+      input.preapprovalId,
+      input.userId,
+      input.provider,
+      input.providerSubject,
+      input.providerTenant,
+      input.workspaceSlug,
+      input.role,
+      now,
+    );
+  }
+
+  private deleteProviderGrantedMembership(input: {
+    userId: string;
+    workspaceSlug: string;
+    role: WorkspaceRole;
+  }): void {
+    this.db.prepare(`
+      DELETE FROM workspace_memberships
+      WHERE user_id = ? AND workspace_slug = ? AND role = ?
+    `).run(input.userId, input.workspaceSlug, input.role);
+  }
+
+  private appendAuthEvent(input: AuthEventInput): void {
+    this.db.prepare(`
+      INSERT INTO auth_events (
+        id,
+        type,
+        user_id,
+        provider,
+        workspace_slug,
+        session_id,
+        reason,
+        metadata_json,
+        ip_hash,
+        user_agent,
+        created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      randomUUID(),
+      input.type,
+      input.userId ?? null,
+      input.provider ?? null,
+      input.workspaceSlug ?? null,
+      input.sessionId ?? null,
+      input.reason ?? null,
+      input.metadata ? JSON.stringify(input.metadata) : null,
+      input.ipHash ?? null,
+      input.userAgent ?? null,
+      toIsoNow(),
+    );
   }
 
   savePasswordCredential(input: PasswordCredential & {

--- a/apps/api/src/services/database.ts
+++ b/apps/api/src/services/database.ts
@@ -235,10 +235,46 @@ function initSchema(db: Database.Database): void {
       FOREIGN KEY (user_id) REFERENCES users(id)
     );
 
+    CREATE TABLE IF NOT EXISTS auth_provider_membership_preapprovals (
+      id TEXT PRIMARY KEY,
+      provider TEXT NOT NULL,
+      provider_subject TEXT NOT NULL,
+      provider_tenant TEXT NOT NULL,
+      workspace_slug TEXT NOT NULL,
+      role TEXT NOT NULL,
+      operator_id TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      revoked_at TEXT,
+      revoked_by TEXT,
+      UNIQUE(provider, provider_subject, provider_tenant, workspace_slug)
+    );
+
+    CREATE TABLE IF NOT EXISTS auth_provider_membership_grants (
+      id TEXT PRIMARY KEY,
+      preapproval_id TEXT NOT NULL,
+      user_id TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      provider_subject TEXT NOT NULL,
+      provider_tenant TEXT NOT NULL,
+      workspace_slug TEXT NOT NULL,
+      role TEXT NOT NULL,
+      granted_at TEXT NOT NULL,
+      revoked_at TEXT,
+      UNIQUE(provider, provider_subject, provider_tenant, workspace_slug, user_id),
+      FOREIGN KEY (preapproval_id) REFERENCES auth_provider_membership_preapprovals(id),
+      FOREIGN KEY (user_id) REFERENCES users(id)
+    );
+
     CREATE INDEX IF NOT EXISTS idx_auth_identities_user ON auth_identities(user_id);
     CREATE INDEX IF NOT EXISTS idx_auth_sessions_user ON auth_sessions(user_id);
     CREATE INDEX IF NOT EXISTS idx_auth_sessions_token ON auth_sessions(token_hash);
     CREATE INDEX IF NOT EXISTS idx_workspace_memberships_workspace ON workspace_memberships(workspace_slug);
+    CREATE INDEX IF NOT EXISTS idx_auth_provider_preapprovals_subject
+      ON auth_provider_membership_preapprovals(provider, provider_subject, provider_tenant);
+    CREATE INDEX IF NOT EXISTS idx_auth_provider_grants_user ON auth_provider_membership_grants(user_id);
+    CREATE INDEX IF NOT EXISTS idx_auth_provider_grants_subject
+      ON auth_provider_membership_grants(provider, provider_subject, provider_tenant);
 
     CREATE TABLE IF NOT EXISTS workspace_summary_runs (
       id TEXT PRIMARY KEY,

--- a/packages/convex/__tests__/search-alerts-convex-test.test.ts
+++ b/packages/convex/__tests__/search-alerts-convex-test.test.ts
@@ -61,6 +61,7 @@ describe("search_alerts (convex-test)", () => {
 
       await t.mutation(api.search_alerts.toggle, {
         alertId: id,
+        workspaceSlug: "ws1",
         enabled: false,
       });
 
@@ -77,10 +78,12 @@ describe("search_alerts (convex-test)", () => {
 
       await t.mutation(api.search_alerts.toggle, {
         alertId: id,
+        workspaceSlug: "ws1",
         enabled: false,
       });
       await t.mutation(api.search_alerts.toggle, {
         alertId: id,
+        workspaceSlug: "ws1",
         enabled: true,
       });
 
@@ -88,6 +91,20 @@ describe("search_alerts (convex-test)", () => {
         workspaceSlug: "ws1",
       });
       expect(enabled).toHaveLength(1);
+    });
+
+    it("rejects toggling an alert from a different workspace", async () => {
+      const t = createTest();
+
+      const id = await t.mutation(api.search_alerts.create, seedAlert({ workspaceSlug: "ws2" }));
+
+      await expect(
+        t.mutation(api.search_alerts.toggle, {
+          alertId: id,
+          workspaceSlug: "ws1",
+          enabled: false,
+        }),
+      ).rejects.toThrow("Search alert not found in workspace");
     });
   });
 
@@ -135,6 +152,7 @@ describe("search_alerts (convex-test)", () => {
 
       await t.mutation(api.search_alerts.toggle, {
         alertId: id2,
+        workspaceSlug: "ws1",
         enabled: false,
       });
 
@@ -173,12 +191,22 @@ describe("search_alerts (convex-test)", () => {
 
       const id = await t.mutation(api.search_alerts.create, seedAlert());
 
-      await t.mutation(api.search_alerts.remove, { alertId: id });
+      await t.mutation(api.search_alerts.remove, { alertId: id, workspaceSlug: "ws1" });
 
       const alerts = await t.query(api.search_alerts.list, {
         workspaceSlug: "ws1",
       });
       expect(alerts).toHaveLength(0);
+    });
+
+    it("rejects deleting an alert from a different workspace", async () => {
+      const t = createTest();
+
+      const id = await t.mutation(api.search_alerts.create, seedAlert({ workspaceSlug: "ws2" }));
+
+      await expect(
+        t.mutation(api.search_alerts.remove, { alertId: id, workspaceSlug: "ws1" }),
+      ).rejects.toThrow("Search alert not found in workspace");
     });
   });
 });

--- a/packages/convex/convex/search_alerts.ts
+++ b/packages/convex/convex/search_alerts.ts
@@ -27,9 +27,14 @@ export const create = mutation({
 export const toggle = mutation({
     args: {
         alertId: v.id("search_alerts"),
+        workspaceSlug: v.string(),
         enabled: v.boolean(),
     },
     handler: async (ctx, args) => {
+        const alert = await ctx.db.get(args.alertId);
+        if (!alert || alert.workspaceSlug !== args.workspaceSlug) {
+            throw new Error("Search alert not found in workspace");
+        }
         await ctx.db.patch(args.alertId, { enabled: args.enabled });
     },
 });
@@ -40,8 +45,13 @@ export const toggle = mutation({
 export const remove = mutation({
     args: {
         alertId: v.id("search_alerts"),
+        workspaceSlug: v.string(),
     },
     handler: async (ctx, args) => {
+        const alert = await ctx.db.get(args.alertId);
+        if (!alert || alert.workspaceSlug !== args.workspaceSlug) {
+            throw new Error("Search alert not found in workspace");
+        }
         await ctx.db.delete(args.alertId);
     },
 });

--- a/scripts/auth-workspace-smoke.test.ts
+++ b/scripts/auth-workspace-smoke.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertExpectedStatus,
+  buildAuthHeaders,
+  extractCsrfToken,
+  parseSetCookieHeaders,
+  readSmokeConfig,
+} from "./auth-workspace-smoke.ts";
+
+describe("auth workspace smoke helpers", () => {
+  it("parses multiple Set-Cookie headers into a browser-style cookie jar", () => {
+    const jar = parseSetCookieHeaders([
+      "trends_session=session-token; Path=/; HttpOnly; SameSite=Lax",
+      "trends_csrf=csrf-token; Path=/; SameSite=Lax",
+    ]);
+
+    expect(jar).toBe("trends_session=session-token; trends_csrf=csrf-token");
+  });
+
+  it("splits a combined Set-Cookie header without splitting Expires commas", () => {
+    const jar = parseSetCookieHeaders(
+      "trends_session=session-token; Expires=Tue, 09 Jun 2026 10:18:14 GMT; Path=/; HttpOnly, trends_csrf=csrf-token; Path=/",
+    );
+
+    expect(jar).toBe("trends_session=session-token; trends_csrf=csrf-token");
+  });
+
+  it("extracts the CSRF token from the local login response", () => {
+    expect(extractCsrfToken({
+      success: true,
+      csrfToken: "csrf-token-1",
+    })).toBe("csrf-token-1");
+  });
+
+  it("requires a CSRF token in the login response", () => {
+    expect(() => extractCsrfToken({ success: true })).toThrow(/csrf/i);
+  });
+
+  it("builds auth headers with cookie, CSRF, and workspace selection", () => {
+    expect(buildAuthHeaders({
+      cookieJar: "trends_session=session-token; trends_csrf=csrf-token",
+      csrfToken: "csrf-token",
+      workspaceSlug: "hr",
+    })).toEqual({
+      Cookie: "trends_session=session-token; trends_csrf=csrf-token",
+      "X-CSRF-Token": "csrf-token",
+      "X-Workspace-Slug": "hr",
+    });
+  });
+
+  it("accepts expected status codes", async () => {
+    const response = new Response(JSON.stringify({ success: true }), { status: 200 });
+
+    await expect(assertExpectedStatus("allowed route", response, [200])).resolves.toBeUndefined();
+  });
+
+  it("reports unexpected status codes with response body", async () => {
+    const response = new Response(JSON.stringify({ error: "Workspace access required" }), { status: 403 });
+
+    await expect(assertExpectedStatus("allowed route", response, [200]))
+      .rejects
+      .toThrow(/allowed route.*403.*Workspace access required/s);
+  });
+
+  it("reads smoke configuration from environment without leaking credentials", () => {
+    expect(readSmokeConfig({
+      API_URL: "https://api.example.com/",
+      WEB_URL: "https://web.example.com/",
+      WORKSPACE: "hr",
+      AUTH_SMOKE_EMAIL: "member@example.com",
+      AUTH_SMOKE_PASSWORD: "secret",
+    })).toMatchObject({
+      apiUrl: "https://api.example.com",
+      webUrl: "https://web.example.com",
+      workspaceSlug: "hr",
+      wrongWorkspaceSlug: "dev",
+      loginUsername: "member@example.com",
+      password: "secret",
+    });
+  });
+
+  it("requires smoke credentials from the environment", () => {
+    expect(() => readSmokeConfig({})).toThrow(/AUTH_SMOKE_EMAIL.*AUTH_SMOKE_PASSWORD/s);
+  });
+});

--- a/scripts/auth-workspace-smoke.ts
+++ b/scripts/auth-workspace-smoke.ts
@@ -1,0 +1,293 @@
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_API_URL = "http://localhost:3000";
+const DEFAULT_WEB_URL = "http://localhost:5173";
+const DEFAULT_WORKSPACE = "hr";
+const MEMBER_ROUTE = "/api/resumes?limit=1";
+const ADMIN_ROUTE = "/api/auth/events?limit=1";
+
+type EnvInput = Partial<Record<string, string | undefined>>;
+
+export type SmokeConfig = {
+  apiUrl: string;
+  webUrl: string;
+  workspaceSlug: string;
+  wrongWorkspaceSlug: string;
+  loginUsername: string;
+  password: string;
+  memberRoute: string;
+  adminRoute: string;
+};
+
+export type AuthHeaderInput = {
+  cookieJar: string;
+  csrfToken: string;
+  workspaceSlug: string;
+};
+
+type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+type HeadersWithSetCookie = Headers & {
+  getSetCookie?: () => string[];
+  raw?: () => Record<string, string[]>;
+};
+
+type SmokeStepResult = {
+  name: string;
+  status: number;
+};
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function requireEnv(value: string | undefined, name: string): string {
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function resolveWrongWorkspace(workspaceSlug: string, env: EnvInput): string {
+  if (env.AUTH_SMOKE_WRONG_WORKSPACE) {
+    return env.AUTH_SMOKE_WRONG_WORKSPACE;
+  }
+  return workspaceSlug === "dev" ? "hr" : "dev";
+}
+
+export function readSmokeConfig(env: EnvInput = process.env): SmokeConfig {
+  const loginUsername = env.AUTH_SMOKE_USERNAME ?? env.AUTH_SMOKE_EMAIL;
+  const missing: string[] = [];
+  if (!loginUsername) {
+    missing.push("AUTH_SMOKE_EMAIL or AUTH_SMOKE_USERNAME");
+  }
+  if (!env.AUTH_SMOKE_PASSWORD) {
+    missing.push("AUTH_SMOKE_PASSWORD");
+  }
+  if (missing.length > 0) {
+    throw new Error(`Missing required auth smoke environment variables: ${missing.join(", ")}`);
+  }
+
+  const workspaceSlug = env.WORKSPACE ?? DEFAULT_WORKSPACE;
+  return {
+    apiUrl: stripTrailingSlash(env.API_URL ?? DEFAULT_API_URL),
+    webUrl: stripTrailingSlash(env.WEB_URL ?? DEFAULT_WEB_URL),
+    workspaceSlug,
+    wrongWorkspaceSlug: resolveWrongWorkspace(workspaceSlug, env),
+    loginUsername: requireEnv(loginUsername, "AUTH_SMOKE_EMAIL"),
+    password: requireEnv(env.AUTH_SMOKE_PASSWORD, "AUTH_SMOKE_PASSWORD"),
+    memberRoute: env.AUTH_SMOKE_MEMBER_ROUTE ?? MEMBER_ROUTE,
+    adminRoute: env.AUTH_SMOKE_ADMIN_ROUTE ?? ADMIN_ROUTE,
+  };
+}
+
+function splitCombinedSetCookieHeader(header: string): string[] {
+  const parts: string[] = [];
+  let start = 0;
+  for (let index = 0; index < header.length; index += 1) {
+    if (header[index] !== ",") {
+      continue;
+    }
+    const remainder = header.slice(index + 1);
+    if (/^\s*[^=;,\s]+=/u.test(remainder)) {
+      parts.push(header.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  parts.push(header.slice(start).trim());
+  return parts.filter((part) => part.length > 0);
+}
+
+export function parseSetCookieHeaders(input: readonly string[] | string | null | undefined): string {
+  const headers = Array.isArray(input)
+    ? input
+    : input
+      ? splitCombinedSetCookieHeader(input)
+      : [];
+  const cookies = headers
+    .map((header) => header.split(";")[0]?.trim() ?? "")
+    .filter((cookie) => /^[^=]+=[\s\S]*$/u.test(cookie));
+
+  if (cookies.length === 0) {
+    throw new Error("Login response did not include session cookies");
+  }
+
+  return cookies.join("; ");
+}
+
+export function extractSetCookieHeaders(headers: Headers): string[] {
+  const withSetCookie = headers as HeadersWithSetCookie;
+  if (typeof withSetCookie.getSetCookie === "function") {
+    return withSetCookie.getSetCookie();
+  }
+  if (typeof withSetCookie.raw === "function") {
+    return withSetCookie.raw()["set-cookie"] ?? [];
+  }
+  const combined = headers.get("set-cookie");
+  return combined ? splitCombinedSetCookieHeader(combined) : [];
+}
+
+export function extractCsrfToken(body: unknown): string {
+  if (
+    typeof body === "object"
+    && body !== null
+    && "csrfToken" in body
+    && typeof body.csrfToken === "string"
+    && body.csrfToken.length > 0
+  ) {
+    return body.csrfToken;
+  }
+  throw new Error("Login response did not include a csrfToken");
+}
+
+export function buildAuthHeaders(input: AuthHeaderInput): Record<string, string> {
+  return {
+    Cookie: input.cookieJar,
+    "X-CSRF-Token": input.csrfToken,
+    "X-Workspace-Slug": input.workspaceSlug,
+  };
+}
+
+export async function assertExpectedStatus(
+  name: string,
+  response: Response,
+  allowedStatuses: readonly number[],
+): Promise<void> {
+  if (allowedStatuses.includes(response.status)) {
+    return;
+  }
+
+  const body = await response.text();
+  throw new Error(
+    `${name} expected HTTP ${allowedStatuses.join(" or ")} but received ${response.status} ${response.statusText}: ${body}`,
+  );
+}
+
+function buildUrl(baseUrl: string, path: string): string {
+  if (/^https?:\/\//u.test(path)) {
+    return path;
+  }
+  return `${baseUrl}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+async function requestStep(params: {
+  name: string;
+  fetchImpl: FetchLike;
+  url: string;
+  init?: RequestInit;
+  expectedStatuses: readonly number[];
+}): Promise<SmokeStepResult> {
+  const response = await params.fetchImpl(params.url, params.init);
+  await assertExpectedStatus(params.name, response, params.expectedStatuses);
+  return {
+    name: params.name,
+    status: response.status,
+  };
+}
+
+export async function runAuthWorkspaceSmoke(
+  config: SmokeConfig = readSmokeConfig(),
+  fetchImpl: FetchLike = fetch,
+): Promise<SmokeStepResult[]> {
+  const results: SmokeStepResult[] = [];
+
+  results.push(await requestStep({
+    name: "web URL",
+    fetchImpl,
+    url: config.webUrl,
+    expectedStatuses: [200],
+  }));
+
+  const loginResponse = await fetchImpl(buildUrl(config.apiUrl, "/api/auth/login"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Workspace-Slug": config.workspaceSlug,
+    },
+    body: JSON.stringify({
+      username: config.loginUsername,
+      password: config.password,
+    }),
+  });
+  await assertExpectedStatus("local login", loginResponse, [200]);
+  results.push({ name: "local login", status: loginResponse.status });
+
+  const cookieJar = parseSetCookieHeaders(extractSetCookieHeaders(loginResponse.headers));
+  const csrfToken = extractCsrfToken(await loginResponse.json());
+  const authHeaders = buildAuthHeaders({
+    cookieJar,
+    csrfToken,
+    workspaceSlug: config.workspaceSlug,
+  });
+
+  results.push(await requestStep({
+    name: "authenticated /api/auth/me",
+    fetchImpl,
+    url: buildUrl(config.apiUrl, "/api/auth/me"),
+    init: { headers: authHeaders },
+    expectedStatuses: [200],
+  }));
+
+  results.push(await requestStep({
+    name: "workspace member route",
+    fetchImpl,
+    url: buildUrl(config.apiUrl, config.memberRoute),
+    init: { headers: authHeaders },
+    expectedStatuses: [200],
+  }));
+
+  results.push(await requestStep({
+    name: "wrong workspace denial",
+    fetchImpl,
+    url: buildUrl(config.apiUrl, config.memberRoute),
+    init: {
+      headers: buildAuthHeaders({
+        cookieJar,
+        csrfToken,
+        workspaceSlug: config.wrongWorkspaceSlug,
+      }),
+    },
+    expectedStatuses: [403],
+  }));
+
+  results.push(await requestStep({
+    name: "anonymous workspace denial",
+    fetchImpl,
+    url: buildUrl(config.apiUrl, config.memberRoute),
+    init: {
+      headers: {
+        "X-Workspace-Slug": config.workspaceSlug,
+      },
+    },
+    expectedStatuses: [401],
+  }));
+
+  results.push(await requestStep({
+    name: "member admin-only denial",
+    fetchImpl,
+    url: buildUrl(config.apiUrl, config.adminRoute),
+    init: { headers: authHeaders },
+    expectedStatuses: [403],
+  }));
+
+  return results;
+}
+
+function isMainModule(): boolean {
+  return process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
+}
+
+if (isMainModule()) {
+  runAuthWorkspaceSmoke()
+    .then((results) => {
+      for (const result of results) {
+        console.log(`PASS ${result.name}: HTTP ${result.status}`);
+      }
+      console.log("PASS session cookie + CSRF token capture: values present (redacted)");
+      console.log("Auth workspace smoke passed.");
+    })
+    .catch((error: unknown) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    });
+}

--- a/scripts/check-route-auth.sh
+++ b/scripts/check-route-auth.sh
@@ -113,9 +113,9 @@ for file in "$ROUTES_DIR"/*.ts; do
   fi
 
   case "$access_class" in
-    workspace-write)
+    workspace-read|workspace-write)
       if ! has_workspace_user_guard "$file"; then
-        echo "FAIL: $base — workspace-write policy requires requireWorkspaceUser"
+        echo "FAIL: $base — $access_class policy requires requireWorkspaceUser"
         FAIL=1
       fi
       ;;
@@ -125,7 +125,7 @@ for file in "$ROUTES_DIR"/*.ts; do
         FAIL=1
       fi
       ;;
-    public|telemetry|workspace-read|internal-worker|candidate-link)
+    public|telemetry|internal-worker|candidate-link)
       ;;
     *)
       echo "FAIL: $base — unsupported route auth policy class: $access_class"

--- a/scripts/check-route-auth.sh
+++ b/scripts/check-route-auth.sh
@@ -1,102 +1,151 @@
 #!/usr/bin/env bash
-# check-route-auth.sh — Verify that API route files have auth middleware.
-#
-# Checks each route file in apps/api/src/routes/ for:
-# 1. Admin middleware or inline admin auth checks
-# 2. Workspace-user middleware for authenticated non-admin write routes
-#
-# Exit 0 if all route files with createRoute have auth.
-# Exit 1 if any non-public route file has createRoute but no auth mechanism detected.
+# check-route-auth.sh — Verify API route files match the route auth policy matrix.
 
 set -euo pipefail
 
-ROUTES_DIR="${ROUTES_DIR:-apps/api/src/routes}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROUTES_DIR="${ROUTES_DIR:-$ROOT_DIR/apps/api/src/routes}"
+POLICY_FILE="${ROUTE_AUTH_POLICY_FILE:-$ROOT_DIR/scripts/route-auth-policy.json}"
 FAIL=0
-SKIP_FILES=(
-  # Health/version — public endpoints
-  "health.ts"
-  "version.ts"
-  # Public read-only data endpoints
-  "search.ts"
-  "rss.ts"
-  "topics.ts"
-  "trends.ts"
-  "industry.ts"
-  # User-facing session/action/state endpoints (workspace-scoped, no admin required)
-  "sessions.ts"
-  "web-vitals.ts"
-  # Auth endpoints are public by design; protected routes consume their sessions.
-  "auth.ts"
-  # Resume search/match (workspace-scoped read paths)
-  "resumes_search.ts"
-  "resumes_match.ts"
-  # Public submission endpoints (browser extension, candidate-facing)
-  "resume-submit.ts"
-  "ai-summary.ts"
-  "search-alerts.ts"
-  "search-analytics.ts"
-  "scoring-evaluation.ts"
-  # Internal worker endpoints (own auth via WORKER_SECRET)
-  "worker.ts"
-)
 
-is_skipped() {
-  local file="$1"
-  local base
-  base=$(basename "$file")
-  for skip in "${SKIP_FILES[@]}"; do
-    if [[ "$base" == "$skip" ]]; then
-      return 0
-    fi
-  done
-  return 1
+POLICY_ROWS="$(
+  node - "$POLICY_FILE" <<'NODE'
+const fs = require("node:fs");
+
+const policyFile = process.argv[2];
+const allowedClasses = new Set([
+  "public",
+  "telemetry",
+  "workspace-read",
+  "workspace-write",
+  "admin",
+  "internal-worker",
+  "candidate-link",
+]);
+
+if (!fs.existsSync(policyFile)) {
+  console.error(`FAIL: route auth policy file missing: ${policyFile}`);
+  process.exit(1);
 }
+
+let policy;
+try {
+  policy = JSON.parse(fs.readFileSync(policyFile, "utf8"));
+} catch (error) {
+  console.error(`FAIL: route auth policy file is invalid JSON: ${error.message}`);
+  process.exit(1);
+}
+
+if (!policy || typeof policy !== "object" || Array.isArray(policy)) {
+  console.error("FAIL: route auth policy file must contain a JSON object");
+  process.exit(1);
+}
+
+let failed = false;
+for (const [file, entry] of Object.entries(policy).sort(([left], [right]) => left.localeCompare(right))) {
+  if (!file.endsWith(".ts")) {
+    console.error(`FAIL: ${file} — policy key must be a TypeScript route basename`);
+    failed = true;
+    continue;
+  }
+
+  const accessClass = entry && typeof entry === "object" ? entry.class : undefined;
+  const reason = entry && typeof entry === "object" ? entry.reason : undefined;
+
+  if (!allowedClasses.has(accessClass)) {
+    console.error(`FAIL: ${file} — policy class must be one of ${Array.from(allowedClasses).join(", ")}`);
+    failed = true;
+  }
+
+  if (typeof reason !== "string" || reason.trim().length === 0) {
+    console.error(`FAIL: ${file} — policy reason is required`);
+    failed = true;
+  }
+
+  if (allowedClasses.has(accessClass) && typeof reason === "string" && reason.trim().length > 0) {
+    console.log(`${file}\t${accessClass}\t${reason.trim().replace(/\s+/g, " ")}`);
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}
+NODE
+)" || exit 1
+
+policy_class_for() {
+  local base="$1"
+  awk -F '\t' -v base="$base" '
+    $1 == base { print $2; found = 1 }
+    END { if (!found) exit 1 }
+  ' <<<"$POLICY_ROWS"
+}
+
+has_admin_guard() {
+  local file="$1"
+  grep -Eq 'requireAdmin|denyIfNotAdmin|getAdminAccessError' "$file" 2>/dev/null
+}
+
+has_workspace_user_guard() {
+  local file="$1"
+  grep -q 'requireWorkspaceUser' "$file" 2>/dev/null
+}
+
+ROUTE_POLICY_BASES=""
 
 for file in "$ROUTES_DIR"/*.ts; do
   base=$(basename "$file")
 
-  # Skip test files, helpers, and known public routes
   if [[ "$base" == *.test.ts ]] || [[ "$base" == *.test-d.ts ]] || [[ "$base" == *helpers* ]]; then
     continue
   fi
 
-  # Check if file has any createRoute calls
   if ! grep -q 'createRoute(' "$file" 2>/dev/null; then
     continue
   fi
 
-  # Skip known public routes
-  if is_skipped "$base"; then
+  ROUTE_POLICY_BASES="$ROUTE_POLICY_BASES $base "
+
+  if ! access_class=$(policy_class_for "$base"); then
+    echo "FAIL: $base — has createRoute but no route auth policy entry"
+    FAIL=1
     continue
   fi
 
-  # Check for auth mechanism
-  has_auth_gate=false
-
-  if grep -q 'requireAdmin' "$file" 2>/dev/null; then
-    has_auth_gate=true
-  fi
-  if grep -q 'denyIfNotAdmin' "$file" 2>/dev/null; then
-    has_auth_gate=true
-  fi
-  if grep -q 'getAdminAccessError' "$file" 2>/dev/null; then
-    has_auth_gate=true
-  fi
-  if grep -q 'requireWorkspaceUser' "$file" 2>/dev/null; then
-    has_auth_gate=true
-  fi
-
-  if [[ "$has_auth_gate" == false ]]; then
-    echo "FAIL: $base — has createRoute but no auth gate"
-    FAIL=1
-  fi
+  case "$access_class" in
+    workspace-write)
+      if ! has_workspace_user_guard "$file"; then
+        echo "FAIL: $base — workspace-write policy requires requireWorkspaceUser"
+        FAIL=1
+      fi
+      ;;
+    admin)
+      if ! has_admin_guard "$file"; then
+        echo "FAIL: $base — admin policy requires requireAdmin, denyIfNotAdmin, or getAdminAccessError"
+        FAIL=1
+      fi
+      ;;
+    public|telemetry|workspace-read|internal-worker|candidate-link)
+      ;;
+    *)
+      echo "FAIL: $base — unsupported route auth policy class: $access_class"
+      FAIL=1
+      ;;
+  esac
 done
 
+while IFS=$'\t' read -r policy_base _policy_class _policy_reason; do
+  if [[ "$ROUTE_POLICY_BASES" != *" $policy_base "* ]]; then
+    echo "FAIL: $policy_base — policy entry has no matching route file with createRoute"
+    FAIL=1
+  fi
+done <<<"$POLICY_ROWS"
+
 if [[ "$FAIL" -eq 0 ]]; then
-  echo "OK: All API route files have auth middleware"
+  echo "OK: API route files match route auth policy matrix"
   exit 0
 else
   echo ""
-  echo "Some route files are missing auth gating. Add requireAdmin, getAdminAccessError, or requireWorkspaceUser."
+  echo "Some route files do not match scripts/route-auth-policy.json."
   exit 1
 fi

--- a/scripts/check-route-auth.test.sh
+++ b/scripts/check-route-auth.test.sh
@@ -43,6 +43,14 @@ app.use("/api/workspace", requireWorkspaceUser);
 app.openapi(route, () => {});
 ROUTE
 
+cat >"$TMP_DIR/workspace-read.ts" <<'ROUTE'
+import { createRoute } from "@hono/zod-openapi";
+import { requireWorkspaceUser } from "../middleware/auth.js";
+const route = createRoute({ method: "get", path: "/api/workspace-read", responses: {} });
+app.use("/api/workspace-read", requireWorkspaceUser);
+app.openapi(route, () => {});
+ROUTE
+
 cat >"$TMP_DIR/admin.ts" <<'ROUTE'
 import { createRoute } from "@hono/zod-openapi";
 import { getAdminAccessError } from "../middleware/auth.js";
@@ -61,6 +69,10 @@ write_policy '{
   "workspace-write.ts": {
     "class": "workspace-write",
     "reason": "Workspace writes require user membership."
+  },
+  "workspace-read.ts": {
+    "class": "workspace-read",
+    "reason": "Workspace reads require user membership."
   },
   "admin.ts": {
     "class": "admin",
@@ -111,6 +123,31 @@ import { createRoute } from "@hono/zod-openapi";
 import { requireWorkspaceUser } from "../middleware/auth.js";
 const route = createRoute({ method: "post", path: "/api/workspace", responses: {} });
 app.use("/api/workspace", requireWorkspaceUser);
+app.openapi(route, () => {});
+ROUTE
+
+cat >"$TMP_DIR/workspace-read.ts" <<'ROUTE'
+import { createRoute } from "@hono/zod-openapi";
+const route = createRoute({ method: "get", path: "/api/workspace-read", responses: {} });
+app.openapi(route, () => {});
+ROUTE
+
+if run_checker >"$FAIL_OUT" 2>&1; then
+  echo "FAIL: checker passed a workspace-read policy without requireWorkspaceUser"
+  exit 1
+fi
+
+if ! grep -q "workspace-read.ts" "$FAIL_OUT"; then
+  echo "FAIL: checker did not report the workspace-read guard gap"
+  cat "$FAIL_OUT"
+  exit 1
+fi
+
+cat >"$TMP_DIR/workspace-read.ts" <<'ROUTE'
+import { createRoute } from "@hono/zod-openapi";
+import { requireWorkspaceUser } from "../middleware/auth.js";
+const route = createRoute({ method: "get", path: "/api/workspace-read", responses: {} });
+app.use("/api/workspace-read", requireWorkspaceUser);
 app.openapi(route, () => {});
 ROUTE
 

--- a/scripts/check-route-auth.test.sh
+++ b/scripts/check-route-auth.test.sh
@@ -18,42 +18,117 @@ TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 PASS_OUT="$TMP_DIR/pass.out"
 FAIL_OUT="$TMP_DIR/fail.out"
+POLICY_FILE="$TMP_DIR/route-auth-policy.json"
+
+run_checker() {
+  ROUTES_DIR="$TMP_DIR" ROUTE_AUTH_POLICY_FILE="$POLICY_FILE" bash "$SCRIPT" "$@"
+}
+
+write_policy() {
+  local body="$1"
+  printf '%s\n' "$body" >"$POLICY_FILE"
+}
+
+cat >"$TMP_DIR/public.ts" <<'ROUTE'
+import { createRoute } from "@hono/zod-openapi";
+const route = createRoute({ method: "get", path: "/api/public", responses: {} });
+app.openapi(route, () => {});
+ROUTE
 
 cat >"$TMP_DIR/workspace-write.ts" <<'ROUTE'
 import { createRoute } from "@hono/zod-openapi";
 import { requireWorkspaceUser } from "../middleware/auth.js";
-const route = createRoute({ method: "post", path: "/api/example", responses: {} });
-app.use("/api/example", requireWorkspaceUser);
+const route = createRoute({ method: "post", path: "/api/workspace", responses: {} });
+app.use("/api/workspace", requireWorkspaceUser);
 app.openapi(route, () => {});
 ROUTE
 
-cat >"$TMP_DIR/inline-admin.ts" <<'ROUTE'
+cat >"$TMP_DIR/admin.ts" <<'ROUTE'
 import { createRoute } from "@hono/zod-openapi";
 import { getAdminAccessError } from "../middleware/auth.js";
-const route = createRoute({ method: "put", path: "/api/example", responses: {} });
+const route = createRoute({ method: "put", path: "/api/admin", responses: {} });
 app.openapi(route, (c) => {
   const adminError = getAdminAccessError(c);
   if (adminError) return c.json(adminError.body, adminError.status);
 });
 ROUTE
 
-ROUTES_DIR="$TMP_DIR" bash "$SCRIPT" >"$PASS_OUT"
+write_policy '{
+  "public.ts": {
+    "class": "public",
+    "reason": "Intentional unauthenticated test route."
+  },
+  "workspace-write.ts": {
+    "class": "workspace-write",
+    "reason": "Workspace writes require user membership."
+  },
+  "admin.ts": {
+    "class": "admin",
+    "reason": "Admin mutation test route."
+  }
+}'
 
-cat >"$TMP_DIR/missing-auth.ts" <<'ROUTE'
+run_checker >"$PASS_OUT"
+
+cat >"$TMP_DIR/missing-policy.ts" <<'ROUTE'
 import { createRoute } from "@hono/zod-openapi";
-const route = createRoute({ method: "post", path: "/api/example", responses: {} });
+const route = createRoute({ method: "get", path: "/api/missing-policy", responses: {} });
 app.openapi(route, () => {});
 ROUTE
 
-if ROUTES_DIR="$TMP_DIR" bash "$SCRIPT" >"$FAIL_OUT" 2>&1; then
-  echo "FAIL: checker passed a createRoute file without auth"
+if run_checker >"$FAIL_OUT" 2>&1; then
+  echo "FAIL: checker passed a createRoute file without a policy entry"
   exit 1
 fi
 
-if ! grep -q "missing-auth.ts" "$FAIL_OUT"; then
-  echo "FAIL: checker did not report the unauthenticated route file"
+if ! grep -q "missing-policy.ts" "$FAIL_OUT"; then
+  echo "FAIL: checker did not report the route file missing a policy entry"
   cat "$FAIL_OUT"
   exit 1
 fi
 
-echo "OK: check-route-auth recognizes auth middleware and reports gaps"
+rm "$TMP_DIR/missing-policy.ts"
+
+cat >"$TMP_DIR/workspace-write.ts" <<'ROUTE'
+import { createRoute } from "@hono/zod-openapi";
+const route = createRoute({ method: "post", path: "/api/workspace", responses: {} });
+app.openapi(route, () => {});
+ROUTE
+
+if run_checker >"$FAIL_OUT" 2>&1; then
+  echo "FAIL: checker passed a workspace-write policy without requireWorkspaceUser"
+  exit 1
+fi
+
+if ! grep -q "workspace-write.ts" "$FAIL_OUT"; then
+  echo "FAIL: checker did not report the workspace-write guard gap"
+  cat "$FAIL_OUT"
+  exit 1
+fi
+
+cat >"$TMP_DIR/workspace-write.ts" <<'ROUTE'
+import { createRoute } from "@hono/zod-openapi";
+import { requireWorkspaceUser } from "../middleware/auth.js";
+const route = createRoute({ method: "post", path: "/api/workspace", responses: {} });
+app.use("/api/workspace", requireWorkspaceUser);
+app.openapi(route, () => {});
+ROUTE
+
+cat >"$TMP_DIR/admin.ts" <<'ROUTE'
+import { createRoute } from "@hono/zod-openapi";
+const route = createRoute({ method: "put", path: "/api/admin", responses: {} });
+app.openapi(route, () => {});
+ROUTE
+
+if run_checker >"$FAIL_OUT" 2>&1; then
+  echo "FAIL: checker passed an admin policy without an admin guard"
+  exit 1
+fi
+
+if ! grep -q "admin.ts" "$FAIL_OUT"; then
+  echo "FAIL: checker did not report the admin guard gap"
+  cat "$FAIL_OUT"
+  exit 1
+fi
+
+echo "OK: check-route-auth enforces route policy entries and guard signals"

--- a/scripts/install-deploy-safety.test.ts
+++ b/scripts/install-deploy-safety.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -188,6 +188,30 @@ describe("production deploy readiness checks", () => {
 });
 
 describe("non-Docker Convex startup safety", () => {
+  it("prints dev-convex-status without ps errors when no local Convex process is running", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "trends-convex-status-"));
+
+    try {
+      const result = spawnSync("make", ["dev-convex-status"], {
+        cwd: new URL("..", import.meta.url),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CONVEX_PORT: String(39000 + Math.floor(Math.random() * 10000)),
+          CONVEX_STATE_DIR: tempDir,
+        },
+      });
+      const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+
+      expect(result.status).toBe(0);
+      expect(output).toContain("No local Convex processes found.");
+      expect(output).not.toContain("list of process IDs must follow -p");
+      expect(output).not.toContain("Usage:");
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
   it("routes make dev-convex through the hardened non-Docker dev script path", () => {
     const recipe = getTargetRecipe("dev-convex");
 

--- a/scripts/route-auth-policy.json
+++ b/scripts/route-auth-policy.json
@@ -1,0 +1,130 @@
+{
+  "actions.ts": {
+    "class": "workspace-write",
+    "reason": "Candidate action writes require authenticated workspace membership through requireWorkspaceUser."
+  },
+  "ai-summary.ts": {
+    "class": "candidate-link",
+    "reason": "Candidate-facing AI summary access is intentionally reachable without workspace login."
+  },
+  "auth.ts": {
+    "class": "public",
+    "reason": "Authentication entrypoints must remain reachable before a user session exists."
+  },
+  "blocks.ts": {
+    "class": "workspace-write",
+    "reason": "Candidate block reads and writes are scoped to authenticated workspace users."
+  },
+  "candidate-status.ts": {
+    "class": "workspace-write",
+    "reason": "Candidate status mutations require authenticated workspace membership while candidate appeal remains a candidate-facing path."
+  },
+  "config.ts": {
+    "class": "admin",
+    "reason": "Runtime configuration reads and writes are admin-only through getAdminAccessError checks."
+  },
+  "filter-presets.ts": {
+    "class": "admin",
+    "reason": "Filter preset administration is guarded by getAdminAccessError checks."
+  },
+  "health.ts": {
+    "class": "public",
+    "reason": "Health check endpoints are intentionally unauthenticated for uptime probes."
+  },
+  "industry.ts": {
+    "class": "public",
+    "reason": "Industry taxonomy lookup data is public product metadata."
+  },
+  "job-descriptions.ts": {
+    "class": "admin",
+    "reason": "Job description operations are guarded by getAdminAccessError checks."
+  },
+  "notifications.ts": {
+    "class": "admin",
+    "reason": "Notification administration uses route-level requireAdmin middleware."
+  },
+  "resume-submit.ts": {
+    "class": "candidate-link",
+    "reason": "Candidate resume submission is externally reachable and uses its own submission token authorization."
+  },
+  "resumes.ts": {
+    "class": "admin",
+    "reason": "Resume analysis, audit, reingest, and reset operations use requireAdmin middleware."
+  },
+  "resumes_admin.ts": {
+    "class": "admin",
+    "reason": "Resume admin operations use per-route requireAdmin middleware."
+  },
+  "resumes_diagnostics.ts": {
+    "class": "admin",
+    "reason": "Resume diagnostic routes use requireAdmin middleware."
+  },
+  "resumes_import.ts": {
+    "class": "admin",
+    "reason": "Resume import, backup, and reset routes use requireAdmin middleware."
+  },
+  "resumes_match.ts": {
+    "class": "workspace-read",
+    "reason": "Resume matching reads are selected by workspace context and are scheduled for later membership hardening."
+  },
+  "resumes_packets.ts": {
+    "class": "admin",
+    "reason": "Review packet and learning feedback operations use requireAdmin middleware."
+  },
+  "resumes_search.ts": {
+    "class": "workspace-read",
+    "reason": "Resume search reads are selected by workspace context and are scheduled for later membership hardening."
+  },
+  "rss.ts": {
+    "class": "public",
+    "reason": "RSS routes expose public feed data."
+  },
+  "scoring-evaluation.ts": {
+    "class": "workspace-read",
+    "reason": "Scoring evaluation reads are workspace-context selected and are scheduled for later membership hardening."
+  },
+  "search-alerts.ts": {
+    "class": "workspace-read",
+    "reason": "Search alert reads are workspace-context selected and are scheduled for later membership hardening."
+  },
+  "search-analytics.ts": {
+    "class": "telemetry",
+    "reason": "Search analytics accepts client telemetry rather than workspace membership-gated operational writes."
+  },
+  "search-profiles.ts": {
+    "class": "admin",
+    "reason": "Search profile administration uses requireAdmin middleware."
+  },
+  "search.ts": {
+    "class": "public",
+    "reason": "News search endpoints expose public product search data."
+  },
+  "sessions.ts": {
+    "class": "workspace-read",
+    "reason": "Session and search-history reads are selected by workspace context and are scheduled for later membership hardening."
+  },
+  "summaries.ts": {
+    "class": "admin",
+    "reason": "Summary administration and runtime configuration use getAdminAccessError checks."
+  },
+  "taxonomy.ts": {
+    "class": "admin",
+    "reason": "Taxonomy routes use requireAdmin middleware."
+  },
+  "topics.ts": {
+    "class": "public",
+    "reason": "Topic routes expose public product data."
+  },
+  "trends.ts": {
+    "class": "public",
+    "reason": "Trend routes expose public product data."
+  },
+  "web-vitals.ts": {
+    "class": "telemetry",
+    "reason": "Web vitals accepts client performance telemetry."
+  },
+  "worker.ts": {
+    "class": "internal-worker",
+    "reason": "Worker proxy routes use the worker service's own authorization path."
+  }
+}

--- a/scripts/route-auth-policy.json
+++ b/scripts/route-auth-policy.json
@@ -64,8 +64,8 @@
     "reason": "Resume import, backup, and reset routes use requireAdmin middleware."
   },
   "resumes_match.ts": {
-    "class": "workspace-read",
-    "reason": "Resume matching reads are selected by workspace context and are scheduled for later membership hardening."
+    "class": "workspace-write",
+    "reason": "Resume matching reads and run mutation paths require authenticated workspace membership through requireWorkspaceUser."
   },
   "resumes_packets.ts": {
     "class": "admin",
@@ -73,19 +73,19 @@
   },
   "resumes_search.ts": {
     "class": "workspace-read",
-    "reason": "Resume search reads are selected by workspace context and are scheduled for later membership hardening."
+    "reason": "The operational resume list route requires authenticated workspace membership; sample and keyword helper routes remain public within the file."
   },
   "rss.ts": {
     "class": "public",
     "reason": "RSS routes expose public feed data."
   },
   "scoring-evaluation.ts": {
-    "class": "workspace-read",
-    "reason": "Scoring evaluation reads are workspace-context selected and are scheduled for later membership hardening."
+    "class": "workspace-write",
+    "reason": "Scoring reports and tuning/rollback operations require authenticated workspace membership through requireWorkspaceUser."
   },
   "search-alerts.ts": {
-    "class": "workspace-read",
-    "reason": "Search alert reads are workspace-context selected and are scheduled for later membership hardening."
+    "class": "workspace-write",
+    "reason": "Search alert reads and mutations require authenticated workspace membership through requireWorkspaceUser."
   },
   "search-analytics.ts": {
     "class": "telemetry",
@@ -100,8 +100,8 @@
     "reason": "News search endpoints expose public product search data."
   },
   "sessions.ts": {
-    "class": "workspace-read",
-    "reason": "Session and search-history reads are selected by workspace context and are scheduled for later membership hardening."
+    "class": "workspace-write",
+    "reason": "Session reads and mutations require authenticated workspace membership through requireWorkspaceUser."
   },
   "summaries.ts": {
     "class": "admin",


### PR DESCRIPTION
## Summary
- add a route auth policy matrix and require policy coverage for all OpenAPI route files
- require workspace membership for operational resume search, match, sessions, scoring evaluation, and search-alert routes
- thread workspace identity through search-alert toggle/delete and enforce workspace ownership in Convex

## Verification
- `npm test -- apps/api/src/routes/resumes_search.test.ts apps/api/src/routes/resumes_match.test.ts apps/api/src/routes/sessions.test.ts apps/api/src/routes/scoring-evaluation.test.ts apps/api/src/routes/search-alerts.test.ts packages/convex/__tests__/search-alerts-convex-test.test.ts apps/api/src/routes/auth.test.ts apps/api/src/services/auth-storage.test.ts`
- `bash scripts/check-route-auth.test.sh && bash scripts/check-route-auth.sh`
- `make check`
- `make dev` plus frontend and authenticated protected-resume smoke

## Vault
- Completed `projects/trends/work/2026-06-08-route-auth-policy-matrix/`
- Completed `projects/trends/work/2026-06-08-workspace-read-boundary-audit/`
