### PR TITLE
fix(auth): record login session id events

### DIFF
--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createAuthMiddleware } from "../middleware/auth.js";
 import { workspaceMiddleware } from "../middleware/workspace.js";
-import { AuthSessionService } from "../services/auth-session-service.js";
+import { AuthSessionService, hashSecret } from "../services/auth-session-service.js";
 import { AuthEventStorage } from "../services/auth-event-storage.js";
 import { AuthStorage } from "../services/auth-storage.js";
 import { config } from "../services/config.js";
@@ -752,11 +752,19 @@ describe("auth event logging", () => {
     });
 
     expect(response.status).toBe(200);
+    const sessionCookie = readCookie(response, config.auth.sessionCookieName);
+    const sessionToken = sessionCookie.split("=", 2)[1];
+    const storedSession = storage.findSessionByTokenHash(hashSecret(sessionToken));
+    if (!storedSession) {
+      throw new Error("Expected successful login to create a stored session");
+    }
+
     const events = eventStorage.listRecent({ limit: 10 });
     expect(events).toHaveLength(1);
     expect(events[0].type).toBe("login_success");
     expect(events[0].provider).toBe("local");
     expect(events[0].workspaceSlug).toBe("hr");
+    expect(events[0].sessionId).toBe(storedSession.id);
   });
 
   it("records login_failure event on invalid credentials", async () => {

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -229,11 +229,14 @@ async function createSessionResponse(
   setSessionCookies(c, session);
 
   return {
-    success: true as const,
-    user,
-    memberships: storage.listMemberships(user.id),
-    csrfToken: session.csrfToken,
-    expiresAt: session.expiresAt,
+    body: {
+      success: true as const,
+      user,
+      memberships: storage.listMemberships(user.id),
+      csrfToken: session.csrfToken,
+      expiresAt: session.expiresAt,
+    },
+    sessionId: session.id,
   };
 }
 
@@ -320,10 +323,10 @@ export function createAuthRoutes(options: AuthRoutesOptions = {}) {
       userId: user.id,
       provider: "local",
       workspaceSlug,
-      sessionId: result.csrfToken ? undefined : undefined,
+      sessionId: result.sessionId,
       metadata: { username },
     });
-    return c.json(result, 200);
+    return c.json(result.body, 200);
   });
 
   const meRoute = createRoute({

--- a/apps/api/src/services/auth-session-service.ts
+++ b/apps/api/src/services/auth-session-service.ts
@@ -13,19 +13,19 @@ export class AuthSessionService {
     private readonly options: { ttlSeconds: number },
   ) {}
 
-  createSession(userId: string): { token: string; csrfToken: string; expiresAt: string } {
+  createSession(userId: string): { id: string; token: string; csrfToken: string; expiresAt: string } {
     const token = randomBytes(32).toString("base64url");
     const csrfToken = randomBytes(32).toString("base64url");
     const expiresAt = new Date(Date.now() + this.options.ttlSeconds * 1000).toISOString();
 
-    this.storage.createSession({
+    const session = this.storage.createSession({
       userId,
       tokenHash: hashSecret(token),
       csrfTokenHash: hashSecret(csrfToken),
       expiresAt,
     });
 
-    return { token, csrfToken, expiresAt };
+    return { id: session.id, token, csrfToken, expiresAt };
   }
 
   resolveSession(token: string): AuthContext | null {


### PR DESCRIPTION
## Summary
- add a regression asserting local login_success events include the stored session id
- return the persisted session id from AuthSessionService.createSession for server-side callers
- keep the login response body unchanged while using the session id for audit logging

## Verification
- bunx vitest run apps/api/src/routes/auth.test.ts -t "records login_success event on successful local login"
- bunx vitest run apps/api/src/routes/auth.test.ts apps/api/src/middleware/auth.test.ts apps/api/src/services/auth-session-service.test.ts apps/api/src/services/auth-storage.test.ts
- bash scripts/check-route-auth.test.sh
- bash scripts/check-route-auth.sh
- make check