### PR TITLE
test(auth): extend workspace smoke negatives

### DIFF
--- a/scripts/auth-workspace-smoke.test.ts
+++ b/scripts/auth-workspace-smoke.test.ts
@@ -6,6 +6,8 @@ import {
   extractCsrfToken,
   parseSetCookieHeaders,
   readSmokeConfig,
+  runAuthWorkspaceSmoke,
+  type SmokeConfig,
 } from "./auth-workspace-smoke.ts";
 
 describe("auth workspace smoke helpers", () => {
@@ -82,5 +84,77 @@ describe("auth workspace smoke helpers", () => {
 
   it("requires smoke credentials from the environment", () => {
     expect(() => readSmokeConfig({})).toThrow(/AUTH_SMOKE_EMAIL.*AUTH_SMOKE_PASSWORD/s);
+  });
+
+  it("runs negative auth smokes before logout success", async () => {
+    const config: SmokeConfig = {
+      apiUrl: "https://api.example.com",
+      webUrl: "https://web.example.com",
+      workspaceSlug: "hr",
+      wrongWorkspaceSlug: "dev",
+      loginUsername: "member@example.com",
+      password: "secret",
+      memberRoute: "/api/resumes?limit=1",
+      adminRoute: "/api/auth/events?limit=1",
+    };
+    const calls: Array<{ url: string; headers: Headers; method: string }> = [];
+
+    const fetchImpl = async (input: string | URL, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const headers = new Headers(init?.headers);
+      const method = init?.method ?? "GET";
+      calls.push({ url, headers, method });
+
+      if (url === config.webUrl) {
+        return new Response("ok", { status: 200 });
+      }
+      if (url === `${config.apiUrl}/api/auth/login`) {
+        return new Response(JSON.stringify({ success: true, csrfToken: "csrf-token" }), {
+          status: 200,
+          headers: {
+            "set-cookie": "trends_session=session-token; Path=/; HttpOnly, trends_csrf=csrf-token; Path=/",
+          },
+        });
+      }
+      if (url === `${config.apiUrl}/api/auth/me`) {
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      if (url === `${config.apiUrl}${config.memberRoute}`) {
+        if (!headers.get("Cookie")) {
+          return new Response(JSON.stringify({ success: false, error: "Authentication required" }), { status: 401 });
+        }
+        if (headers.get("X-Workspace-Slug") === config.wrongWorkspaceSlug) {
+          return new Response(JSON.stringify({ success: false, error: "Workspace access required" }), { status: 403 });
+        }
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      if (url === `${config.apiUrl}${config.adminRoute}`) {
+        return new Response(JSON.stringify({ success: false, error: "Admin access required" }), { status: 403 });
+      }
+      if (url === `${config.apiUrl}/api/auth/logout` && method === "POST") {
+        const status = headers.get("X-CSRF-Token") === "csrf-token" ? 200 : 403;
+        return new Response(JSON.stringify({ success: status === 200 }), { status });
+      }
+      return new Response(JSON.stringify({ success: false, error: `Unhandled ${method} ${url}` }), { status: 500 });
+    };
+
+    const results = await runAuthWorkspaceSmoke(config, fetchImpl);
+
+    expect(results.map((result) => result.name)).toEqual([
+      "web URL",
+      "local login",
+      "authenticated /api/auth/me",
+      "workspace member route",
+      "wrong workspace denial",
+      "anonymous workspace denial",
+      "member admin-only denial",
+      "csrf rejection",
+      "logout success",
+    ]);
+
+    const logoutCalls = calls.filter((call) => call.url === `${config.apiUrl}/api/auth/logout`);
+    expect(logoutCalls).toHaveLength(2);
+    expect(logoutCalls[0]?.headers.get("X-CSRF-Token")).toBeNull();
+    expect(logoutCalls[1]?.headers.get("X-CSRF-Token")).toBe("csrf-token");
   });
 });

--- a/scripts/auth-workspace-smoke.ts
+++ b/scripts/auth-workspace-smoke.ts
@@ -270,6 +270,31 @@ export async function runAuthWorkspaceSmoke(
     expectedStatuses: [403],
   }));
 
+  results.push(await requestStep({
+    name: "csrf rejection",
+    fetchImpl,
+    url: buildUrl(config.apiUrl, "/api/auth/logout"),
+    init: {
+      method: "POST",
+      headers: {
+        Cookie: cookieJar,
+        "X-Workspace-Slug": config.workspaceSlug,
+      },
+    },
+    expectedStatuses: [403],
+  }));
+
+  results.push(await requestStep({
+    name: "logout success",
+    fetchImpl,
+    url: buildUrl(config.apiUrl, "/api/auth/logout"),
+    init: {
+      method: "POST",
+      headers: authHeaders,
+    },
+    expectedStatuses: [200],
+  }));
+
   return results;
 }
 


### PR DESCRIPTION
## Summary
- add auth workspace smoke coverage for CSRF rejection on logout
- add auth workspace smoke coverage for successful logout with CSRF
- cover the full smoke runner sequence with a fake fetch test

## Verification
- bunx vitest run scripts/auth-workspace-smoke.test.ts
- bunx vitest run scripts/auth-workspace-smoke.test.ts apps/api/src/middleware/auth.test.ts apps/api/src/routes/auth.test.ts
- bash scripts/check-route-auth.test.sh
- bash scripts/check-route-auth.sh
- make check