### PR TITLE
feat(auth): audit provider admin actions

### DIFF
--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -633,6 +633,10 @@ describe("provider membership admin routes", () => {
       providerTenant: "tenant-1",
       email: providerUser.email,
       displayName: providerUser.displayName,
+      rawProfile: {
+        access_token: "secret-access-token",
+        rawProfile: "secret-profile",
+      },
     });
     const app = createTestApp(storage, eventStorage);
 
@@ -668,6 +672,24 @@ describe("provider membership admin routes", () => {
         { userId: providerUser.id, workspaceSlug: "hr", role: "admin" },
       ],
     });
+
+    const events = eventStorage.listRecent({ limit: 10 });
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: "provider_membership_preapproved",
+        userId: admin.id,
+        provider: "casdoor",
+        workspaceSlug: "hr",
+        metadata: expect.objectContaining({
+          action: "preapprove",
+          operatorId: admin.id,
+          providerSubject: "sub-1",
+          providerTenant: "tenant-1",
+          role: "admin",
+        }),
+      }),
+    ]));
+    expect(JSON.stringify(events)).not.toMatch(/secret-access-token|secret-profile|rawProfile/i);
   });
 
   it("lets admins revoke provider-derived access without deleting unrelated manual memberships", async () => {
@@ -730,6 +752,22 @@ describe("provider membership admin routes", () => {
     expect(storage.listMemberships(providerUser.id)).toEqual([
       { userId: providerUser.id, workspaceSlug: "dev", role: "admin" },
     ]);
+    const events = eventStorage.listRecent({ limit: 10 });
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: "provider_membership_revoked",
+        userId: admin.id,
+        provider: "casdoor",
+        workspaceSlug: "hr",
+        metadata: expect.objectContaining({
+          action: "revoke",
+          operatorId: admin.id,
+          providerSubject: "sub-1",
+          providerTenant: "tenant-1",
+          role: "user",
+        }),
+      }),
+    ]));
   });
 
   it("lets admins revoke provider access without deleting same-workspace manual memberships", async () => {

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -205,6 +205,37 @@ function listAppliedWorkspaceMemberships(
   );
 }
 
+function appendProviderMembershipAdminEvent(
+  eventStorage: AuthEventStorage,
+  input: {
+    action: "preapprove" | "revoke";
+    operatorId: string;
+    provider: AuthProvider;
+    providerSubject: string;
+    providerTenant: string;
+    workspaceSlug: string;
+    role?: WorkspaceRole;
+  },
+): void {
+  const type = input.action === "preapprove"
+    ? "provider_membership_preapproved"
+    : "provider_membership_revoked";
+
+  eventStorage.append({
+    type,
+    userId: input.operatorId,
+    provider: input.provider,
+    workspaceSlug: input.workspaceSlug,
+    metadata: {
+      action: input.action,
+      operatorId: input.operatorId,
+      providerSubject: input.providerSubject,
+      providerTenant: input.providerTenant,
+      ...(input.role ? { role: input.role } : {}),
+    },
+  });
+}
+
 function setSessionCookies(
   c: Parameters<typeof setCookie>[0],
   session: { token: string; csrfToken: string; expiresAt: string },
@@ -801,6 +832,15 @@ export function createAuthRoutes(options: AuthRoutesOptions = {}) {
     if (!preapproval) {
       return c.json({ success: false as const, error: "Provider membership preapproval not found" }, 404);
     }
+    appendProviderMembershipAdminEvent(getEventStorage(), {
+      action: "preapprove",
+      operatorId: auth.user.id,
+      provider: input.provider,
+      providerSubject: input.providerSubject,
+      providerTenant: input.providerTenant,
+      workspaceSlug: input.workspaceSlug,
+      role: input.role,
+    });
 
     return c.json({
       success: true as const,
@@ -873,6 +913,15 @@ export function createAuthRoutes(options: AuthRoutesOptions = {}) {
     if (!revoked) {
       return c.json({ success: false as const, error: "Provider membership preapproval not found" }, 404);
     }
+    appendProviderMembershipAdminEvent(getEventStorage(), {
+      action: "revoke",
+      operatorId: auth.user.id,
+      provider: input.provider,
+      providerSubject: input.providerSubject,
+      providerTenant: input.providerTenant,
+      workspaceSlug: input.workspaceSlug,
+      role: revoked.role,
+    });
 
     return c.json({
       success: true as const,

--- a/apps/api/src/services/auth-event-types.ts
+++ b/apps/api/src/services/auth-event-types.ts
@@ -6,6 +6,8 @@ export type AuthEventType =
   | "workspace_access_denied"
   | "admin_access_denied"
   | "oidc_state_invalid"
+  | "provider_membership_preapproved"
+  | "provider_membership_revoked"
   | "workspace_membership_granted"
   | "workspace_membership_revoked";
 


### PR DESCRIPTION
## Summary
- add redacted provider-admin API audit events for preapprove and revoke actions
- attribute those events to the authenticated operator user id
- cover preapprove/revoke metadata and raw provider-profile redaction in route tests

## Verification
- bunx vitest run apps/api/src/routes/auth.test.ts -t "authenticated actor attribution|unrelated manual memberships"
- bunx vitest run apps/api/src/routes/auth.test.ts apps/api/src/middleware/auth.test.ts apps/api/src/services/auth-event-storage.test.ts apps/api/src/services/auth-storage.test.ts scripts/auth/manage-provider-membership.test.ts
- bash scripts/check-route-auth.test.sh
- bash scripts/check-route-auth.sh
- make auth-provider-claims-smoke
- bunx vitest run scripts/auth/casdoor-wecom-claims-smoke.test.ts
- make check