### PR TITLE
fix(auth): preserve manual memberships on provider revoke

### DIFF
--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -731,6 +731,68 @@ describe("provider membership admin routes", () => {
       { userId: providerUser.id, workspaceSlug: "dev", role: "admin" },
     ]);
   });
+
+  it("lets admins revoke provider access without deleting same-workspace manual memberships", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-provider-admin-revoke-manual-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(root);
+    const admin = await seedWorkspaceUser(storage, {
+      username: "hr-admin",
+      email: "admin@example.com",
+      role: "admin",
+    });
+    const providerUser = storage.createUser({
+      email: "casdoor@example.com",
+      displayName: "Casdoor User",
+    });
+    storage.linkIdentity({
+      userId: providerUser.id,
+      provider: "casdoor",
+      providerSubject: "sub-1",
+      providerTenant: "tenant-1",
+      email: providerUser.email,
+      displayName: providerUser.displayName,
+    });
+    storage.upsertMembership({ userId: providerUser.id, workspaceSlug: "hr", role: "user" });
+    storage.preapproveProviderMembership({
+      provider: "casdoor",
+      providerSubject: "sub-1",
+      providerTenant: "tenant-1",
+      workspaceSlug: "hr",
+      role: "user",
+      operatorId: admin.id,
+    });
+    const app = createTestApp(storage, eventStorage);
+
+    const response = await app.request("/api/auth/provider-memberships/revoke", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...createSessionHeaders(storage, admin.id),
+      },
+      body: JSON.stringify({
+        provider: "casdoor",
+        providerSubject: "sub-1",
+        providerTenant: "tenant-1",
+        workspaceSlug: "hr",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      revoked: {
+        provider: "casdoor",
+        providerSubject: "sub-1",
+        providerTenant: "tenant-1",
+        workspaceSlug: "hr",
+        active: false,
+      },
+    });
+    expect(storage.listMemberships(providerUser.id)).toEqual([
+      { userId: providerUser.id, workspaceSlug: "hr", role: "user" },
+    ]);
+  });
 });
 
 describe("auth event logging", () => {

--- a/apps/api/src/services/auth-storage.test.ts
+++ b/apps/api/src/services/auth-storage.test.ts
@@ -163,6 +163,67 @@ describe("auth sqlite schema", () => {
     ]);
   });
 
+  it("preserves same-workspace manual memberships when provider-derived access is revoked", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-casdoor-manual-same-workspace-"));
+    const storage = new AuthStorage(root);
+
+    storage.preapproveProviderMembership({
+      provider: "casdoor",
+      providerSubject: "casdoor-user-1",
+      providerTenant: "https://casdoor.example.com",
+      workspaceSlug: "hr",
+      role: "user",
+      operatorId: "operator@example.com",
+    });
+
+    const user = storage.createUser({
+      email: "wecom-user@example.com",
+      displayName: "WeCom User",
+    });
+    storage.linkIdentity({
+      userId: user.id,
+      provider: "casdoor",
+      providerSubject: "casdoor-user-1",
+      providerTenant: "https://casdoor.example.com",
+      email: user.email,
+      displayName: user.displayName,
+    });
+    storage.upsertMembership({ userId: user.id, workspaceSlug: "hr", role: "user" });
+
+    expect(storage.applyProviderMembershipPreapprovals({
+      provider: "casdoor",
+      providerSubject: "casdoor-user-1",
+      providerTenant: "https://casdoor.example.com",
+      userId: user.id,
+    })).toEqual([
+      { userId: user.id, workspaceSlug: "hr", role: "user" },
+    ]);
+
+    storage.revokeProviderMembershipPreapproval({
+      provider: "casdoor",
+      providerSubject: "casdoor-user-1",
+      providerTenant: "https://casdoor.example.com",
+      workspaceSlug: "hr",
+      operatorId: "operator@example.com",
+    });
+
+    expect(storage.listMemberships(user.id)).toEqual([
+      { userId: user.id, workspaceSlug: "hr", role: "user" },
+    ]);
+    expect(storage.listProviderMembershipGrants({
+      provider: "casdoor",
+      workspaceSlug: "hr",
+      includeRevoked: true,
+    })).toMatchObject([
+      {
+        providerSubject: "casdoor-user-1",
+        providerTenant: "https://casdoor.example.com",
+        workspaceSlug: "hr",
+        active: false,
+      },
+    ]);
+  });
+
   it("grants immediately when a Casdoor preapproval matches an existing identity", () => {
     const root = mkdtempSync(path.join(tmpdir(), "trends-auth-casdoor-existing-preapproval-"));
     const storage = new AuthStorage(root);

--- a/apps/api/src/services/auth-storage.ts
+++ b/apps/api/src/services/auth-storage.ts
@@ -55,6 +55,7 @@ type ProviderMembershipGrantRow = {
   user_id?: unknown;
   workspace_slug?: unknown;
   role?: unknown;
+  membership_created?: unknown;
 };
 
 type ProviderMembershipGrantListRow = ProviderMembershipGrantRow & {
@@ -567,11 +568,13 @@ export class AuthStorage {
         workspaceSlug: row.workspace_slug,
         role: row.role,
       };
+      const existingMembership = this.findMembership(input.userId, row.workspace_slug);
       const existingGrant = this.findActiveProviderMembershipGrant({
         ...input,
         workspaceSlug: row.workspace_slug,
       });
       const isNewGrant = !existingGrant || existingGrant.role !== row.role;
+      const membershipCreated = existingGrant ? existingGrant.membershipCreated : existingMembership === null;
 
       this.upsertMembership(membership);
       if (isNewGrant) {
@@ -580,6 +583,7 @@ export class AuthStorage {
           preapprovalId: row.id,
           workspaceSlug: row.workspace_slug,
           role: row.role,
+          membershipCreated,
         });
         this.appendAuthEvent({
           type: "workspace_membership_granted",
@@ -622,7 +626,7 @@ export class AuthStorage {
 
     const now = toIsoNow();
     const grants = this.db.prepare(`
-      SELECT id, user_id, workspace_slug, role
+      SELECT id, user_id, workspace_slug, role, membership_created
       FROM auth_provider_membership_grants
       WHERE provider = ?
         AND provider_subject = ?
@@ -652,11 +656,13 @@ export class AuthStorage {
         continue;
       }
 
-      this.deleteProviderGrantedMembership({
-        userId: grant.user_id,
-        workspaceSlug: grant.workspace_slug,
-        role: grant.role,
-      });
+      if (grant.membership_created !== 0) {
+        this.deleteProviderGrantedMembership({
+          userId: grant.user_id,
+          workspaceSlug: grant.workspace_slug,
+          role: grant.role,
+        });
+      }
       this.db.prepare(`
         UPDATE auth_provider_membership_grants
         SET revoked_at = ?
@@ -702,15 +708,29 @@ export class AuthStorage {
     }));
   }
 
+  private findMembership(userId: string, workspaceSlug: string): WorkspaceMembership | null {
+    const row = this.db.prepare(`
+      SELECT user_id, workspace_slug, role
+      FROM workspace_memberships
+      WHERE user_id = ? AND workspace_slug = ?
+    `).get(userId, workspaceSlug) as MembershipRow | undefined;
+
+    return row ? {
+      userId: row.user_id,
+      workspaceSlug: row.workspace_slug,
+      role: row.role,
+    } : null;
+  }
+
   private findActiveProviderMembershipGrant(input: {
     provider: AuthProvider;
     providerSubject: string;
     providerTenant: string;
     workspaceSlug: string;
     userId: string;
-  }): { role: WorkspaceRole } | null {
+  }): { role: WorkspaceRole; membershipCreated: boolean } | null {
     const row = this.db.prepare(`
-      SELECT role
+      SELECT role, membership_created
       FROM auth_provider_membership_grants
       WHERE provider = ?
         AND provider_subject = ?
@@ -726,7 +746,9 @@ export class AuthStorage {
       input.userId,
     ) as ProviderMembershipGrantRow | undefined;
 
-    return isWorkspaceRole(row?.role) ? { role: row.role } : null;
+    return isWorkspaceRole(row?.role)
+      ? { role: row.role, membershipCreated: row.membership_created !== 0 }
+      : null;
   }
 
   private upsertProviderMembershipGrant(input: {
@@ -737,6 +759,7 @@ export class AuthStorage {
     workspaceSlug: string;
     role: WorkspaceRole;
     userId: string;
+    membershipCreated: boolean;
   }): void {
     const now = toIsoNow();
     this.db.prepare(`
@@ -749,13 +772,15 @@ export class AuthStorage {
         provider_tenant,
         workspace_slug,
         role,
+        membership_created,
         granted_at,
         revoked_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
       ON CONFLICT(provider, provider_subject, provider_tenant, workspace_slug, user_id)
       DO UPDATE SET
         preapproval_id = excluded.preapproval_id,
         role = excluded.role,
+        membership_created = excluded.membership_created,
         granted_at = excluded.granted_at,
         revoked_at = NULL
     `).run(
@@ -767,6 +792,7 @@ export class AuthStorage {
       input.providerTenant,
       input.workspaceSlug,
       input.role,
+      input.membershipCreated ? 1 : 0,
       now,
     );
   }

--- a/apps/api/src/services/database.test.ts
+++ b/apps/api/src/services/database.test.ts
@@ -71,6 +71,7 @@ describe("getResumeScreeningDb", () => {
           all: vi.fn(() => [
             { name: "resume_matches" },
             { name: "search_sessions" },
+            { name: "auth_provider_membership_grants" },
           ]),
         };
       }
@@ -94,5 +95,6 @@ describe("getResumeScreeningDb", () => {
     const { getResumeScreeningDb } = await import("./database");
 
     expect(() => getResumeScreeningDb(process.cwd())).not.toThrow();
+    expect(execMock).toHaveBeenCalledWith("ALTER TABLE auth_provider_membership_grants ADD COLUMN membership_created INTEGER NOT NULL DEFAULT 1");
   });
 });

--- a/apps/api/src/services/database.ts
+++ b/apps/api/src/services/database.ts
@@ -259,6 +259,7 @@ function initSchema(db: Database.Database): void {
       provider_tenant TEXT NOT NULL,
       workspace_slug TEXT NOT NULL,
       role TEXT NOT NULL,
+      membership_created INTEGER NOT NULL DEFAULT 1,
       granted_at TEXT NOT NULL,
       revoked_at TEXT,
       UNIQUE(provider, provider_subject, provider_tenant, workspace_slug, user_id),
@@ -357,6 +358,10 @@ function initSchema(db: Database.Database): void {
     ensureColumn(db, "search_sessions", "workspace_slug", "TEXT DEFAULT 'dev'");
     ensureColumn(db, "search_sessions", "share_title", "TEXT");
     ensureColumn(db, "search_sessions", "search_state", "TEXT");
+  }
+
+  if (existingTables.has("auth_provider_membership_grants")) {
+    ensureColumn(db, "auth_provider_membership_grants", "membership_created", "INTEGER NOT NULL DEFAULT 1");
   }
 }
 


### PR DESCRIPTION
## Summary
- add storage and provider-admin API regressions for same-workspace manual memberships during provider revocation
- track whether a provider grant created the workspace membership row
- only delete workspace memberships on provider revoke when the provider grant created them, while keeping existing grants backward-compatible via schema upgrade

## Verification
- bunx vitest run apps/api/src/services/auth-storage.test.ts apps/api/src/routes/auth.test.ts -t "same-workspace manual memberships"
- bunx vitest run apps/api/src/services/auth-storage.test.ts apps/api/src/routes/auth.test.ts scripts/auth/manage-provider-membership.test.ts apps/api/src/services/database.test.ts
- make auth-provider-claims-smoke
- bunx vitest run scripts/auth/casdoor-wecom-claims-smoke.test.ts
- make check