### PR TITLE
fix(auth): inject app auth event storage

### DIFF
--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createApp } from "./app";
+import { createAuthHeaders } from "./routes/test-auth-helpers";
+import { AuthEventStorage } from "./services/auth-event-storage";
+import { resetResumeScreeningDb } from "./services/database";
+
+describe("createApp auth event storage wiring", () => {
+  afterEach(() => {
+    resetResumeScreeningDb();
+  });
+
+  it("uses injected auth event storage for CSRF and workspace denials", async () => {
+    const auth = createAuthHeaders({ workspaceSlug: "hr", role: "user" });
+    const eventStorage = new AuthEventStorage(auth.root);
+    const app = createApp({
+      authStorage: auth.storage,
+      authEventStorage: eventStorage,
+      authTtlSeconds: 3600,
+    });
+
+    const csrfResponse = await app.request("/api/candidate-status", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+        Cookie: auth.headers.Cookie,
+      },
+      body: JSON.stringify({
+        identityKey: "resume-1",
+        status: "interviewing",
+      }),
+    });
+    expect(csrfResponse.status).toBe(403);
+
+    const workspaceResponse = await app.request("/api/candidate-status", {
+      method: "POST",
+      headers: {
+        ...auth.headers,
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "dev",
+      },
+      body: JSON.stringify({
+        identityKey: "resume-1",
+        status: "interviewing",
+      }),
+    });
+    expect(workspaceResponse.status).toBe(403);
+
+    const events = eventStorage.listRecent({ limit: 10 });
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "csrf_reject",
+          userId: auth.userId,
+          workspaceSlug: "hr",
+        }),
+        expect.objectContaining({
+          type: "workspace_access_denied",
+          userId: auth.userId,
+          workspaceSlug: "dev",
+        }),
+      ]),
+    );
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -40,6 +40,7 @@ import {
 } from "./routes/index.js";
 import { createAuthRoutes } from "./routes/auth.js";
 import { config } from "./services/config.js";
+import type { AuthEventStorage } from "./services/auth-event-storage.js";
 import type { AuthStorage } from "./services/auth-storage.js";
 import type { AuthContext } from "./services/auth-types.js";
 import { workspaceMiddleware } from "./middleware/workspace.js";
@@ -70,6 +71,7 @@ function resolveCorsOrigin(origin: string): string | null {
 
 type CreateAppOptions = {
   authStorage?: AuthStorage;
+  authEventStorage?: AuthEventStorage;
   authContext?: AuthContext;
   authTtlSeconds?: number;
 };
@@ -107,6 +109,7 @@ export function createApp(options: CreateAppOptions = {}) {
   const app = new OpenAPIHono();
   const authMiddleware = createAuthMiddleware({
     storage: options.authStorage,
+    eventStorage: options.authEventStorage,
     ttlSeconds: options.authTtlSeconds,
   });
 
@@ -145,6 +148,12 @@ export function createApp(options: CreateAppOptions = {}) {
       await next();
     });
   }
+  if (options.authEventStorage) {
+    app.use("*", async (c, next) => {
+      c.set("authEventStorage", options.authEventStorage);
+      await next();
+    });
+  }
   app.use("*", authMiddleware.optionalAuth);
 
   // Rate limiting on API routes (100 req/min per IP in production).
@@ -175,6 +184,7 @@ export function createApp(options: CreateAppOptions = {}) {
   app.route("/", healthRoutes);
   app.route("/", createAuthRoutes({
     storage: options.authStorage,
+    eventStorage: options.authEventStorage,
     ttlSeconds: options.authTtlSeconds,
   }));
   app.route("/", aiSummaryRoutes);

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -10,6 +10,7 @@ import { hasWorkspaceRole, type AuthContext } from "../services/auth-types.js";
 declare module "hono" {
   interface ContextVariableMap {
     auth?: AuthContext;
+    authEventStorage?: AuthEventStorage;
   }
 }
 
@@ -45,7 +46,6 @@ export function getAdminAccessError(c: { var: { auth?: AuthContext; workspaceSlu
 
 export function createAuthMiddleware(options: AuthMiddlewareOptions = {}) {
   let storage = options.storage;
-  let eventStorage = options.eventStorage;
   let sessions: AuthSessionService | undefined;
   const sessionCookieName = options.sessionCookieName ?? config.auth.sessionCookieName;
   const csrfHeaderName = options.csrfHeaderName ?? "X-CSRF-Token";
@@ -58,11 +58,8 @@ export function createAuthMiddleware(options: AuthMiddlewareOptions = {}) {
     return sessions;
   }
 
-  function getEventStorage(): AuthEventStorage | null {
-    if (options.eventStorage) return options.eventStorage;
-    // Lazy create only if eventStorage was not explicitly set
-    // Skip event logging when no eventStorage is configured (default middleware)
-    return null;
+  function getEventStorage(c: { var: { authEventStorage?: AuthEventStorage } }): AuthEventStorage | null {
+    return options.eventStorage ?? c.var.authEventStorage ?? null;
   }
 
   const optionalAuth: MiddlewareHandler = async (c, next) => {
@@ -80,7 +77,7 @@ export function createAuthMiddleware(options: AuthMiddlewareOptions = {}) {
       return c.json({ success: false as const, error: "Authentication required" }, 401);
     }
     if (!hasWorkspaceRole(auth.memberships, c.var.workspaceSlug, ["user", "admin"])) {
-      getEventStorage()?.append({
+      getEventStorage(c)?.append({
         type: "workspace_access_denied",
         userId: auth.user.id,
         workspaceSlug: c.var.workspaceSlug,
@@ -97,7 +94,7 @@ export function createAuthMiddleware(options: AuthMiddlewareOptions = {}) {
       const auth = c.var.auth;
       if (auth) {
         const eventType = adminError.status === 401 ? "workspace_access_denied" as const : "admin_access_denied" as const;
-        getEventStorage()?.append({
+        getEventStorage(c)?.append({
           type: eventType,
           userId: auth.user.id,
           workspaceSlug: c.var.workspaceSlug,
@@ -124,7 +121,7 @@ export function createAuthMiddleware(options: AuthMiddlewareOptions = {}) {
     const csrf = c.req.header(csrfHeaderName);
     if (!csrf || !getSessions().verifyCsrf(token, csrf)) {
       const auth = c.var.auth;
-      getEventStorage()?.append({
+      getEventStorage(c)?.append({
         type: "csrf_reject",
         userId: auth?.user.id,
         workspaceSlug: c.var.workspaceSlug,


### PR DESCRIPTION
## Summary
- add app-level regression coverage for injected auth event storage
- thread authEventStorage through createApp into auth middleware and routes
- expose the app-provided event sink on request context so default route guards log denials into the same store

## Verification
- bunx vitest run apps/api/src/app.test.ts
- bunx vitest run apps/api/src/app.test.ts apps/api/src/middleware/auth.test.ts apps/api/src/routes/auth.test.ts apps/api/src/routes/candidate-status.test.ts
- bash scripts/check-route-auth.test.sh
- bash scripts/check-route-auth.sh
- make check