### PR TITLE
test(auth): align workspace registry consumers

### DIFF
--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
+import { listWorkspaceSlugs } from "@trends/shared";
 
 import { AuthSessionService } from "../services/auth-session-service.js";
 import { AuthEventStorage } from "../services/auth-event-storage.js";
@@ -95,6 +96,33 @@ describe("auth middleware gates", () => {
 
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toMatchObject({ actorId: "user-1" });
+  });
+
+  it.each(listWorkspaceSlugs())("allows a matching member for registered workspace %s", async (slug) => {
+    const middleware = createAuthMiddleware();
+    const app = createGateApp(createAuthContext("user", slug), middleware.requireWorkspaceUser);
+
+    const res = await app.request("/protected", {
+      headers: { "X-Workspace-Slug": slug },
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ actorId: "user-1" });
+  });
+
+  it("rejects invalid workspace slugs before the auth gate runs", async () => {
+    const middleware = createAuthMiddleware();
+    const app = createGateApp(createAuthContext("user", "hr"), middleware.requireWorkspaceUser);
+
+    const res = await app.request("/protected", {
+      headers: { "X-Workspace-Slug": "prod" },
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining("Invalid workspace slug"),
+    });
   });
 
   it("requires admin membership for admin routes", async () => {

--- a/apps/api/src/middleware/workspace.test.ts
+++ b/apps/api/src/middleware/workspace.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
+import { formatWorkspaceSlugList, getAccessLevel, listWorkspaceSlugs } from "@trends/shared";
 
 import { workspaceMiddleware, requireAdmin, denyIfNotAdmin } from "./workspace.js";
 import { serverTimingMiddleware } from "./server-timing.js";
@@ -94,26 +95,18 @@ describe("workspaceMiddleware", () => {
     const body = await res.json();
     expect(body.success).toBe(false);
     expect(body.error).toContain("Invalid workspace slug");
+    expect(body.error).toContain(`Allowed: ${formatWorkspaceSlugList()}`);
   });
 
-  it("sets accessLevel based on workspace", async () => {
+  it.each(listWorkspaceSlugs())("accepts registered workspace %s with its shared access level", async (slug) => {
     const app = createTestApp();
     const res = await app.request("/test", {
-      headers: { "X-Workspace-Slug": "dev" },
+      headers: { "X-Workspace-Slug": slug },
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.accessLevel).toBe("admin");
-  });
-
-  it("sets user accessLevel for hr workspace", async () => {
-    const app = createTestApp();
-    const res = await app.request("/test", {
-      headers: { "X-Workspace-Slug": "hr" },
-    });
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.accessLevel).toBe("user");
+    expect(body.workspaceSlug).toBe(slug);
+    expect(body.accessLevel).toBe(getAccessLevel(slug));
   });
 });
 

--- a/apps/api/src/middleware/workspace.ts
+++ b/apps/api/src/middleware/workspace.ts
@@ -1,5 +1,11 @@
 import type { MiddlewareHandler } from "hono";
-import { getAccessLevel, isValidWorkspace, type AccessLevel, type WorkspaceSlug } from "@trends/shared";
+import {
+  formatWorkspaceSlugList,
+  getAccessLevel,
+  isValidWorkspace,
+  type AccessLevel,
+  type WorkspaceSlug,
+} from "@trends/shared";
 
 declare module "hono" {
   interface ContextVariableMap {
@@ -20,7 +26,7 @@ export const workspaceMiddleware: MiddlewareHandler = async (c, next) => {
     return c.json(
       {
         success: false,
-        error: `Invalid workspace slug: ${candidate}. Allowed: dev, hr`,
+        error: `Invalid workspace slug: ${candidate}. Allowed: ${formatWorkspaceSlugList()}`,
       },
       400,
     );

--- a/apps/api/src/routes/search-profiles.ts
+++ b/apps/api/src/routes/search-profiles.ts
@@ -13,7 +13,7 @@ import {
     getWorkspaceSearchProfileTemplates,
     isRecord,
     isValidWorkspace,
-    WORKSPACE_TEAMS,
+    listWorkspaceSlugs,
 } from "@trends/shared";
 
 import {
@@ -293,7 +293,7 @@ type JobDescriptionSyncPayload = {
 
 const DEFAULT_WORKSPACE_SLUG = "dev";
 const CONFIG_SEED_SOURCE = "config/search-profiles";
-const KNOWN_WORKSPACE_SLUGS = Object.keys(WORKSPACE_TEAMS).filter(isValidWorkspace);
+const KNOWN_WORKSPACE_SLUGS = listWorkspaceSlugs();
 
 function belongsToWorkspace(recordWorkspaceSlug: unknown, workspaceSlug: string): boolean {
     const normalizedRecordWorkspace = readString(recordWorkspaceSlug);

--- a/apps/api/src/routes/summaries.ts
+++ b/apps/api/src/routes/summaries.ts
@@ -2,8 +2,9 @@ import { randomUUID } from "node:crypto";
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import {
-  WORKSPACE_TEAMS,
+  formatWorkspaceSlugList,
   isValidWorkspace,
+  listWorkspaceSlugs,
   type SummaryProfileRecord as SummaryProfileRecordType,
   type SummaryProfileRuntimeItem as SummaryProfileRuntimeItemType,
   type SummaryProfilesConfig as SummaryProfilesConfigType,
@@ -25,7 +26,7 @@ const app = new OpenAPIHono();
 const summaryDataService = new SummaryDataService();
 const summaryRenderer = new SummaryRenderer();
 const workspaceSummaryRunStorage = new WorkspaceSummaryRunStorage();
-const KNOWN_WORKSPACE_SLUGS = Object.keys(WORKSPACE_TEAMS).filter(isValidWorkspace);
+const KNOWN_WORKSPACE_SLUGS = listWorkspaceSlugs();
 const SummaryPeriodSchema = z.enum(["daily", "weekly", "monthly"]);
 const WorkspaceSlugSchema = z.string().min(1);
 
@@ -344,7 +345,7 @@ function resolveWorkspaceSlug(value: string | undefined, fallback: WorkspaceSlug
     return fallback;
   }
   if (!isValidWorkspace(candidate)) {
-    throw new Error(`Invalid workspace slug: ${candidate}. Allowed: dev, hr`);
+    throw new Error(`Invalid workspace slug: ${candidate}. Allowed: ${formatWorkspaceSlugList()}`);
   }
   return candidate;
 }

--- a/packages/shared/src/workspace.test.ts
+++ b/packages/shared/src/workspace.test.ts
@@ -1,9 +1,26 @@
 import { describe, expect, it } from 'vitest'
-import { isValidWorkspace, getAccessLevel, WORKSPACE_TEAMS } from './workspace'
+import { isValidWorkspace, getAccessLevel, WORKSPACE_TEAMS, formatWorkspaceSlugList, listWorkspaceSlugs } from './workspace'
 
 describe('WORKSPACE_TEAMS', () => {
   it('has dev and hr teams', () => {
     expect(Object.keys(WORKSPACE_TEAMS)).toEqual(['dev', 'hr'])
+  })
+})
+
+describe('workspace registry helpers', () => {
+  it('lists registered workspace slugs in registry order', () => {
+    expect(listWorkspaceSlugs()).toEqual(['dev', 'hr'])
+  })
+
+  it('formats registered workspace slugs for consumer error messages', () => {
+    expect(formatWorkspaceSlugList()).toBe('dev, hr')
+  })
+
+  it('keeps the helper list aligned with validation and access levels', () => {
+    for (const slug of listWorkspaceSlugs()) {
+      expect(isValidWorkspace(slug)).toBe(true)
+      expect(getAccessLevel(slug)).toBe(WORKSPACE_TEAMS[slug].accessLevel)
+    }
   })
 })
 
@@ -22,6 +39,11 @@ describe('isValidWorkspace', () => {
 
   it('returns false for empty string', () => {
     expect(isValidWorkspace('')).toBe(false)
+  })
+
+  it('returns false for inherited object property names', () => {
+    expect(isValidWorkspace('toString')).toBe(false)
+    expect(isValidWorkspace('constructor')).toBe(false)
   })
 })
 

--- a/packages/shared/src/workspace.ts
+++ b/packages/shared/src/workspace.ts
@@ -7,7 +7,15 @@ export type WorkspaceSlug = keyof typeof WORKSPACE_TEAMS;
 export type AccessLevel = "admin" | "user";
 
 export function isValidWorkspace(slug: string): slug is WorkspaceSlug {
-  return slug in WORKSPACE_TEAMS;
+  return Object.prototype.hasOwnProperty.call(WORKSPACE_TEAMS, slug);
+}
+
+export function listWorkspaceSlugs(): WorkspaceSlug[] {
+  return Object.keys(WORKSPACE_TEAMS).filter(isValidWorkspace);
+}
+
+export function formatWorkspaceSlugList(): string {
+  return listWorkspaceSlugs().join(", ");
 }
 
 export function getAccessLevel(slug: string): AccessLevel | null {

--- a/scripts/auth/manage-provider-membership.test.ts
+++ b/scripts/auth/manage-provider-membership.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
+import { formatWorkspaceSlugList, listWorkspaceSlugs } from "@trends/shared";
 
 import { AuthEventStorage } from "../../apps/api/src/services/auth-event-storage.js";
 import { AuthStorage } from "../../apps/api/src/services/auth-storage.js";
@@ -112,6 +113,48 @@ describe("manage-provider-membership CLI", () => {
     });
   });
 
+  it.each(listWorkspaceSlugs())("accepts registered workspace %s in provider membership commands", (slug) => {
+    expect(parseProviderMembershipArgs([
+      "preapprove",
+      "--provider",
+      "casdoor",
+      "--provider-subject",
+      "sub-1",
+      "--provider-tenant",
+      "tenant-1",
+      "--workspace",
+      slug,
+      "--role",
+      "user",
+      "--operator-id",
+      "ops@example.com",
+      "--output",
+      "json",
+    ])).toMatchObject({
+      action: "preapprove",
+      workspaceSlug: slug,
+    });
+
+    expect(parseProviderMembershipArgs([
+      "revoke",
+      "--provider",
+      "casdoor",
+      "--provider-subject",
+      "sub-1",
+      "--provider-tenant",
+      "tenant-1",
+      "--workspace",
+      slug,
+      "--operator-id",
+      "ops@example.com",
+      "--output",
+      "json",
+    ])).toMatchObject({
+      action: "revoke",
+      workspaceSlug: slug,
+    });
+  });
+
   it("parses provider audit export filters", () => {
     expect(parseProviderMembershipArgs([
       "export-audit",
@@ -189,7 +232,7 @@ describe("manage-provider-membership CLI", () => {
         "json",
       ]);
       executeProviderMembershipCommand(command, { projectRoot: root });
-    }).toThrow(/workspace/i);
+    }).toThrow(`--workspace must be one of: ${formatWorkspaceSlugList()}`);
 
     const storage = new AuthStorage(root);
     expect(storage.listProviderMembershipPreapprovals({ provider: "casdoor", includeRevoked: true })).toEqual([]);

--- a/scripts/auth/manage-provider-membership.ts
+++ b/scripts/auth/manage-provider-membership.ts
@@ -9,7 +9,7 @@
 
 import { pathToFileURL } from "node:url";
 
-import { isValidWorkspace, WORKSPACE_TEAMS } from "@trends/shared";
+import { formatWorkspaceSlugList, isValidWorkspace } from "@trends/shared";
 
 import { AuthEventStorage } from "../../apps/api/src/services/auth-event-storage.js";
 import { AuthStorage } from "../../apps/api/src/services/auth-storage.js";
@@ -212,7 +212,7 @@ function parseWorkspace(value: string | undefined): string | undefined {
   if (isValidWorkspace(value)) {
     return value;
   }
-  throw new Error(`--workspace must be one of: ${Object.keys(WORKSPACE_TEAMS).join(", ")}`);
+  throw new Error(`--workspace must be one of: ${formatWorkspaceSlugList()}`);
 }
 
 function parseIsoFilter(name: string, value: string | undefined): string | undefined {


### PR DESCRIPTION
## Summary
- add shared workspace slug listing and allowed-list formatting helpers
- switch workspace middleware, provider membership CLI, summaries, and search profiles to the shared registry helpers
- add agreement coverage across shared workspace helpers, auth middleware, workspace middleware, and provider CLI parsing

## Verification
- npm --workspace @trends/shared run build
- bunx vitest run packages/shared/src/workspace.test.ts apps/api/src/middleware/workspace.test.ts apps/api/src/middleware/auth.test.ts scripts/auth/manage-provider-membership.test.ts apps/api/src/routes/summaries.test.ts apps/api/src/routes/search-profiles.test.ts
- bash scripts/check-route-auth.test.sh
- bash scripts/check-route-auth.sh
- make check