### PR TITLE
feat(auth): allow anonymous hr resume search

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -74,6 +74,15 @@ export function createAuthMiddleware(options: AuthMiddlewareOptions = {}) {
   const requireWorkspaceUser: MiddlewareHandler = async (c, next) => {
     const auth = c.var.auth;
     if (!auth) {
+      getEventStorage(c)?.append({
+        type: "workspace_access_denied",
+        workspaceSlug: c.var.workspaceSlug,
+        reason: "authentication_required",
+        metadata: {
+          method: c.req.method,
+          path: c.req.path,
+        },
+      });
       return c.json({ success: false as const, error: "Authentication required" }, 401);
     }
     if (!hasWorkspaceRole(auth.memberships, c.var.workspaceSlug, ["user", "admin"])) {

--- a/apps/api/src/routes/actions.test.ts
+++ b/apps/api/src/routes/actions.test.ts
@@ -3,20 +3,29 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import actionsRoutes from './actions'
 import { createAuthMiddleware } from '../middleware/auth'
+import { AuthEventStorage } from '../services/auth-event-storage'
 import { workspaceMiddleware } from '../middleware/workspace'
 import { ActionStorage } from '../services/action-storage'
 import type { AuthStorage } from '../services/auth-storage'
 import { resetResumeScreeningDb } from '../services/database'
 import { createAuthHeaders } from './test-auth-helpers'
 
-function createTestApp(storage?: AuthStorage) {
+function createTestApp(options: { storage?: AuthStorage; eventStorage?: AuthEventStorage } = {}) {
   const app = new OpenAPIHono()
   app.use('*', workspaceMiddleware)
-  if (storage) {
-    const middleware = createAuthMiddleware({ storage, ttlSeconds: 3600 })
-    app.use('*', middleware.optionalAuth)
-    app.use('/api/*', middleware.requireCsrf)
+  if (options.eventStorage) {
+    app.use('*', async (c, next) => {
+      c.set('authEventStorage', options.eventStorage)
+      await next()
+    })
   }
+  const middleware = createAuthMiddleware({
+    storage: options.storage,
+    eventStorage: options.eventStorage,
+    ttlSeconds: 3600,
+  })
+  app.use('*', middleware.optionalAuth)
+  app.use('/api/*', middleware.requireCsrf)
   app.route('/', actionsRoutes)
   return app
 }
@@ -58,13 +67,46 @@ describe('actions routes', () => {
       expect(saveSpy).not.toHaveBeenCalled()
     })
 
+    it('records auth denial evidence for anonymous writes', async () => {
+      const eventStorage = new AuthEventStorage()
+      const saveSpy = vi.spyOn(ActionStorage.prototype, 'saveAction').mockReturnValue(MOCK_ACTION as never)
+      const app = createTestApp({ eventStorage })
+
+      const response = await app.request('/api/actions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Workspace-Slug': 'hr',
+        },
+        body: JSON.stringify({
+          resumeId: 'resume-123',
+          actionType: 'rating',
+          actionData: { rating: 4 },
+        }),
+      })
+
+      expect(response.status).toBe(401)
+      expect(saveSpy).not.toHaveBeenCalled()
+      expect(eventStorage.listRecent({ type: 'workspace_access_denied', limit: 10 })).toContainEqual(
+        expect.objectContaining({
+          type: 'workspace_access_denied',
+          workspaceSlug: 'hr',
+          reason: 'authentication_required',
+          metadata: expect.objectContaining({
+            method: 'POST',
+            path: '/api/actions',
+          }),
+        }),
+      )
+    })
+
     it('creates a star action with the authenticated actor', async () => {
       const auth = createAuthHeaders({ workspaceSlug: 'hr', role: 'user' })
       const saveSpy = vi.spyOn(ActionStorage.prototype, 'saveAction').mockReturnValue({
         ...MOCK_ACTION,
         userId: auth.userId,
       } as never)
-      const app = createTestApp(auth.storage)
+      const app = createTestApp({ storage: auth.storage })
       const response = await app.request('/api/actions', {
         method: 'POST',
         headers: {
@@ -93,7 +135,7 @@ describe('actions routes', () => {
     it('creates an action with optional data', async () => {
       const auth = createAuthHeaders({ workspaceSlug: 'hr', role: 'user' })
       const saveSpy = vi.spyOn(ActionStorage.prototype, 'saveAction').mockReturnValue(MOCK_ACTION as never)
-      const app = createTestApp(auth.storage)
+      const app = createTestApp({ storage: auth.storage })
       await app.request('/api/actions', {
         method: 'POST',
         headers: {
@@ -117,7 +159,7 @@ describe('actions routes', () => {
     it('rejects authenticated users outside the selected workspace', async () => {
       const auth = createAuthHeaders({ workspaceSlug: 'hr', requestWorkspaceSlug: 'dev', role: 'user' })
       const saveSpy = vi.spyOn(ActionStorage.prototype, 'saveAction').mockReturnValue(MOCK_ACTION as never)
-      const app = createTestApp(auth.storage)
+      const app = createTestApp({ storage: auth.storage })
       const response = await app.request('/api/actions', {
         method: 'POST',
         headers: {

--- a/apps/api/src/routes/candidate-status.test.ts
+++ b/apps/api/src/routes/candidate-status.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createApp } from "../app";
+import { AuthEventStorage } from "../services/auth-event-storage";
 import { config } from "../services/config";
 import { resetResumeScreeningDb } from "../services/database";
 import { workspaceConfigService } from "../services/workspace-config-service";
@@ -85,6 +86,43 @@ describe("candidate-status route", () => {
 
     expect(response.status).toBe(401);
     expect(calls).toHaveLength(0);
+  });
+
+  it("records auth denial evidence for anonymous status writes", async () => {
+    const calls: ConvexCall[] = [];
+    const eventStorage = new AuthEventStorage();
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      calls.push(parseConvexCall(input, init));
+      return convexSuccess(null);
+    });
+
+    const app = createApp({ authEventStorage: eventStorage });
+    const response = await app.request("/api/candidate-status", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({
+        identityKey: "resume-1",
+        status: "interviewing",
+        notes: "Looks promising",
+      }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(calls).toHaveLength(0);
+    expect(eventStorage.listRecent({ type: "workspace_access_denied", limit: 10 })).toContainEqual(
+      expect.objectContaining({
+        type: "workspace_access_denied",
+        workspaceSlug: "hr",
+        reason: "authentication_required",
+        metadata: expect.objectContaining({
+          method: "POST",
+          path: "/api/candidate-status",
+        }),
+      }),
+    );
   });
 
   it("updates candidate status successfully", async () => {

--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -560,6 +560,49 @@ describe("resume routes", () => {
     expect(calls.some((call) => call.pathName === "candidate_blocks:list")).toBe(true);
   });
 
+  it("omits operational statusCounts for anonymous hr convex search", async () => {
+    const calls: ConvexCall[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const call = parseConvexCall(input, init);
+      calls.push(call);
+
+      if (call.pathName === "resumes:listWithIngestDataPage") {
+        return convexSuccess({
+          results: [
+            buildConvexResumeRecord("resume-live-1", {
+              identityKey: "ik-live-1",
+              name: "Anonymous Visible",
+            }),
+          ],
+          total: 1,
+        });
+      }
+
+      if (call.pathName === "candidate_status:list" || call.pathName === "candidate_blocks:list") {
+        return convexSuccess([]);
+      }
+
+      throw new Error(`Unexpected convex path: ${call.pathName}`);
+    });
+
+    const app = createTestApp(null);
+    const response = await app.request("/api/resumes?source=convex&limit=1", {
+      headers: {
+        "X-Workspace-Slug": "hr",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.summary.statusCounts).toBeUndefined();
+    expect(calls).toEqual([
+      expect.objectContaining({
+        pathName: "resumes:listWithIngestDataPage",
+      }),
+    ]);
+  });
+
   it("keeps the static skills-version route from being shadowed by resume detail lookup", async () => {
     const app = createTestApp();
     const response = await app.request("/api/resumes/skills-version");

--- a/apps/api/src/routes/resumes_search.test.ts
+++ b/apps/api/src/routes/resumes_search.test.ts
@@ -65,7 +65,23 @@ describe("resumes_search", () => {
 });
 
 describe("ResumesQuerySchema semantic search params", () => {
-  it("rejects anonymous resume list requests", async () => {
+  it("allows anonymous resume list requests for the hr workspace", async () => {
+    vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
+      items: [],
+      sample: undefined,
+      metadata: undefined,
+      indexes: [],
+    });
+
+    const app = createTestApp();
+    const response = await app.request("/api/resumes", {
+      headers: { "X-Workspace-Slug": "hr" },
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("rejects anonymous resume list requests without an hr workspace header", async () => {
     vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
       items: [],
       sample: undefined,
@@ -75,6 +91,22 @@ describe("ResumesQuerySchema semantic search params", () => {
 
     const app = createTestApp();
     const response = await app.request("/api/resumes");
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects anonymous resume list requests for the dev workspace", async () => {
+    vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
+      items: [],
+      sample: undefined,
+      metadata: undefined,
+      indexes: [],
+    });
+
+    const app = createTestApp();
+    const response = await app.request("/api/resumes", {
+      headers: { "X-Workspace-Slug": "dev" },
+    });
 
     expect(response.status).toBe(401);
   });

--- a/apps/api/src/routes/resumes_search.ts
+++ b/apps/api/src/routes/resumes_search.ts
@@ -1,4 +1,5 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import type { MiddlewareHandler } from "hono";
 import {
   ResumeService,
   normalizeEducationLevel,
@@ -87,6 +88,14 @@ const MAX_SAFE_CONVEX_POST_FILTER_SCAN = 250;
 type CandidateStatus = typeof CANDIDATE_STATUS_VALUES[number];
 type CandidateStatusCounts = Record<CandidateStatus, number>;
 const CANDIDATE_STATUS_SET: ReadonlySet<string> = new Set(CANDIDATE_STATUS_VALUES);
+
+const allowAnonymousHrResumeRead: MiddlewareHandler = async (c, next) => {
+  if (!c.var.auth && c.var.workspaceSlug === "hr") {
+    await next();
+    return;
+  }
+  return requireWorkspaceUser(c, next);
+};
 
 function createCandidateStatusCounts(): CandidateStatusCounts {
   return {
@@ -730,7 +739,7 @@ const getResumesRoute = createRoute({
   method: "get",
   path: "/api/resumes",
   tags: ["resumes"],
-  middleware: [requireWorkspaceUser] as const,
+  middleware: [allowAnonymousHrResumeRead] as const,
   summary: "List resumes from a sample file",
   description: "Returns resume items from the latest or specified sample JSON",
   request: {
@@ -784,6 +793,7 @@ app.openapi(getResumesRoute, (c) => {
   const sampleName = sample?.trim() || undefined;
   const keyword = q?.trim() || undefined;
   const keywordExpansion = resumeService.expandSearchQuery(keyword);
+  const canReadOperationalOverlays = Boolean(c.var.auth);
   const normalizedLocationAlias = location?.trim() || undefined;
   const effectiveLocations = locations && locations.length > 0
     ? locations
@@ -1081,25 +1091,28 @@ app.openapi(getResumesRoute, (c) => {
           });
         }
 
-        // Compute status counts from the working set, then apply explicit
-        // status filters before response pagination. Without this, status=new
-        // reported counts but still returned all statuses.
+        // Compute operational status overlays only after authentication. Anonymous
+        // HR search returns base resume/search data and ignores status filters
+        // because status is part of the HR decision trail.
         let statusCounts: CandidateStatusCounts | undefined;
         let statusFilteredWorking = working;
-        try {
-          const statusContext = await loadCandidateStatusContext(workspaceSlug, showBlocked);
-          statusCounts = countCandidateStatuses(working, statusContext);
-          if (normalizedStatusFilters.length > 0) {
-            statusFilteredWorking = working.filter((item) =>
-              matchesStatusFilter(item, statusContext, normalizedStatusFilters)
-            );
+        const canApplyStatusFilters = canReadOperationalOverlays && normalizedStatusFilters.length > 0;
+        if (canReadOperationalOverlays) {
+          try {
+            const statusContext = await loadCandidateStatusContext(workspaceSlug, showBlocked);
+            statusCounts = countCandidateStatuses(working, statusContext);
+            if (canApplyStatusFilters) {
+              statusFilteredWorking = working.filter((item) =>
+                matchesStatusFilter(item, statusContext, normalizedStatusFilters)
+              );
+            }
+          } catch (error) {
+            logger.error("[Resumes] Failed to load candidate status context", error, {
+              route: "resumes_search",
+              workspaceSlug,
+            });
+            statusCounts = undefined;
           }
-        } catch (error) {
-          logger.error("[Resumes] Failed to load candidate status context", error, {
-            route: "resumes_search",
-            workspaceSlug,
-          });
-          statusCounts = undefined;
         }
 
         // Cursor-scan returns all results without pre-slicing, so
@@ -1111,11 +1124,11 @@ app.openapi(getResumesRoute, (c) => {
         // canUseSourcePagination with no keywords already has offset/limit from Convex list page;
         // all other paths need offset/limit applied locally.
         const isSourcePaginated = canUseSourcePagination && normalizedKeywords.length === 0;
-        const shouldUsePrePagedResponse = normalizedStatusFilters.length === 0 && (usesPrePagedMatchResults || isSourcePaginated);
+        const shouldUsePrePagedResponse = !canApplyStatusFilters && (usesPrePagedMatchResults || isSourcePaginated);
         const limited = shouldUsePrePagedResponse
           ? statusFilteredWorking.map((item) => item.resume)
           : pagedWorking.map((item) => item.resume);
-        const responseTotal = normalizedStatusFilters.length > 0
+        const responseTotal = canApplyStatusFilters
           ? statusFilteredWorking.length
           : (usesPrePagedMatchResults || isSourcePaginated)
             ? (totalCount ?? statusFilteredWorking.length)
@@ -1271,7 +1284,7 @@ app.openapi(getResumesRoute, (c) => {
           total: 0,
           returned: 0,
           query: keyword,
-          statusCounts: createCandidateStatusCounts(),
+          ...(canReadOperationalOverlays ? { statusCounts: createCandidateStatusCounts() } : {}),
         },
         data: [],
       }, 200);

--- a/apps/web/src/components/BulkActionBar.tsx
+++ b/apps/web/src/components/BulkActionBar.tsx
@@ -210,6 +210,7 @@ export function BulkActionBar({
                         size="sm"
                         data-testid="bulk-clear-selection"
                         onClick={onClearSelection}
+                        disabled={disabled}
                     >
                         {t('bulkActions.clearSelection', '取消选择')}
                     </Button>
@@ -256,6 +257,7 @@ export function BulkActionBar({
                     <Select
                         value={exportFormat}
                         aria-label={t('bulkActions.exportFormat')}
+                        disabled={disabled}
                         onChange={(e) => {
                             const val = e.target.value
                             const format = val === 'xlsx' ? 'xlsx' : 'csv'

--- a/apps/web/src/components/StarRating.test.tsx
+++ b/apps/web/src/components/StarRating.test.tsx
@@ -46,6 +46,29 @@ describe('StarRating', () => {
     await userEvent.setup().click(screen.getByRole('button', { name: '4 stars' }))
   })
 
+  it('disables star buttons when disabled and does not call onChange', async () => {
+    const onChange = vi.fn()
+    render(<StarRating value={2} onChange={onChange} disabled />)
+
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(5)
+    buttons.forEach((button) => {
+      expect(button).toBeDisabled()
+    })
+
+    await userEvent.setup().click(screen.getByRole('button', { name: '4 stars' }))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('treats missing onChange as read-only', () => {
+    render(<StarRating value={2} />)
+
+    screen.getAllByRole('button').forEach((button) => {
+      expect(button).toBeDisabled()
+    })
+  })
+
   it('applies filled class to stars up to the value', () => {
     render(<StarRating value={3} />)
     const buttons = screen.getAllByRole('button')

--- a/apps/web/src/components/StarRating.tsx
+++ b/apps/web/src/components/StarRating.tsx
@@ -3,12 +3,16 @@ import { Star } from 'lucide-react'
 export function StarRating({
   value,
   onChange,
+  disabled = false,
   size = 16,
 }: {
   value?: number
   onChange?: (rating: number) => void
+  disabled?: boolean
   size?: number
 }) {
+  const readOnly = disabled || !onChange
+
   return (
     <div className="flex items-center gap-0.5" role="group" aria-label="User rating">
       {[1, 2, 3, 4, 5].map((star) => {
@@ -17,9 +21,13 @@ export function StarRating({
           <button
             key={star}
             type="button"
-            className="p-0 leading-none"
+            className="p-0 leading-none disabled:cursor-not-allowed disabled:opacity-70"
+            disabled={readOnly}
             onClick={(e) => {
               e.stopPropagation()
+              if (readOnly) {
+                return
+              }
               onChange?.(value === star ? 0 : star)
             }}
             aria-label={`${star} star${star > 1 ? 's' : ''}`}

--- a/apps/web/src/components/search/SnippetCard.test.tsx
+++ b/apps/web/src/components/search/SnippetCard.test.tsx
@@ -45,18 +45,26 @@ vi.mock('@/components/search/SnippetCardExpanded', () => ({
   }) => (
     <div>
       <div>Expanded card for {item.resume.name ?? 'Unnamed resume'}</div>
-      <button data-testid="block-trigger" onClick={() => onBlockTrigger?.()}>
-        Block
-      </button>
-      <button data-testid="note-trigger" onClick={() => onNoteTrigger?.()}>
-        Add Note
-      </button>
-      <button data-testid="status-reject" onClick={() => onCandidateStatusChange?.(item.identityKey, 'interviewed_reject')}>
-        Mark Rejected
-      </button>
-      <button data-testid="status-hired" onClick={() => onCandidateStatusChange?.(item.identityKey, 'hired')}>
-        Mark Hired
-      </button>
+      {onBlockTrigger ? (
+        <button data-testid="block-trigger" onClick={() => onBlockTrigger()}>
+          Block
+        </button>
+      ) : null}
+      {onNoteTrigger ? (
+        <button data-testid="note-trigger" onClick={() => onNoteTrigger()}>
+          Add Note
+        </button>
+      ) : null}
+      {onCandidateStatusChange ? (
+        <>
+          <button data-testid="status-reject" onClick={() => onCandidateStatusChange(item.identityKey, 'interviewed_reject')}>
+            Mark Rejected
+          </button>
+          <button data-testid="status-hired" onClick={() => onCandidateStatusChange(item.identityKey, 'hired')}>
+            Mark Hired
+          </button>
+        </>
+      ) : null}
     </div>
   ),
 }))
@@ -360,6 +368,22 @@ describe('SnippetCard', () => {
     expect(screen.getByText('Candidate 1')).toBeInTheDocument()
   })
 
+  it('keeps star rating read-only when onRating is not provided', () => {
+    render(
+      <SnippetCard
+        expanded={false}
+        item={createResult(1)}
+        itemKey="result-1"
+        onToggleExpanded={vi.fn()}
+        userRating={3}
+      />
+    )
+
+    screen.getAllByRole('button', { name: /stars?$/ }).forEach((button) => {
+      expect(button).toBeDisabled()
+    })
+  })
+
   it('shows work history column when work history exists', () => {
     render(
       <SnippetCard
@@ -388,6 +412,22 @@ describe('SnippetCard', () => {
     expect(screen.queryByTitle('Led machine tools growth across Malaysia.')).not.toBeInTheDocument()
   })
 
+  it('hides expanded mutation triggers when callbacks are not provided', () => {
+    render(
+      <SnippetCard
+        expanded
+        item={createResult(1, { blocked: false })}
+        itemKey="result-1"
+        onToggleExpanded={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByTestId('block-trigger')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('note-trigger')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('status-reject')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('status-hired')).not.toBeInTheDocument()
+  })
+
   it('opens block dialog when block trigger is clicked from expanded card', async () => {
     const user = userEvent.setup()
 
@@ -397,6 +437,7 @@ describe('SnippetCard', () => {
         item={createResult(1, { blocked: false })}
         itemKey="result-1"
         onToggleExpanded={vi.fn()}
+        onToggleBlock={vi.fn()}
       />
     )
 
@@ -415,6 +456,7 @@ describe('SnippetCard', () => {
         item={createResult(1)}
         itemKey="result-1"
         onToggleExpanded={vi.fn()}
+        onCandidateStatusChange={vi.fn()}
       />
     )
 
@@ -433,6 +475,7 @@ describe('SnippetCard', () => {
         item={createResult(1)}
         itemKey="result-1"
         onToggleExpanded={vi.fn()}
+        onCandidateStatusChange={vi.fn()}
       />
     )
 
@@ -463,6 +506,7 @@ describe('SnippetCard', () => {
 
   it('dismisses block dialog on cancel', async () => {
     const user = userEvent.setup()
+    const onToggleBlock = vi.fn()
 
     render(
       <SnippetCard
@@ -470,6 +514,7 @@ describe('SnippetCard', () => {
         item={createResult(1, { blocked: false })}
         itemKey="result-1"
         onToggleExpanded={vi.fn()}
+        onToggleBlock={onToggleBlock}
       />
     )
 

--- a/apps/web/src/components/search/SnippetCard.tsx
+++ b/apps/web/src/components/search/SnippetCard.tsx
@@ -417,29 +417,35 @@ export const SnippetCard = memo(function SnippetCard({
           showAiScore={showAiScore}
           onViewDetails={onViewDetails ? () => onViewDetails(item) : undefined}
           candidateStatus={candidateStatus}
-          onCandidateStatusChange={(identityKey, nextStatus) => {
-            if (nextStatus === 'interviewed_reject' || nextStatus === 'withdrawn') {
-              setPendingStatus(nextStatus)
-              setNoteInput(statusNotes)
-              setPromptDialogOpen(true)
-              return
+          onCandidateStatusChange={onCandidateStatusChange
+            ? (identityKey, nextStatus) => {
+              if (nextStatus === 'interviewed_reject' || nextStatus === 'withdrawn') {
+                setPendingStatus(nextStatus)
+                setNoteInput(statusNotes)
+                setPromptDialogOpen(true)
+                return
+              }
+              onCandidateStatusChange(identityKey, nextStatus)
             }
-            onCandidateStatusChange?.(identityKey, nextStatus)
-          }}
+            : undefined}
           statusOptions={STATUS_OPTIONS}
           userRating={userRating}
-          onBlockTrigger={() => {
-            if (item.blocked) {
-              onToggleBlock?.(item.identityKey, true)
-            } else {
-              setBlockNoteInput('')
-              setBlockDialogOpen(true)
+          onBlockTrigger={onToggleBlock
+            ? () => {
+              if (item.blocked) {
+                onToggleBlock(item.identityKey, true)
+              } else {
+                setBlockNoteInput('')
+                setBlockDialogOpen(true)
+              }
             }
-          }}
-          onNoteTrigger={() => {
-            setCommentNoteInput(statusNotes)
-            setCommentDialogOpen(true)
-          }}
+            : undefined}
+          onNoteTrigger={onCandidateStatusChange
+            ? () => {
+              setCommentNoteInput(statusNotes)
+              setCommentDialogOpen(true)
+            }
+            : undefined}
         />
         </div>
       ) : null}

--- a/apps/web/src/hooks/useResumeSearchState.test.tsx
+++ b/apps/web/src/hooks/useResumeSearchState.test.tsx
@@ -72,6 +72,7 @@ const {
   saveSearchHistoryMutationMock,
   recentSearchHistoryRecordsMock,
   analysisTasksMock,
+  authMock,
   ratingsByResumeMock,
   statusByIdentityMock,
   updateStatusMock,
@@ -80,6 +81,9 @@ const {
   taxonomyClusterRecordsMock,
   useFacetCountsMock,
   useConvexResumesMock,
+  useCandidateActionsHookMock,
+  useCandidateBlocksHookMock,
+  useCandidateStatusHookMock,
   useMutationMock,
   useQueryMock,
   useUrlSearchStateMock,
@@ -101,6 +105,9 @@ const {
   saveSearchHistoryMutationMock: vi.fn(async () => 'history-1'),
   recentSearchHistoryRecordsMock: [] as Array<Record<string, unknown>>,
   analysisTasksMock: [] as Array<Record<string, unknown>>,
+  authMock: {
+    isAuthenticated: true,
+  },
   ratingsByResumeMock: {} as Record<string, number>,
   statusByIdentityMock: {} as Record<string, CandidateStatusRecord>,
   updateStatusMock: vi.fn(async () => true),
@@ -109,6 +116,9 @@ const {
   taxonomyClusterRecordsMock: [] as Array<Record<string, unknown>>,
   useFacetCountsMock: vi.fn(),
   useConvexResumesMock: vi.fn(),
+  useCandidateActionsHookMock: vi.fn(),
+  useCandidateBlocksHookMock: vi.fn(),
+  useCandidateStatusHookMock: vi.fn(),
   useMutationMock: vi.fn(),
   useQueryMock: vi.fn(),
   useUrlSearchStateMock: vi.fn(),
@@ -126,25 +136,41 @@ vi.mock('@/contexts/WorkspaceContext', () => ({
   useWorkspace: () => workspaceMock,
 }))
 
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => authMock,
+}))
+
 vi.mock('@/hooks/useUrlSearchState', () => ({
   useUrlSearchState: (...args: unknown[]) => useUrlSearchStateMock(...args),
 }))
 
 vi.mock('@/hooks/useCandidateStatus', () => ({
-  useCandidateStatus: () => ({
-    statusByIdentity: statusByIdentityMock,
-    updateStatus: updateStatusMock,
-  }),
+  useCandidateStatus: (...args: unknown[]) => useCandidateStatusHookMock(...args),
 }))
 
 vi.mock('@/hooks/useCandidateBlocks', () => ({
-  useCandidateBlocks: () => ({
-    blocksByIdentity: blocksByIdentityMock,
-  }),
+  useCandidateBlocks: (...args: unknown[]) => useCandidateBlocksHookMock(...args),
 }))
 
 vi.mock('@/hooks/useCandidateActions', () => ({
-  useCandidateActions: () => ({
+  useCandidateActions: (...args: unknown[]) => useCandidateActionsHookMock(...args),
+}))
+
+function createCandidateStatusHookValue() {
+  return {
+    statusByIdentity: statusByIdentityMock,
+    updateStatus: updateStatusMock,
+  }
+}
+
+function createCandidateBlocksHookValue() {
+  return {
+    blocksByIdentity: blocksByIdentityMock,
+  }
+}
+
+function createCandidateActionsHookValue() {
+  return {
     actions: {},
     actionsByResume: {},
     aiFeedbackByResume: {},
@@ -154,8 +180,8 @@ vi.mock('@/hooks/useCandidateActions', () => ({
     reload: vi.fn(),
     saveAction: saveActionMock,
     getAiFeedback: vi.fn(),
-  }),
-}))
+  }
+}
 
 vi.mock('@/hooks/useConvexResumes', () => ({
   useConvexResumes: (...args: unknown[]) => useConvexResumesMock(...args),
@@ -261,6 +287,7 @@ describe('useResumeSearchState', () => {
     localStorage.clear()
 
     workspaceMock.slug = 'dev'
+    authMock.isAuthenticated = true
     parsedStateMock.shareSessionId = undefined
     parsedStateMock.query = undefined
     parsedStateMock.location = undefined
@@ -299,6 +326,9 @@ describe('useResumeSearchState', () => {
       parsedState: parsedStateMock,
       syncToUrl: syncToUrlMock,
     })
+    useCandidateStatusHookMock.mockReturnValue(createCandidateStatusHookValue())
+    useCandidateBlocksHookMock.mockReturnValue(createCandidateBlocksHookValue())
+    useCandidateActionsHookMock.mockReturnValue(createCandidateActionsHookValue())
 
     useQueryMock.mockImplementation((query) => {
       if (query === 'recent-searches-query') {
@@ -343,6 +373,24 @@ describe('useResumeSearchState', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  it('does not load operational overlays for anonymous users', () => {
+    authMock.isAuthenticated = false
+
+    const { result } = renderHook(() => useResumeSearchState())
+
+    expect(useCandidateStatusHookMock).toHaveBeenCalledWith(false)
+    expect(useCandidateBlocksHookMock).toHaveBeenCalledWith(false)
+    expect(useCandidateActionsHookMock).toHaveBeenCalledWith(
+      expect.any(String),
+      undefined,
+      false,
+    )
+    expect(useQueryMock).toHaveBeenCalledWith('analysis-tasks-list-query', 'skip')
+    expect(useQueryMock).toHaveBeenCalledWith('recent-searches-query', 'skip')
+    expect(useQueryMock).toHaveBeenCalledWith('resumes:countResumesByStatus', 'skip')
+    expect(result.current.searchHistoryLoading).toBe(false)
   })
 
   it('defaults to score-first ordering for loaded search results', () => {

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -1,10 +1,11 @@
 import { formatKeywordQuery, isSalesRequiredContext, parseKeywordQuery, resolveLocationHierarchy } from '@trends/shared'
 import { matchesSalaryFilter } from '@/hooks/resume-filter-helpers'
-import { useMutation } from 'convex/react'
+import { useMutation, useQuery } from 'convex/react'
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, useTransition } from 'react'
 import { toast } from 'sonner'
 import { logSearchEvent } from '@/lib/search-analytics'
 import { api } from '../../../../packages/convex/convex/_generated/api'
+import { useAuth } from '@/contexts/AuthContext'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { useCandidateActions } from '@/hooks/useCandidateActions'
 import { useCandidateBlocks } from '@/hooks/useCandidateBlocks'
@@ -723,8 +724,10 @@ function ensureStoredSessionKey(storageKey: string): string {
 }
 
 export function useResumeSearchState() {
+  const { isAuthenticated } = useAuth()
   const { slug } = useWorkspace()
   const { parsedState, syncToUrl } = useUrlSearchState()
+  const canLoadOperationalState = isAuthenticated
   const storageKey = `${SESSION_KEY_PREFIX}.${slug}`
   const [sessionKey, setSessionKey] = useState(() =>
     ensureStoredSessionKey(storageKey),
@@ -753,19 +756,31 @@ export function useResumeSearchState() {
     api.sessions.markSearchHistoryOpened,
   )
   const dispatchAnalysis = useMutation(api.analysis_tasks.dispatch)
-  const analysisTasks = useStableQuery(api.analysis_tasks.list)
-  const recentSearchHistoryRecords = useStableQuery(api.sessions.recentSearches, {
-    sessionKey,
-    workspaceSlug: slug,
-    limit: 10,
-  })
+  const analysisTasks = useQuery(
+    api.analysis_tasks.list,
+    canLoadOperationalState ? {} : 'skip',
+  )
+  const recentSearchHistoryRecords = useQuery(
+    api.sessions.recentSearches,
+    canLoadOperationalState
+      ? {
+        sessionKey,
+        workspaceSlug: slug,
+        limit: 10,
+      }
+      : 'skip',
+  )
   const taxonomyClusterRecords = useStableQuery(api.taxonomy_clusters.list, {
     workspaceSlug: slug,
     status: 'active',
   })
-  const { statusByIdentity, updateStatus: updateCandidateStatus } = useCandidateStatus(true)
-  const { blocksByIdentity, blockCandidates, unblockCandidate } = useCandidateBlocks(true)
-  const { actions: actionsByResume, ratingsByResume, saveAction, getAiFeedback } = useCandidateActions(sessionKey, parsedState.jobDescriptionId)
+  const { statusByIdentity, updateStatus: updateCandidateStatus } = useCandidateStatus(canLoadOperationalState)
+  const { blocksByIdentity, blockCandidates, unblockCandidate } = useCandidateBlocks(canLoadOperationalState)
+  const { actions: actionsByResume, ratingsByResume, saveAction, getAiFeedback } = useCandidateActions(
+    sessionKey,
+    parsedState.jobDescriptionId,
+    canLoadOperationalState,
+  )
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const apiBaseUrl = useMemo(() => {
     const rawBaseUrl = import.meta.env.VITE_API_URL || '/api'
@@ -1002,7 +1017,7 @@ export function useResumeSearchState() {
 
   const facetCounts: FacetCounts = useFacetCounts(blockVisibleResults, taxonomyClusters)
   const statusCounts = useStatusCounts({
-    enabled: !isLanding,
+    enabled: !isLanding && canLoadOperationalState,
     filters: {
       ...backendFilters,
       showBlocked: parsedState.filters.showBlocked === true,
@@ -1136,6 +1151,9 @@ export function useResumeSearchState() {
 
   const lastSavedFingerprintRef = useRef<string>('')
   useEffect(() => {
+    if (!canLoadOperationalState) {
+      return
+    }
     if (isLanding) {
       return
     }
@@ -1190,7 +1208,7 @@ export function useResumeSearchState() {
     }, 800)
 
     return () => window.clearTimeout(timer)
-  }, [isLanding, parsedState, results, saveSearchHistory, sessionKey, slug])
+  }, [canLoadOperationalState, isLanding, parsedState, results, saveSearchHistory, sessionKey, slug])
 
   useEffect(() => {
     if (aiModeEnabled) {
@@ -1949,7 +1967,7 @@ export function useResumeSearchState() {
     results,
     selectedClusterTags,
     selectedRawTags,
-    searchHistoryLoading: recentSearchHistoryRecords === undefined,
+    searchHistoryLoading: canLoadOperationalState && recentSearchHistoryRecords === undefined,
     isFilterPending,
     committedMinRoleYears,
     setMinRoleYearsFilter,

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -472,6 +472,9 @@
         "analyzeLoaded": "Analyze loaded {{count}}",
         "analyzeLoadedResults": "Analyze loaded results"
       },
+      "readOnly": {
+        "loginRequired": "Sign in to rate, update status, add notes, block, export, or run bulk actions."
+      },
       "aiSummary": {
         "title": "AI result summary",
         "noSummary": "No summary is available for the current search yet.",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -471,6 +471,9 @@
         "analyzeLoaded": "分析已加载的 {{count}} 份",
         "analyzeLoadedResults": "分析已加载结果"
       },
+      "readOnly": {
+        "loginRequired": "登录后可评分、更新状态、添加备注、屏蔽、导出或执行批量操作。"
+      },
       "aiSummary": {
         "title": "AI 结果摘要",
         "noSummary": "当前搜索暂时没有可用摘要。",

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -471,6 +471,9 @@
         "analyzeLoaded": "分析已載入的 {{count}} 份",
         "analyzeLoadedResults": "分析已載入結果"
       },
+      "readOnly": {
+        "loginRequired": "登入後可評分、更新狀態、加入備註、屏蔽、匯出或執行批量操作。"
+      },
       "aiSummary": {
         "title": "AI 結果摘要",
         "noSummary": "目前搜尋暫時沒有可用摘要。",

--- a/apps/web/src/lib/auth.test.ts
+++ b/apps/web/src/lib/auth.test.ts
@@ -40,9 +40,11 @@ const authMe = {
 describe('auth helpers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    document.cookie = 'trends_csrf=; Max-Age=0; path=/'
   })
 
   it('fetches the current auth context', async () => {
+    document.cookie = 'trends_csrf=csrf-token; path=/'
     mockApiClient.GET.mockResolvedValueOnce({ data: authMe })
 
     await expect(fetchCurrentAuth()).resolves.toEqual(authMe)
@@ -51,9 +53,16 @@ describe('auth helpers', () => {
   })
 
   it('returns null when current auth request is unauthenticated', async () => {
+    document.cookie = 'trends_csrf=csrf-token; path=/'
     mockApiClient.GET.mockResolvedValueOnce({ error: { status: 401 } })
 
     await expect(fetchCurrentAuth()).resolves.toBeNull()
+  })
+
+  it('skips the current auth request when no csrf cookie is present', async () => {
+    await expect(fetchCurrentAuth()).resolves.toBeNull()
+
+    expect(mockApiClient.GET).not.toHaveBeenCalled()
   })
 
   it('logs in with local credentials', async () => {

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -203,7 +203,21 @@ function sanitizeRedirectPath(path: string): string {
   return path
 }
 
+function hasCookie(name: string): boolean {
+  if (typeof document === 'undefined') {
+    return true
+  }
+  const prefix = `${name}=`
+  return document.cookie
+    .split(';')
+    .map((part) => part.trim())
+    .some((part) => part.startsWith(prefix))
+}
+
 export async function fetchCurrentAuth(): Promise<CurrentAuth | null> {
+  if (!hasCookie('trends_csrf')) {
+    return null
+  }
   const { data, error } = await rawApiClient.GET<CurrentAuth>('/api/auth/me')
   if (error || data?.success !== true) {
     return null

--- a/apps/web/src/pages/ResumeSearchPage.test.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.test.tsx
@@ -6,7 +6,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ResumeSearchPage } from './ResumeSearchPage'
 import type { ResumeSearchResultItem } from '@/components/search/search-types'
 import type { ConvexResumeItem } from '@/hooks/useConvexResumes'
+import type { AuthUser, WorkspaceRole } from '@/lib/auth'
 import type { UrlSearchState } from '@/hooks/useUrlSearchState'
+
+type AuthMockValue = {
+  user: AuthUser | null
+  workspaceRole: WorkspaceRole | null
+  isAuthenticated: boolean
+  isLoading: boolean
+  login: (username: string, password: string) => Promise<boolean>
+  logout: () => Promise<void>
+  refresh: () => Promise<void>
+}
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -31,6 +42,7 @@ vi.mock('react-i18next', () => ({
         'resumes.searchPage.analysis.analyzeLoaded': 'Analyze loaded {{count}}',
         'resumes.searchPage.analysis.analyzeLoadedResults': 'Analyze loaded results',
         'resumes.searchPage.analysis.analyzing': 'Analyzing...',
+        'resumes.searchPage.readOnly.loginRequired': 'Sign in to rate, update status, add notes, block, export, or run bulk actions.',
       }
       const text = englishTexts[key] ?? key
       return text.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
@@ -55,8 +67,24 @@ const featureFlagsMock = vi.hoisted(() => ({
   resumeAiSummaryEnabled: false,
 }))
 
+const authMock = vi.hoisted((): { value: AuthMockValue } => ({
+  value: {
+    user: { id: 'user-1', displayName: 'Tester', status: 'active' },
+    workspaceRole: 'user',
+    isAuthenticated: true,
+    isLoading: false,
+    login: vi.fn(async () => true),
+    logout: vi.fn(async () => {}),
+    refresh: vi.fn(async () => {}),
+  },
+}))
+
 vi.mock('@/lib/feature-flags', () => ({
   isResumeAiSummaryEnabled: () => featureFlagsMock.resumeAiSummaryEnabled,
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => authMock.value,
 }))
 
 vi.mock('@/hooks/useAiSearchSummary', () => ({
@@ -284,8 +312,13 @@ vi.mock('@/components/search/SearchResultsList', () => ({
     loading,
     loadingMore,
     showAiScore,
+    onAction,
+    onCandidateStatusChange,
     onLoadMore,
+    onRating,
     onToggleExpanded,
+    onToggleSelect,
+    onToggleBlock,
   }: {
     expandedIds: Set<string>
     hasMore: boolean
@@ -293,14 +326,26 @@ vi.mock('@/components/search/SearchResultsList', () => ({
     loading?: boolean
     loadingMore?: boolean
     showAiScore?: boolean
+    onAction?: () => void
+    onCandidateStatusChange?: () => void
     onLoadMore: () => void
+    onRating?: () => void
     onToggleExpanded: (key: string) => void
+    onToggleSelect?: () => void
+    onToggleBlock?: () => void
   }) => (
     <div>
       <div>
         Results List {items.length} hasMore:{String(hasMore)} loading:
         {String(loading)} loadingMore:{String(loadingMore)} showAiScore:
         {String(showAiScore)} expanded:{Array.from(expandedIds).join('|') || 'none'}
+      </div>
+      <div>
+        Result controls action:{String(Boolean(onAction))} rating:
+        {String(Boolean(onRating))} status:
+        {String(Boolean(onCandidateStatusChange))} block:
+        {String(Boolean(onToggleBlock))} select:
+        {String(Boolean(onToggleSelect))}
       </div>
       {items[0] ? (
         <button type="button" onClick={() => onToggleExpanded(items[0].key)}>
@@ -355,6 +400,7 @@ vi.mock('@/components/BulkActionBar', () => ({
     onBulkAction,
     exportFormat,
     highScoreCount,
+    disabled,
     selectedCount,
     totalCount,
     totalCountIsLowerBound,
@@ -363,19 +409,20 @@ vi.mock('@/components/BulkActionBar', () => ({
     onBulkAction?: (action: string, format?: string) => void
     exportFormat?: string
     highScoreCount?: number
+    disabled?: boolean
     selectedCount?: number
     totalCount?: number
     totalCountIsLowerBound?: boolean
   }) => (
     <div>
-      <div>BulkActionBar {selectedCount}/{totalCount}{totalCountIsLowerBound ? '+' : ''} high:{highScoreCount} fmt:{exportFormat}</div>
+      <div>BulkActionBar {selectedCount}/{totalCount}{totalCountIsLowerBound ? '+' : ''} high:{highScoreCount} fmt:{exportFormat} disabled:{String(Boolean(disabled))}</div>
       {onExportFormatChange && (
-        <button type="button" onClick={() => onExportFormatChange('xlsx')}>
+        <button type="button" disabled={disabled} onClick={() => onExportFormatChange('xlsx')}>
           Change Export Format
         </button>
       )}
       {onBulkAction && (
-        <button type="button" onClick={() => onBulkAction('export', exportFormat)}>
+        <button type="button" disabled={disabled} onClick={() => onBulkAction('export', exportFormat)}>
           Bulk Export
         </button>
       )}
@@ -528,6 +575,15 @@ describe('ResumeSearchPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     featureFlagsMock.resumeAiSummaryEnabled = false
+    authMock.value = {
+      user: { id: 'user-1', displayName: 'Tester', status: 'active' },
+      workspaceRole: 'user',
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(async () => true),
+      logout: vi.fn(async () => {}),
+      refresh: vi.fn(async () => {}),
+    }
     useIndustryKeywordsMock.mockReturnValue({
       hotKeywords: [],
       quickStartProfiles: [],
@@ -891,6 +947,59 @@ describe('ResumeSearchPage', () => {
 
     expect(state.setExportFormat).toHaveBeenCalledWith('xlsx')
     expect(state.handleBulkAction).toHaveBeenCalledWith('export', 'csv')
+  })
+
+  it('keeps anonymous search results read-only and blocks bulk/export candidate operations', async () => {
+    const user = userEvent.setup()
+    authMock.value = {
+      user: null,
+      workspaceRole: null,
+      isAuthenticated: false,
+      isLoading: false,
+      login: vi.fn(async () => false),
+      logout: vi.fn(async () => {}),
+      refresh: vi.fn(async () => {}),
+    }
+    const state = createResumeSearchState({
+      activeQuery: 'CNC Sales',
+      analysisCandidateCount: 1,
+      disableAnalyzeResults: false,
+      filteredResults: [createResult(1)],
+      highScoreCount: 1,
+      isLanding: false,
+      selectedIds: new Set<string>(['resume-1']),
+    })
+    useResumeSearchStateMock.mockReturnValue(state)
+
+    render(<ResumeSearchPage />)
+
+    expect(
+      screen.getByRole('status', {
+        name: 'Sign in to rate, update status, add notes, block, export, or run bulk actions.',
+      }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Result controls action:false rating:false status:false block:false select:false',
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/BulkActionBar 1\/1 high:1 fmt:csv disabled:true/),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Change Export Format' }),
+    ).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Bulk Export' })).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: /Analyze loaded 1/i }),
+    ).toBeDisabled()
+
+    await user.click(screen.getByRole('button', { name: 'Bulk Export' }))
+    await user.click(screen.getByRole('button', { name: /Analyze loaded 1/i }))
+
+    expect(state.setExportFormat).not.toHaveBeenCalled()
+    expect(state.handleBulkAction).not.toHaveBeenCalled()
+    expect(state.analyzeResults).not.toHaveBeenCalled()
   })
 
   it('wires the search-first analyze action into the page controls', async () => {

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -18,10 +18,12 @@ import { Button } from '@/components/ui/button'
 import { useAiSearchSummary } from '@/hooks/useAiSearchSummary'
 import { useIndustryKeywords } from '@/hooks/useIndustryKeywords'
 import { useResumeSearchState } from '@/hooks/useResumeSearchState'
+import { useAuth } from '@/contexts/AuthContext'
 import { isResumeAiSummaryEnabled } from '@/lib/feature-flags'
 
 export function ResumeSearchPage() {
   const { t } = useTranslation()
+  const { isAuthenticated, isLoading: authLoading } = useAuth()
   const resumeAiSummaryEnabled = isResumeAiSummaryEnabled()
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
   const [filtersOpen, setFiltersOpen] = useState(false)
@@ -305,6 +307,11 @@ export function ResumeSearchPage() {
   const reloadPageLabel = t('resumes.searchPage.error.reloadPage', {
     defaultValue: 'Reload page',
   })
+  const readOnlyLoginRequiredLabel = t('resumes.searchPage.readOnly.loginRequired', {
+    defaultValue: 'Sign in to rate, update status, add notes, block, export, or run bulk actions.',
+  })
+  const canManageCandidateData = isAuthenticated
+  const showReadOnlyLoginRequired = !authLoading && !canManageCandidateData
 
   return (
     <div className="space-y-6">
@@ -393,7 +400,7 @@ export function ResumeSearchPage() {
                     size="sm"
                     data-testid="resume-analyze-button"
                     className="h-10 gap-2 rounded-full px-4"
-                    disabled={disableAnalyzeResults || !aiModeEnabled}
+                    disabled={disableAnalyzeResults || !aiModeEnabled || !canManageCandidateData}
                     onClick={() => {
                       void analyzeResults()
                     }}
@@ -416,6 +423,16 @@ export function ResumeSearchPage() {
                 </div>
               </div>
 
+              {showReadOnlyLoginRequired ? (
+                <div
+                  role="status"
+                  aria-label={readOnlyLoginRequiredLabel}
+                  className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900"
+                >
+                  {readOnlyLoginRequiredLabel}
+                </div>
+              ) : null}
+
               {resumeAiSummaryEnabled && (
                 <ErrorBoundary fallback={<InlineErrorFallback message={errorAiSummaryLabel} />}>
                   <AiSummaryPanel
@@ -433,6 +450,7 @@ export function ResumeSearchPage() {
                   selectedCount={selectedIds.size}
                   highScoreCount={highScoreCount}
                   exportFormat={exportFormat}
+                  disabled={!canManageCandidateData}
                   onExportFormatChange={setExportFormat}
                   onSelectAll={selectAll}
                   onSelectHighScore={() => selectHighScore()}
@@ -458,11 +476,11 @@ export function ResumeSearchPage() {
                   selectedIds={selectedIds}
                   actionsByResume={actionsByResume}
                   ratingsByResume={ratingsByResume}
-                  onToggleSelect={toggleSelectItem}
-                  onAction={handleCandidateAction}
-                  onRating={handleRating}
-                  onCandidateStatusChange={handleCandidateStatusChange}
-                  onToggleBlock={handleToggleBlock}
+                  onToggleSelect={canManageCandidateData ? toggleSelectItem : undefined}
+                  onAction={canManageCandidateData ? handleCandidateAction : undefined}
+                  onRating={canManageCandidateData ? handleRating : undefined}
+                  onCandidateStatusChange={canManageCandidateData ? handleCandidateStatusChange : undefined}
+                  onToggleBlock={canManageCandidateData ? handleToggleBlock : undefined}
                   searchQuery={queryInput}
                 />
               </ErrorBoundary>

--- a/scripts/route-auth-policy.json
+++ b/scripts/route-auth-policy.json
@@ -73,7 +73,7 @@
   },
   "resumes_search.ts": {
     "class": "workspace-read",
-    "reason": "The operational resume list route requires authenticated workspace membership; sample and keyword helper routes remain public within the file."
+    "reason": "The operational resume list route requires authenticated workspace membership except for the narrow anonymous read-only hr workspace search fast path; sample and keyword helper routes remain public within the file."
   },
   "rss.ts": {
     "class": "public",


### PR DESCRIPTION
## Summary
- Allow anonymous read-only `GET /api/resumes` only for the `hr` workspace while keeping `dev` and missing-workspace reads authenticated.
- Keep operational candidate overlays and all candidate-changing actions login-required, with redacted `workspace_access_denied` events for anonymous denials.
- Make anonymous `/hr/resumes` read-only in the UI and skip operational subscriptions/fetches until login.
- Avoid the anonymous `/api/auth/me` browser-console 401 when no CSRF cookie exists.

## Verification
- `bunx vitest run apps/api/src/routes/resumes_search.test.ts apps/api/src/routes/resumes.test.ts apps/api/src/routes/actions.test.ts apps/api/src/routes/candidate-status.test.ts apps/api/src/middleware/auth.test.ts`
- `npm --workspace @trends/web run test -- src/lib/auth.test.ts src/hooks/useResumeSearchState.test.tsx src/pages/ResumeSearchPage.test.tsx src/components/search/SnippetCard.test.tsx src/components/StarRating.test.tsx`
- `bash scripts/check-route-auth.test.sh`
- `bash scripts/check-route-auth.sh`
- `git diff --check`
- `make check`
- Headless Playwright smoke: `/hr/resumes?location=China&q=CNC+%E9%94%80%E5%94%AE&minRoleYears=1&roleType=sales&minAge=25&maxAge=40` returned 189 resumes, showed the read-only login notice, and had no console messages, failed requests, or 4xx/5xx responses.