### PR TITLE
fix(auth): validate provider CLI workspaces

### DIFF
--- a/scripts/auth/manage-provider-membership.test.ts
+++ b/scripts/auth/manage-provider-membership.test.ts
@@ -167,6 +167,79 @@ describe("manage-provider-membership CLI", () => {
     ])).toThrow(/workspace/);
   });
 
+  it("rejects unknown preapprove workspaces before mutating storage", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-provider-membership-invalid-preapprove-"));
+
+    expect(() => {
+      const command = parseProviderMembershipArgs([
+        "preapprove",
+        "--provider",
+        "casdoor",
+        "--provider-subject",
+        "sub-1",
+        "--provider-tenant",
+        "tenant-1",
+        "--workspace",
+        "prod",
+        "--role",
+        "user",
+        "--operator-id",
+        "ops@example.com",
+        "--output",
+        "json",
+      ]);
+      executeProviderMembershipCommand(command, { projectRoot: root });
+    }).toThrow(/workspace/i);
+
+    const storage = new AuthStorage(root);
+    expect(storage.listProviderMembershipPreapprovals({ provider: "casdoor", includeRevoked: true })).toEqual([]);
+  });
+
+  it("rejects unknown revoke workspaces before mutating storage", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-provider-membership-invalid-revoke-"));
+    const storage = new AuthStorage(root);
+    storage.preapproveProviderMembership({
+      provider: "casdoor",
+      providerSubject: "sub-1",
+      providerTenant: "tenant-1",
+      workspaceSlug: "prod",
+      role: "user",
+      operatorId: "ops@example.com",
+    });
+
+    expect(() => {
+      const command = parseProviderMembershipArgs([
+        "revoke",
+        "--provider",
+        "casdoor",
+        "--provider-subject",
+        "sub-1",
+        "--provider-tenant",
+        "tenant-1",
+        "--workspace",
+        "prod",
+        "--operator-id",
+        "ops@example.com",
+        "--output",
+        "json",
+      ]);
+      executeProviderMembershipCommand(command, { projectRoot: root });
+    }).toThrow(/workspace/i);
+
+    expect(storage.listProviderMembershipPreapprovals({
+      provider: "casdoor",
+      workspaceSlug: "prod",
+      includeRevoked: true,
+    })).toMatchObject([
+      {
+        providerSubject: "sub-1",
+        providerTenant: "tenant-1",
+        workspaceSlug: "prod",
+        active: true,
+      },
+    ]);
+  });
+
   it("returns dry-run output without touching storage", () => {
     const root = mkdtempSync(path.join(tmpdir(), "trends-provider-membership-dry-"));
     const result = executeProviderMembershipCommand(

--- a/scripts/auth/manage-provider-membership.ts
+++ b/scripts/auth/manage-provider-membership.ts
@@ -9,6 +9,8 @@
 
 import { pathToFileURL } from "node:url";
 
+import { isValidWorkspace, WORKSPACE_TEAMS } from "@trends/shared";
+
 import { AuthEventStorage } from "../../apps/api/src/services/auth-event-storage.js";
 import { AuthStorage } from "../../apps/api/src/services/auth-storage.js";
 import type { AuthEvent } from "../../apps/api/src/services/auth-event-types.js";
@@ -203,6 +205,16 @@ function parseAuditStatus(value: string | undefined): ProviderAuditStatus {
   throw new Error("--status must be active, revoked, or all");
 }
 
+function parseWorkspace(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (isValidWorkspace(value)) {
+    return value;
+  }
+  throw new Error(`--workspace must be one of: ${Object.keys(WORKSPACE_TEAMS).join(", ")}`);
+}
+
 function parseIsoFilter(name: string, value: string | undefined): string | undefined {
   if (value === undefined) {
     return undefined;
@@ -258,7 +270,7 @@ export function parseProviderMembershipArgs(argv: string[]): ProviderMembershipC
         i++;
         break;
       case "--workspace":
-        workspaceSlug = readFlagValue(argv, i, arg);
+        workspaceSlug = parseWorkspace(readFlagValue(argv, i, arg));
         i++;
         break;
       case "--role":


### PR DESCRIPTION
## Summary
- validate provider membership CLI --workspace values against the shared workspace registry
- reject unknown mutating workspaces before preapprove/revoke storage changes
- keep valid dev/hr dry-run and mutating command behavior covered

## Verification
- bunx vitest run scripts/auth/manage-provider-membership.test.ts -t "unknown .* workspaces"
- bunx vitest run scripts/auth/manage-provider-membership.test.ts
- bunx vitest run scripts/auth/manage-provider-membership.test.ts scripts/auth/casdoor-wecom-claims-smoke.test.ts packages/shared/src/workspace.test.ts apps/api/src/services/auth-storage.test.ts
- make auth-provider-claims-smoke
- make check