### PR TITLE
refactor: parameterize SSH host — use ${SSH_HOST:-ptcloud} fallback, never hardcode

### DIFF
--- a/.claude/commands/ssh-server-inspector.md
+++ b/.claude/commands/ssh-server-inspector.md
@@ -1,6 +1,6 @@
 # SSH Server Inspector
 
-Inspect a remote Ubuntu server over SSH to validate and troubleshoot deployments (especially Caddy reverse proxy). Use when you need OS/disk/memory info, listening ports, key folders, and Caddy service status/config/logs for a host alias like "ptcloud" or "root@ptcloud".
+Inspect a remote Ubuntu server over SSH to validate and troubleshoot deployments (especially Caddy reverse proxy). Use when you need OS/disk/memory info, listening ports, key folders, and Caddy service status/config/logs for an SSH host alias like "myserver" or "user@myserver".
 
 ## How to run
 
@@ -18,8 +18,8 @@ Options:
 
 Examples:
 ```bash
-~/.codex/skills/ssh-server-inspector/scripts/inspect_host.sh ptcloud
-~/.codex/skills/ssh-server-inspector/scripts/inspect_host.sh root@ptcloud --ports 80,443,3000 --paths /etc/caddy,/var/www
+~/.codex/skills/ssh-server-inspector/scripts/inspect_host.sh <ssh_target>
+~/.codex/skills/ssh-server-inspector/scripts/inspect_host.sh root@<ssh_target> --ports 80,443,3000 --paths /etc/caddy,/var/www
 ```
 
 ## How to use the report

--- a/.claude/dev-loop.config.md
+++ b/.claude/dev-loop.config.md
@@ -345,7 +345,7 @@ bump_script:
 publish_via: none
 deploy_script: bash scripts/install.sh upgrade
 manifests_count: 5
-remote_hosts: [ptcloud]
+remote_hosts: [${SSH_HOST:-ptcloud}]
 ```
 
 ## CI Configuration
@@ -363,7 +363,7 @@ ci_discovery: runtime
 ```yaml
 notes:
   stack: Monorepo — React+Vite (web), Hono+OpenAPI (api), FastAPI (worker), Convex (data)
-  deploy: production deploys via `make on-prod-deploy` on ptcloud after `make on-prod-deploy-check`
+  deploy: production deploys via `make on-prod-deploy` on prod host (`SSH_HOST`, defaults to `ptcloud`) after `make on-prod-deploy-check`
   config_docs: CLAUDE.md is canonical; AGENTS.md is symlink
   planning: EnterPlanMode gated — TDD-first pipeline uses superpowers:writing-plans for plan, then superpowers:test-driven-development for execute
   gotcha: api-types.ts regenerates on make check after API schema edits — always stage it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ make local-restore-from-prod FILE=output/resume-backups/resumes-prod-<...>.tar.g
 # Go CLI: trends resume full-restore <path>
 ```
 
-### On prod host (after `ssh ptcloud && cd /opt/trends`)
+### On prod host (SSH via `${SSH_HOST:-ptcloud}`; `SSH_HOST` defaults to `ptcloud` if unset)
 ```bash
 make on-prod-deploy-check        # dry run (alias: prod-deploy-check / deploy-check)
 make on-prod-deploy              # full upgrade (alias: prod-deploy / deploy)
@@ -139,11 +139,11 @@ make on-prod-install             # first-time systemd install (alias: prod-insta
 make on-prod-refresh-env         # refresh env + rebuild web bundle (alias: refresh-env)
 ```
 
-### Preview deployment (preview.pt-mes.com on ptcloud)
+### Preview deployment (preview.pt-mes.com; uses `${SSH_HOST:-ptcloud}`)
 Preview runs in parallel with production on different ports — Convex `4210/4211`, API `3002`, MCP `3334`, web at `/home/ubuntu/trends-preview/apps/web/dist`. See `deploy/restore-preview-from-prod.sh` and the compound entry `projects/trends/compound/2026-05-29-preview-deployment-lessons.md` for the full postmortem.
 
 ```bash
-# On ptcloud as root
+# On the preview host as root (SSH_HOST)
 bash /opt/trends/deploy/setup-preview.sh           # rsync code, build API+web (~6m)
 cd /home/ubuntu/trends-preview && \
   docker compose -f docker-compose.preview.yml up -d   # Convex + MCP

--- a/deploy/preview-doctor.sh
+++ b/deploy/preview-doctor.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Preview environment health check + auto-recovery for preview.pt-mes.com.
 #
-# Run on ptcloud (any user with sudo). Reports on:
+# Run on the preview host (any user with sudo). Reports on:
 #   - Caddy reachability (preview.pt-mes.com)
 #   - Convex container health + memory headroom
 #   - Convex /version + sync HTTP upgrade

--- a/deploy/restore-preview-from-prod.sh
+++ b/deploy/restore-preview-from-prod.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Restore production data into preview Convex via Convex export/import API.
-# Run on ptcloud as root.
+# Run on the preview host as root.
 #
 # This is the CORRECT way to copy data between Convex deployments.
 # DO NOT use raw SQLite file copy — binary version mismatch breaks schema push.

--- a/deploy/setup-preview.sh
+++ b/deploy/setup-preview.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Sets up the preview environment at /home/ubuntu/trends-preview/ from origin/main.
-# Run on ptcloud as root.  Usage: bash deploy/setup-preview.sh
+# Run on the preview host as root.  Usage: bash deploy/setup-preview.sh
 #
 # IMPORTANT: This pulls from origin/main, NOT /opt/trends. Production might be
 # weeks behind main. Preview should always reflect the bleeding-edge code.

--- a/deploy/sync-preview-convex-env.sh
+++ b/deploy/sync-preview-convex-env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Hydrate preview AI runtime env from production env and sync it into preview Convex.
-# Run on ptcloud as root after the preview Convex container is running.
+# Run on the preview host as root after the preview Convex container is running.
 set -euo pipefail
 
 PREVIEW_DIR="${PREVIEW_DIR:-/home/ubuntu/trends-preview}"

--- a/scripts/upgrade-convex.sh
+++ b/scripts/upgrade-convex.sh
@@ -4,7 +4,7 @@
 # Handles three environments:
 #   dev        macOS local dev (auto-detected) — bun install, local prefetch
 #   linux-dev  Linux dev VM                   — npm install, local prefetch
-#   prod       Linux prod (ptcloud)           — patches package.json, prints manual steps
+#   prod       Linux prod (SSH_HOST, defaults to ptcloud) — patches package.json, prints manual steps
 #
 # Also writes CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS to .env.local,
 # which is the official override for the CLI's startup timeout (available in
@@ -308,7 +308,7 @@ patch_convex_dep "$CARET_VERSION" "$WEB_PKG_JSON" "$CONVEX_PKG_JSON"
 
 if [[ "$ENV" == "prod" ]]; then
     log ""
-    log "=== Production Upgrade Instructions (ptcloud) ==="
+    log "=== Production Upgrade Instructions (SSH_HOST, defaults to ptcloud) ==="
     log ""
     log "The package.json files have been patched locally."
     log "Complete the production upgrade with these manual steps:"
@@ -318,8 +318,8 @@ if [[ "$ENV" == "prod" ]]; then
     log "     git commit -m 'chore: upgrade convex to $CARET_VERSION'"
     log "     git push"
     log ""
-    log "  2. Deploy to ptcloud:"
-    log "     ssh ptcloud && cd /opt/trends && sudo make on-prod-deploy"
+    log "  2. Deploy to prod host:"
+    log "     ssh \${SSH_HOST:-ptcloud} && cd /opt/trends && sudo make on-prod-deploy"
     log ""
     log "  3. Add startup timeout to production env config:"
     log "     # Add to /etc/trends/env:"


### PR DESCRIPTION
## Summary
- Replace all hardcoded `ptcloud` host references across CLAUDE.md, dev-loop config, shell scripts, and command docs
- Use `${SSH_HOST:-ptcloud}` variable-with-fallback pattern consistently (already used in Makefile)
- Prevents agents/scripts from fabricating literal hostname into output (e.g., handoff reports)

## Files changed
- `CLAUDE.md` — prod host and preview deployment sections
- `.claude/dev-loop.config.md` — remote_hosts and deploy notes
- `.claude/commands/ssh-server-inspector.md` — examples and description
- `deploy/*.sh` (4 files) — comment headers
- `scripts/upgrade-convex.sh` — env comments and printed instructions

## Test plan
- [x] `make check` passes