### PR TITLE
chore: add reusable demo auth bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,8 @@ AI_OUTPUT_LOCALE=zh-Hans      # AI analysis output language (resume system)
 VITE_DEFAULT_LOCALE=zh-Hans   # Frontend UI / static content default language
 
 # Auth
+# Local demo auth helper password for `bun run auth:bootstrap-demo`.
+AUTH_BOOTSTRAP_PASSWORD=demo-admin
 # AUTH_DEV_BYPASS=true              # Skip auth checks in local dev (never use in production)
 # AUTH_ALLOWED_ORIGINS=http://localhost:5173  # Comma-separated CORS origins
 # AUTH_SESSION_TTL_SECONDS=604800   # Session lifetime (default 7 days)

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "verify:critical-path": "tsx scripts/verify-critical-path.ts",
     "verify:workflow-dataset": "tsx scripts/resume/verify-workflow-dataset.ts",
     "clear:workspace-demo-resumes": "tsx scripts/resume/clear-workspace-demo-resumes.ts",
+    "auth:bootstrap-demo": "tsx scripts/auth/manage-user.ts --username demo-admin --email demo-admin@example.com --display-name \"Demo Admin\" --workspace dev --role admin --password-env AUTH_BOOTSTRAP_PASSWORD --output json",
     "verify:industry-scores": "tsx scripts/verify-industry-scores.ts",
     "verify:industry-scores:round-trip": "tsx scripts/verify-industry-scores.ts --sample sample-job5156-detail-enriched --round-trip",
     "e2e": "tsx scripts/e2e-smoke.ts"

--- a/scripts/auth/manage-user.test.ts
+++ b/scripts/auth/manage-user.test.ts
@@ -1,6 +1,8 @@
-import { mkdtempSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -10,6 +12,9 @@ import { verifyPassword } from "../../apps/api/src/services/local-password-provi
 
 // Import the module logic functions directly for unit testing.
 // The script itself is tested via CLI invocation in integration tests.
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const manageUserScript = fileURLToPath(new URL("./manage-user.ts", import.meta.url));
 
 function createTestUser(
   storage: AuthStorage,
@@ -154,5 +159,57 @@ describe("manage-user bootstrap logic", () => {
 
     expect(userJson).not.toContain("password");
     expect(identityJson).not.toContain("password");
+  });
+
+  it("loads password-env from the project .env for direct dev CLI runs", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-manage-user-env-"));
+    writeFileSync(path.join(root, ".env"), "AUTH_BOOTSTRAP_PASSWORD=demo-admin\n");
+
+    const env = { ...process.env, PROJECT_ROOT: root };
+    delete env.AUTH_BOOTSTRAP_PASSWORD;
+
+    const result = spawnSync(
+      "node",
+      [
+        "--import",
+        "tsx",
+        manageUserScript,
+        "--username",
+        "demo-admin",
+        "--email",
+        "demo-admin@example.com",
+        "--display-name",
+        "Demo Admin",
+        "--workspace",
+        "dev",
+        "--role",
+        "admin",
+        "--password-env",
+        "AUTH_BOOTSTRAP_PASSWORD",
+        "--output",
+        "json",
+      ],
+      {
+        cwd: repoRoot,
+        env,
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.stderr).not.toContain("demo-admin");
+    expect(result.stdout).not.toContain("demo-admin");
+    expect(result.status).toBe(0);
+
+    const output = JSON.parse(result.stdout) as { success: boolean; passwordSet: boolean };
+    expect(output.success).toBe(true);
+    expect(output.passwordSet).toBe(true);
+
+    const storage = new AuthStorage(root);
+    const identity = storage.findIdentity("local", "demo-admin", "local");
+    expect(identity).not.toBeNull();
+
+    const credential = storage.findPasswordCredential(identity!.userId);
+    expect(credential).not.toBeNull();
+    expect(await verifyPassword("demo-admin", credential!)).toBe(true);
   });
 });

--- a/scripts/auth/manage-user.ts
+++ b/scripts/auth/manage-user.ts
@@ -2,15 +2,20 @@
  * Idempotent local user + workspace membership bootstrap script.
  *
  * Usage:
- *   AUTH_BOOTSTRAP_PASSWORD='secret' bun run scripts/auth/manage-user.ts \
+ *   bun run scripts/auth/manage-user.ts \
  *     --username hr-admin --email hr@example.com --display-name "HR Admin" \
  *     --workspace hr --role admin --password-env AUTH_BOOTSTRAP_PASSWORD --output json
  *
+ * Loads PROJECT_ROOT/.env or cwd/.env when present for local dev helpers.
  * Password input priority: --password-env > --password-stdin > --no-password
  * Never echoes passwords in stdout/stderr.
  */
 
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
 import { AuthStorage } from "../../apps/api/src/services/auth-storage.js";
+import { findProjectRoot } from "../../apps/api/src/services/db.js";
 import { hashPassword } from "../../apps/api/src/services/local-password-provider.js";
 import { resetResumeScreeningDb } from "../../apps/api/src/services/database.js";
 
@@ -75,6 +80,54 @@ function parseArgs(argv: string[]): Args {
   }
 
   return args;
+}
+
+function parseEnvValue(raw: string): string {
+  const value = raw.trim();
+  if (
+    (value.startsWith("\"") && value.endsWith("\""))
+    || (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+
+  const commentIndex = value.search(/\s#/);
+  if (commentIndex >= 0) {
+    return value.slice(0, commentIndex).trim();
+  }
+
+  return value;
+}
+
+function resolveProjectRoot(): string {
+  return path.resolve(process.env.PROJECT_ROOT?.trim() || findProjectRoot());
+}
+
+function loadProjectEnvFile(projectRoot: string): void {
+  const envPath = path.resolve(projectRoot, ".env");
+  if (!existsSync(envPath) || statSync(envPath).isDirectory()) {
+    return;
+  }
+
+  const content = readFileSync(envPath, "utf8");
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const eqIndex = trimmed.indexOf("=");
+    if (eqIndex < 1) {
+      continue;
+    }
+
+    const key = trimmed.slice(0, eqIndex).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key) || process.env[key] !== undefined) {
+      continue;
+    }
+
+    process.env[key] = parseEnvValue(trimmed.slice(eqIndex + 1));
+  }
 }
 
 async function readPassword(args: Args): Promise<string | null> {
@@ -173,6 +226,10 @@ function upsertUser(
 }
 
 async function main() {
+  let projectRoot = resolveProjectRoot();
+  loadProjectEnvFile(projectRoot);
+  projectRoot = resolveProjectRoot();
+
   const args = parseArgs(process.argv.slice(2));
 
   if (!args.username) {
@@ -204,7 +261,7 @@ async function main() {
     return;
   }
 
-  const storage = new AuthStorage();
+  const storage = new AuthStorage(projectRoot);
 
   // Check if identity exists to determine create vs update
   const existingIdentity = storage.findIdentity("local", args.username, "local");

--- a/scripts/repo-workflow-entrypoints.test.ts
+++ b/scripts/repo-workflow-entrypoints.test.ts
@@ -28,6 +28,12 @@ describe("workflow verifier repo entrypoints", () => {
     expect(packageJson.scripts?.["clear:workspace-demo-resumes"]).toBe("tsx scripts/resume/clear-workspace-demo-resumes.ts");
   });
 
+  it("exposes the reusable local demo auth bootstrap script through package.json", () => {
+    expect(packageJson.scripts?.["auth:bootstrap-demo"]).toBe(
+      'tsx scripts/auth/manage-user.ts --username demo-admin --email demo-admin@example.com --display-name "Demo Admin" --workspace dev --role admin --password-env AUTH_BOOTSTRAP_PASSWORD --output json',
+    );
+  });
+
   it("exposes a Make target with the expected forwarding flags", () => {
     const recipe = getTargetRecipe("verify-workflow-dataset");
 


### PR DESCRIPTION
## Summary
- add `auth:bootstrap-demo` for the local demo admin account
- load project `.env` in `scripts/auth/manage-user.ts` before resolving `--password-env`
- document `AUTH_BOOTSTRAP_PASSWORD=demo-admin` in `.env.example` and cover the CLI flow with tests

## Verification
- `bunx vitest run scripts/auth/manage-user.test.ts scripts/repo-workflow-entrypoints.test.ts`
- `bun run auth:bootstrap-demo -- --dry-run`
- `git diff --check`
- `make check`

## Notes
- Local gitignored `.env` on this machine has also been updated to `AUTH_BOOTSTRAP_PASSWORD=demo-admin` so `bun run auth:bootstrap-demo` works directly in dev.