### PR TITLE
fix(auth): surface provider membership API errors

### DIFF
--- a/apps/web/src/lib/api-helpers.ts
+++ b/apps/web/src/lib/api-helpers.ts
@@ -5,6 +5,7 @@ export type QueryParams = Record<string, string | number | boolean | undefined>
 export type ApiResult<T> = {
   data?: T
   error?: unknown
+  response?: { status?: number }
 }
 
 export type ApiClientLike = {

--- a/apps/web/src/lib/auth.test.ts
+++ b/apps/web/src/lib/auth.test.ts
@@ -112,10 +112,17 @@ describe('auth helpers', () => {
     expect(mockApiClient.GET).toHaveBeenCalledWith('/api/auth/provider-memberships')
   })
 
-  it('returns null when provider membership fetch fails', async () => {
-    mockApiClient.GET.mockResolvedValueOnce({ error: { status: 403 } })
+  it('returns provider membership fetch failures with status and message', async () => {
+    mockApiClient.GET.mockResolvedValueOnce({
+      error: { success: false, error: 'Admin access required' },
+      response: { status: 403 },
+    })
 
-    await expect(fetchProviderMemberships()).resolves.toBeNull()
+    await expect(fetchProviderMemberships()).resolves.toEqual({
+      success: false,
+      status: 403,
+      error: 'Admin access required',
+    })
   })
 
   it('preapproves provider membership through the auth endpoint', async () => {
@@ -155,6 +162,25 @@ describe('auth helpers', () => {
     })
   })
 
+  it('returns provider preapproval failures with status and message', async () => {
+    mockApiClient.POST.mockResolvedValueOnce({
+      error: { success: false, error: 'Invalid workspace' },
+      response: { status: 400 },
+    })
+
+    await expect(preapproveProviderMembership({
+      provider: 'casdoor',
+      providerSubject: 'sub-1',
+      providerTenant: 'tenant-1',
+      workspaceSlug: 'prod',
+      role: 'user',
+    })).resolves.toEqual({
+      success: false,
+      status: 400,
+      error: 'Invalid workspace',
+    })
+  })
+
   it('revokes provider membership through the auth endpoint', async () => {
     const response = {
       success: true as const,
@@ -187,6 +213,24 @@ describe('auth helpers', () => {
         providerTenant: 'tenant-1',
         workspaceSlug: 'hr',
       },
+    })
+  })
+
+  it('returns provider revocation failures with status and message', async () => {
+    mockApiClient.POST.mockResolvedValueOnce({
+      error: { success: false, error: 'Provider membership preapproval not found' },
+      response: { status: 404 },
+    })
+
+    await expect(revokeProviderMembership({
+      provider: 'casdoor',
+      providerSubject: 'sub-1',
+      providerTenant: 'tenant-1',
+      workspaceSlug: 'hr',
+    })).resolves.toEqual({
+      success: false,
+      status: 404,
+      error: 'Provider membership preapproval not found',
     })
   })
 })

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -91,6 +91,14 @@ export type ProviderMembershipsResponse = {
   events: AuthEvent[]
 }
 
+export type ProviderMembershipApiError = {
+  success: false
+  error: string
+  status?: number
+}
+
+export type ProviderMembershipsResult = ProviderMembershipsResponse | ProviderMembershipApiError
+
 export type PreapproveProviderMembershipInput = {
   provider: AuthProvider
   providerSubject: string
@@ -105,6 +113,8 @@ export type PreapproveProviderMembershipResponse = {
   appliedMemberships: WorkspaceMembership[]
 }
 
+export type PreapproveProviderMembershipResult = PreapproveProviderMembershipResponse | ProviderMembershipApiError
+
 export type RevokeProviderMembershipInput = {
   provider: AuthProvider
   providerSubject: string
@@ -115,6 +125,64 @@ export type RevokeProviderMembershipInput = {
 export type RevokeProviderMembershipResponse = {
   success: true
   revoked: ProviderMembershipPreapproval
+}
+
+export type RevokeProviderMembershipResult = RevokeProviderMembershipResponse | ProviderMembershipApiError
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function readStatus(value: unknown): number | undefined {
+  if (!isRecord(value) || typeof value.status !== 'number') {
+    return undefined
+  }
+  return value.status
+}
+
+function readErrorMessage(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (value instanceof Error && value.message.trim()) {
+    return value.message
+  }
+  if (!isRecord(value)) {
+    return undefined
+  }
+  if (typeof value.error === 'string' && value.error.trim()) {
+    return value.error
+  }
+  if (typeof value.message === 'string' && value.message.trim()) {
+    return value.message
+  }
+  return undefined
+}
+
+function defaultErrorForStatus(status: number | undefined, fallback: string): string {
+  switch (status) {
+    case 401:
+      return 'Authentication required'
+    case 403:
+      return 'Admin access required'
+    default:
+      return fallback
+  }
+}
+
+function providerMembershipApiError(
+  data: unknown,
+  error: unknown,
+  response: { status?: number } | undefined,
+  fallback: string,
+): ProviderMembershipApiError {
+  const status = response?.status ?? readStatus(error) ?? readStatus(data)
+  const message = readErrorMessage(data) ?? readErrorMessage(error) ?? defaultErrorForStatus(status, fallback)
+  const result: ProviderMembershipApiError = { success: false, error: message }
+  if (status !== undefined) {
+    result.status = status
+  }
+  return result
 }
 
 function joinApiPath(path: string): string {
@@ -158,38 +226,38 @@ export async function logout(): Promise<boolean> {
   return !error && data?.success === true
 }
 
-export async function fetchProviderMemberships(): Promise<ProviderMembershipsResponse | null> {
-  const { data, error } = await rawApiClient.GET<ProviderMembershipsResponse>('/api/auth/provider-memberships')
-  if (error || data?.success !== true) {
-    return null
+export async function fetchProviderMemberships(): Promise<ProviderMembershipsResult> {
+  const { data, error, response } = await rawApiClient.GET<ProviderMembershipsResult>('/api/auth/provider-memberships')
+  if (data?.success === true) {
+    return data
   }
-  return data
+  return providerMembershipApiError(data, error, response, 'Failed to load provider membership state')
 }
 
 export async function preapproveProviderMembership(
   input: PreapproveProviderMembershipInput,
-): Promise<PreapproveProviderMembershipResponse | null> {
-  const { data, error } = await rawApiClient.POST<PreapproveProviderMembershipResponse>(
+): Promise<PreapproveProviderMembershipResult> {
+  const { data, error, response } = await rawApiClient.POST<PreapproveProviderMembershipResult>(
     '/api/auth/provider-memberships/preapprove',
     { body: input },
   )
-  if (error || data?.success !== true) {
-    return null
+  if (data?.success === true) {
+    return data
   }
-  return data
+  return providerMembershipApiError(data, error, response, 'Failed to grant provider access')
 }
 
 export async function revokeProviderMembership(
   input: RevokeProviderMembershipInput,
-): Promise<RevokeProviderMembershipResponse | null> {
-  const { data, error } = await rawApiClient.POST<RevokeProviderMembershipResponse>(
+): Promise<RevokeProviderMembershipResult> {
+  const { data, error, response } = await rawApiClient.POST<RevokeProviderMembershipResult>(
     '/api/auth/provider-memberships/revoke',
     { body: input },
   )
-  if (error || data?.success !== true) {
-    return null
+  if (data?.success === true) {
+    return data
   }
-  return data
+  return providerMembershipApiError(data, error, response, 'Failed to revoke provider access')
 }
 
 export function getCasdoorLoginUrl(redirectTo: string = getCurrentRedirectPath()): string {

--- a/apps/web/src/pages/system-settings/SystemSettingsAuthPage.test.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsAuthPage.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mockFetchProviderMemberships = vi.hoisted(() => vi.fn())
 const mockPreapproveProviderMembership = vi.hoisted(() => vi.fn())
 const mockRevokeProviderMembership = vi.hoisted(() => vi.fn())
+const mockToast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }))
 
 vi.mock('@/lib/auth', () => ({
   fetchProviderMemberships: mockFetchProviderMemberships,
@@ -14,6 +15,10 @@ vi.mock('@/lib/auth', () => ({
 
 vi.mock('@/contexts/WorkspaceContext', () => ({
   useWorkspace: () => ({ slug: 'hr' }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: mockToast,
 }))
 
 import { SystemSettingsAuthPage } from './SystemSettingsAuthPage'
@@ -139,14 +144,59 @@ describe('SystemSettingsAuthPage', () => {
     })
   })
 
-  it('hides admin controls when provider membership state cannot be loaded', async () => {
-    mockFetchProviderMemberships.mockResolvedValueOnce(null)
+  it('hides admin controls and shows provider membership load errors', async () => {
+    mockFetchProviderMemberships.mockResolvedValueOnce({
+      success: false,
+      status: 403,
+      error: 'Admin access required',
+    })
     render(<SystemSettingsAuthPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Admin access required')).toBeInTheDocument()
+      expect(screen.getByText('Admin access required (403)')).toBeInTheDocument()
     })
     expect(screen.queryByTestId('auth-preapprove-submit')).not.toBeInTheDocument()
     expect(screen.queryByTestId('auth-revoke-sub-1-hr')).not.toBeInTheDocument()
+  })
+
+  it('shows provider preapproval error messages from the API', async () => {
+    mockPreapproveProviderMembership.mockResolvedValueOnce({
+      success: false,
+      status: 400,
+      error: 'Invalid workspace',
+    })
+    const user = userEvent.setup()
+    render(<SystemSettingsAuthPage />)
+
+    await screen.findByText('Casdoor User')
+    await user.clear(screen.getByTestId('auth-provider-subject-input'))
+    await user.type(screen.getByTestId('auth-provider-subject-input'), 'sub-2')
+    await user.clear(screen.getByTestId('auth-provider-tenant-input'))
+    await user.type(screen.getByTestId('auth-provider-tenant-input'), 'tenant-2')
+    await user.clear(screen.getByTestId('auth-workspace-input'))
+    await user.type(screen.getByTestId('auth-workspace-input'), 'prod')
+    await user.click(screen.getByTestId('auth-preapprove-submit'))
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith('Invalid workspace')
+    })
+  })
+
+  it('shows provider revocation error messages from the API', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValueOnce(true)
+    mockRevokeProviderMembership.mockResolvedValueOnce({
+      success: false,
+      status: 404,
+      error: 'Provider membership preapproval not found',
+    })
+    const user = userEvent.setup()
+    render(<SystemSettingsAuthPage />)
+
+    await user.click(await screen.findByTestId('auth-revoke-sub-1-hr'))
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith('Provider membership preapproval not found')
+    })
+    confirmSpy.mockRestore()
   })
 })

--- a/apps/web/src/pages/system-settings/SystemSettingsAuthPage.tsx
+++ b/apps/web/src/pages/system-settings/SystemSettingsAuthPage.tsx
@@ -10,6 +10,7 @@ import {
   preapproveProviderMembership,
   revokeProviderMembership,
   type AuthProvider,
+  type ProviderMembershipApiError,
   type ProviderMembershipPreapproval,
   type ProviderMembershipsResponse,
   type WorkspaceRole,
@@ -39,6 +40,10 @@ function toActionId(value: string): string {
   return value.replace(/[^a-zA-Z0-9-]+/g, '-')
 }
 
+function formatProviderMembershipError(error: ProviderMembershipApiError): string {
+  return error.status === undefined ? error.error : `${error.error} (${error.status})`
+}
+
 function StatusPill({ active }: { active: boolean }) {
   return (
     <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${active ? 'bg-emerald-50 text-emerald-700' : 'bg-muted text-muted-foreground'}`}>
@@ -63,6 +68,7 @@ export function SystemSettingsAuthPage() {
   const [state, setState] = useState<ProviderMembershipsResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [accessDenied, setAccessDenied] = useState(false)
+  const [accessError, setAccessError] = useState<ProviderMembershipApiError | null>(null)
   const [submitting, setSubmitting] = useState(false)
   const [form, setForm] = useState<FormState>(() => createInitialForm(slug))
   const providerIdentities = state?.identities.filter((identity) => identity.provider === form.provider) ?? []
@@ -71,11 +77,19 @@ export function SystemSettingsAuthPage() {
     setLoading(true)
     try {
       const result = await fetchProviderMemberships()
+      if (result.success === false) {
+        setState(null)
+        setAccessError(result)
+        setAccessDenied(true)
+        return
+      }
       setState(result)
-      setAccessDenied(result === null)
+      setAccessError(null)
+      setAccessDenied(false)
     } catch (error) {
       reportUiError('Failed to load provider membership state', error)
       setState(null)
+      setAccessError(null)
       setAccessDenied(true)
     } finally {
       setLoading(false)
@@ -100,8 +114,8 @@ export function SystemSettingsAuthPage() {
         workspaceSlug: form.workspaceSlug.trim(),
         role: form.role,
       })
-      if (!result) {
-        toast.error(t('debugConfig.authAccessGrantFailed', { defaultValue: 'Failed to grant provider access' }))
+      if (result.success === false) {
+        toast.error(result.error)
         return
       }
       toast.success(t('debugConfig.authAccessGrantSaved', { defaultValue: 'Provider access saved' }))
@@ -130,8 +144,8 @@ export function SystemSettingsAuthPage() {
         providerTenant: preapproval.providerTenant,
         workspaceSlug: preapproval.workspaceSlug,
       })
-      if (!result) {
-        toast.error(t('debugConfig.authAccessRevokeFailed', { defaultValue: 'Failed to revoke provider access' }))
+      if (result.success === false) {
+        toast.error(result.error)
         return
       }
       toast.success(t('debugConfig.authAccessRevoked', { defaultValue: 'Provider access revoked' }))
@@ -156,7 +170,9 @@ export function SystemSettingsAuthPage() {
         </h2>
         <Card className="border-destructive/30">
           <CardContent className="py-6 text-sm text-destructive">
-            {t('debugConfig.authAccessAdminRequired', { defaultValue: 'Admin access required' })}
+            {accessError
+              ? formatProviderMembershipError(accessError)
+              : t('debugConfig.authAccessAdminRequired', { defaultValue: 'Admin access required' })}
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- return structured provider membership API failures from web auth helpers
- show provider-admin load failures with backend message/status
- surface provider preapprove/revoke API messages in toast errors

## Verification
- npm --workspace @trends/web run test -- src/lib/auth.test.ts src/pages/system-settings/SystemSettingsAuthPage.test.tsx
- make check