### PR TITLE
fix: isolate demo admin workspace

### DIFF
--- a/apps/api/src/middleware/__tests__/middleware.test.ts
+++ b/apps/api/src/middleware/__tests__/middleware.test.ts
@@ -19,7 +19,7 @@ describe("workspaceMiddleware", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.slug).toBe("dev");
-    expect(body.level).toBe("admin");
+    expect(body.level).toBe("user");
   });
 
   it("uses X-Workspace-Slug header when provided", async () => {
@@ -82,9 +82,23 @@ describe("requireAdmin", () => {
     app.get("/test", (c) => c.text("ok"));
 
     const res = await app.request("/test", {
-      headers: { "X-Workspace-Slug": "dev" },
+      headers: { "X-Workspace-Slug": "admin" },
     });
     expect(res.status).toBe(200);
+  });
+
+  it("blocks dev workspace with 403", async () => {
+    const app = createTestApp();
+    app.use("*", workspaceMiddleware);
+    app.use("*", requireAdmin);
+    app.get("/test", (c) => c.text("ok"));
+
+    const res = await app.request("/test", {
+      headers: { "X-Workspace-Slug": "dev" },
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Admin access required");
   });
 
   it("blocks non-admin workspaces with 403", async () => {

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -86,6 +86,21 @@ describe("auth middleware gates", () => {
     });
   });
 
+  it("does not let an admin workspace membership access the dev workspace", async () => {
+    const middleware = createAuthMiddleware();
+    const app = createGateApp(createAuthContext("admin", "admin"), middleware.requireWorkspaceUser);
+
+    const res = await app.request("/protected", {
+      headers: { "X-Workspace-Slug": "dev" },
+    });
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      success: false,
+      error: "Workspace access required",
+    });
+  });
+
   it("allows a workspace user member on the selected workspace", async () => {
     const middleware = createAuthMiddleware();
     const app = createGateApp(createAuthContext("user", "hr"), middleware.requireWorkspaceUser);

--- a/apps/api/src/middleware/workspace.test.ts
+++ b/apps/api/src/middleware/workspace.test.ts
@@ -38,6 +38,7 @@ describe("workspaceMiddleware", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.workspaceSlug).toBe("dev");
+    expect(body.accessLevel).toBe("user");
   });
 
   it("uses workspace from X-Workspace-Slug header", async () => {
@@ -115,12 +116,23 @@ describe("workspaceMiddleware", () => {
 // ---------------------------------------------------------------------------
 
 describe("requireAdmin", () => {
-  it("allows admin workspace (dev)", async () => {
+  it("allows admin workspace", async () => {
+    const app = createAdminApp();
+    const res = await app.request("/admin", {
+      headers: { "X-Workspace-Slug": "admin" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects dev workspace because it is not the admin workspace", async () => {
     const app = createAdminApp();
     const res = await app.request("/admin", {
       headers: { "X-Workspace-Slug": "dev" },
     });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toContain("Admin access required");
   });
 
   it("rejects non-admin workspace (hr)", async () => {
@@ -137,8 +149,7 @@ describe("requireAdmin", () => {
   it("rejects request without workspace middleware (undefined accessLevel)", async () => {
     const app = createAdminApp();
     const res = await app.request("/admin");
-    // Default workspace is dev (admin), so this should pass
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(403);
   });
 });
 

--- a/apps/api/src/services/auth-storage.ts
+++ b/apps/api/src/services/auth-storage.ts
@@ -693,6 +693,16 @@ export class AuthStorage {
     `).run(input.userId, input.workspaceSlug, input.role, now, now);
   }
 
+  replaceMemberships(userId: string, memberships: readonly Omit<WorkspaceMembership, "userId">[]): void {
+    const replace = this.db.transaction(() => {
+      this.db.prepare("DELETE FROM workspace_memberships WHERE user_id = ?").run(userId);
+      for (const membership of memberships) {
+        this.upsertMembership({ userId, ...membership });
+      }
+    });
+    replace();
+  }
+
   listMemberships(userId: string): WorkspaceMembership[] {
     const rows = this.db.prepare(`
       SELECT user_id, workspace_slug, role

--- a/apps/web/e2e/provider-membership-admin.spec.ts
+++ b/apps/web/e2e/provider-membership-admin.spec.ts
@@ -89,7 +89,7 @@ const users: Record<UserKind, AuthUser> = {
 }
 
 const memberships: Record<UserKind, WorkspaceMembership[]> = {
-  admin: [{ userId: users.admin.id, workspaceSlug: 'dev', role: 'admin' }],
+  admin: [{ userId: users.admin.id, workspaceSlug: 'admin', role: 'admin' }],
   hr: [{ userId: users.hr.id, workspaceSlug: 'hr', role: 'user' }],
 }
 
@@ -482,7 +482,8 @@ async function installProviderMembershipApi(page: Page) {
 }
 
 async function signIn(page: Page, username: string, password: string, redirectTo: string) {
-  await page.goto(`/dev/login?redirectTo=${encodeURIComponent(redirectTo)}`)
+  const loginWorkspace = redirectTo.startsWith('/admin/') ? 'admin' : 'dev'
+  await page.goto(`/${loginWorkspace}/login?redirectTo=${encodeURIComponent(redirectTo)}`)
   await page.getByLabel('Username').fill(username)
   await page.getByLabel('Password').fill(password)
   await page.getByRole('button', { name: 'Sign in' }).click()
@@ -493,7 +494,7 @@ test.describe('Provider membership admin page', () => {
   test('admin can operate provider membership grants and revocations', async ({ page }) => {
     const api = await installProviderMembershipApi(page)
 
-    await signIn(page, 'admin-e2e', 'admin-secret', '/dev/system/settings/auth')
+    await signIn(page, 'admin-e2e', 'admin-secret', '/admin/system/settings/auth')
     const consoleProblems = collectConsoleProblems(page)
     await page.reload()
 
@@ -550,7 +551,7 @@ test.describe('Provider membership admin page', () => {
   test('HR user cannot operate provider membership admin page or endpoints', async ({ page }) => {
     const api = await installProviderMembershipApi(page)
 
-    await signIn(page, 'hr-e2e', 'hr-secret', '/dev/system/settings/auth')
+    await signIn(page, 'hr-e2e', 'hr-secret', '/admin/system/settings/auth')
 
     await expect(page.getByText('Admin access required')).toBeVisible()
     await expect(page.getByTestId('auth-preapprove-submit')).toHaveCount(0)
@@ -560,7 +561,7 @@ test.describe('Provider membership admin page', () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'X-Workspace-Slug': 'dev',
+          'X-Workspace-Slug': 'admin',
         },
         body: JSON.stringify({
           provider: 'casdoor',

--- a/apps/web/src/components/Header.test.tsx
+++ b/apps/web/src/components/Header.test.tsx
@@ -6,7 +6,7 @@ import { Header } from './Header'
 const mockState = vi.hoisted(() => ({
   slug: 'dev',
   name: 'Development',
-  isAdmin: true,
+  isAdmin: false,
 }))
 
 function renderMockLink(
@@ -95,7 +95,7 @@ describe('Header', () => {
   beforeEach(() => {
     mockState.slug = 'dev'
     mockState.name = 'Development'
-    mockState.isAdmin = true
+    mockState.isAdmin = false
     featureFlagsMock.reviewPacketsEnabled = true
   })
 
@@ -115,26 +115,30 @@ describe('Header', () => {
   })
 
   it('does not attach resume reset state to review packets, settings, or system links', () => {
+    mockState.slug = 'admin'
+    mockState.name = 'Admin'
+    mockState.isAdmin = true
+
     render(<Header />)
 
     const reviewPacketLinks = screen.getAllByRole('link', { name: 'Review packets' })
     expect(reviewPacketLinks).toHaveLength(2)
     reviewPacketLinks.forEach((link) => {
-      expect(link).toHaveAttribute('href', '/dev/review-packets')
+      expect(link).toHaveAttribute('href', '/admin/review-packets')
       expect(link).toHaveAttribute('data-reset', 'false')
     })
 
     const settingsLinks = screen.getAllByRole('link', { name: 'Settings' })
     expect(settingsLinks).toHaveLength(2)
     settingsLinks.forEach((link) => {
-      expect(link).toHaveAttribute('href', '/dev/settings')
+      expect(link).toHaveAttribute('href', '/admin/settings')
       expect(link).toHaveAttribute('data-reset', 'false')
     })
 
     const systemLinks = screen.getAllByRole('link', { name: 'System from i18n' })
     expect(systemLinks).toHaveLength(2)
     systemLinks.forEach((link) => {
-      expect(link).toHaveAttribute('href', '/dev/system')
+      expect(link).toHaveAttribute('href', '/admin/system')
       expect(link).toHaveAttribute('data-reset', 'false')
     })
   })

--- a/apps/web/src/components/JobDescriptionSelect.test.tsx
+++ b/apps/web/src/components/JobDescriptionSelect.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@/lib/api-helpers', () => ({
 }))
 
 vi.mock('@/contexts/WorkspaceContext', () => ({
-  useWorkspace: () => ({ slug: 'dev', name: 'Dev', accessLevel: 'admin', isAdmin: true }),
+  useWorkspace: () => ({ slug: 'admin', name: 'Admin', accessLevel: 'admin', isAdmin: true }),
 }))
 
 import { JobDescriptionSelect } from '@/components/JobDescriptionSelect'
@@ -93,7 +93,7 @@ describe('JobDescriptionSelect', () => {
     renderWithRouter(<JobDescriptionSelect {...defaultProps} value="jd-1" />)
 
     const link = screen.getByRole('link')
-    expect(link).toHaveAttribute('href', '/dev/system/jds')
+    expect(link).toHaveAttribute('href', '/admin/system/jds')
   })
 
   it('does not show external link when no value', () => {

--- a/apps/web/src/components/SidebarResetNavigation.test.tsx
+++ b/apps/web/src/components/SidebarResetNavigation.test.tsx
@@ -112,12 +112,13 @@ describe('Sidebar reset navigation', () => {
   })
 
   it('attaches resume reset state to system sidebar home links only', () => {
-    mockState.pathname = '/dev/system/settings'
+    mockState.pathname = '/admin/system/settings'
+    mockState.slug = 'admin'
 
     const { container } = render(<SystemSidebar />)
 
-    expectResetLinks(container, '/dev/resumes', 2)
-    expectPlainLink(container, '/dev/system/settings')
-    expectPlainLink(container, '/dev/system/jds')
+    expectResetLinks(container, '/admin/resumes', 2)
+    expectPlainLink(container, '/admin/system/settings')
+    expectPlainLink(container, '/admin/system/jds')
   })
 })

--- a/apps/web/src/components/SystemSidebar.test.tsx
+++ b/apps/web/src/components/SystemSidebar.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 
 vi.mock('@/contexts/WorkspaceContext', () => ({
-  useWorkspace: () => ({ slug: 'dev', name: 'Dev', accessLevel: 'admin', isAdmin: true }),
+  useWorkspace: () => ({ slug: 'admin', name: 'Admin', accessLevel: 'admin', isAdmin: true }),
 }))
 
 vi.mock('@/hooks/useSystemMetadata', () => ({
@@ -21,7 +21,7 @@ vi.mock('@trends/shared', () => ({
 
 import { SystemSidebar } from '@/components/SystemSidebar'
 
-function renderWithRouter(ui: React.ReactElement, path = '/dev/resumes') {
+function renderWithRouter(ui: React.ReactElement, path = '/admin/resumes') {
   return render(<MemoryRouter initialEntries={[path]}>{ui}</MemoryRouter>)
 }
 
@@ -40,7 +40,7 @@ describe('SystemSidebar', () => {
   })
 
   it('highlights active navigation item', () => {
-    renderWithRouter(<SystemSidebar />, '/dev/system/settings')
+    renderWithRouter(<SystemSidebar />, '/admin/system/settings')
     const settingsLink = screen.getByText('Settings').closest('a')
     expect(settingsLink?.className).toContain('bg-primary/10')
   })

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -6,7 +6,7 @@ type AuthState = {
   workspaceRole: WorkspaceRole | null
   isAuthenticated: boolean
   isLoading: boolean
-  login: (username: string, password: string) => Promise<boolean>
+  login: (username: string, password: string) => Promise<CurrentAuth | null>
   logout: () => Promise<void>
   refresh: () => Promise<void>
 }
@@ -16,7 +16,7 @@ const AuthContext = createContext<AuthState>({
   workspaceRole: null,
   isAuthenticated: false,
   isLoading: true,
-  login: async () => false,
+  login: async () => null,
   logout: async () => {},
   refresh: async () => {},
 })
@@ -39,14 +39,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     void refresh()
   }, [refresh])
 
-  const login = useCallback(async (username: string, password: string): Promise<boolean> => {
+  const login = useCallback(async (username: string, password: string): Promise<CurrentAuth | null> => {
     const result = await loginWithLocalPassword(username, password)
-    if (result?.success) {
-      await refresh()
-      return true
+    if (!result?.success) {
+      return null
     }
-    return false
-  }, [refresh])
+
+    const refreshed = await fetchCurrentAuth()
+    if (refreshed) {
+      setAuth(refreshed)
+      setIsLoading(false)
+      return refreshed
+    }
+
+    const fallback: CurrentAuth = {
+      success: true,
+      user: result.user,
+      memberships: result.memberships,
+      workspaceRole: null,
+    }
+    setAuth(fallback)
+    setIsLoading(false)
+    return fallback
+  }, [])
 
   const logout = useCallback(async () => {
     await logoutApi()

--- a/apps/web/src/contexts/WorkspaceContext.test.tsx
+++ b/apps/web/src/contexts/WorkspaceContext.test.tsx
@@ -17,10 +17,11 @@ vi.mock('react-router-dom', () => ({
 
 vi.mock('@trends/shared', () => ({
   WORKSPACE_TEAMS: {
-    dev: { name: 'Development', accessLevel: 'admin' },
-    prod: { name: 'Production', accessLevel: 'member' },
+    admin: { name: 'Admin', accessLevel: 'admin' },
+    dev: { name: 'Development', accessLevel: 'user' },
+    hr: { name: 'HR Team', accessLevel: 'user' },
   },
-  isValidWorkspace: (s: string) => s === 'dev' || s === 'prod',
+  isValidWorkspace: (s: string) => s === 'admin' || s === 'dev' || s === 'hr',
 }))
 
 import { WorkspaceProvider, useWorkspace } from '@/contexts/WorkspaceContext'
@@ -39,14 +40,14 @@ function renderWithProvider(slug: string | undefined, children: ReactNode) {
 describe('WorkspaceProvider', () => {
   beforeEach(() => { vi.clearAllMocks() })
 
-  it('provides context for valid dev slug', () => {
-    renderWithProvider('dev', <TestConsumer />)
-    expect(screen.getByTestId('ws')).toHaveTextContent('dev:Development:admin:true')
+  it('provides context for valid admin slug', () => {
+    renderWithProvider('admin', <TestConsumer />)
+    expect(screen.getByTestId('ws')).toHaveTextContent('admin:Admin:admin:true')
   })
 
-  it('provides context for valid prod slug', () => {
-    renderWithProvider('prod', <TestConsumer />)
-    expect(screen.getByTestId('ws')).toHaveTextContent('prod:Production:member:false')
+  it('provides context for valid dev slug', () => {
+    renderWithProvider('dev', <TestConsumer />)
+    expect(screen.getByTestId('ws')).toHaveTextContent('dev:Development:user:false')
   })
 
   it('redirects for invalid slug', () => {

--- a/apps/web/src/layouts/SystemSettingsLayout.test.tsx
+++ b/apps/web/src/layouts/SystemSettingsLayout.test.tsx
@@ -36,8 +36,8 @@ describe('SystemSettingsLayout', () => {
     mockUseSystemMetadata.mockReturnValue({
       navigation: {
         systemSettings: [
-          { id: 'overview', titleKey: 'tabs.overview', defaultTitle: 'Overview', href: '/dev/system' },
-          { id: 'config', titleKey: 'tabs.config', defaultTitle: 'Config Sources', href: '/dev/system/config' },
+          { id: 'overview', titleKey: 'tabs.overview', defaultTitle: 'Overview', href: '/admin/system' },
+          { id: 'config', titleKey: 'tabs.config', defaultTitle: 'Config Sources', href: '/admin/system/config' },
         ],
       },
     })
@@ -65,7 +65,7 @@ describe('SystemSettingsLayout', () => {
     expect(links).toHaveLength(2)
     expect(links[0]).toHaveTextContent('Overview')
     expect(links[1]).toHaveTextContent('Config Sources')
-    expect(links[0]).toHaveAttribute('href', '/dev/system')
+    expect(links[0]).toHaveAttribute('href', '/admin/system')
   })
 
   it('renders outlet for child routes', () => {

--- a/apps/web/src/pages/DebugConfig.test.tsx
+++ b/apps/web/src/pages/DebugConfig.test.tsx
@@ -277,7 +277,7 @@ describe('System settings routes', () => {
   })
 
   it('renders the overview hub with local settings navigation', () => {
-    renderSettingsRoute('/dev/system/settings')
+    renderSettingsRoute('/admin/system/settings')
 
     expect(screen.getByText('Settings overview')).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Open each system settings area in its own page.' })).toBeInTheDocument()
@@ -288,14 +288,14 @@ describe('System settings routes', () => {
   })
 
   it('loads config-source details on the config sources route', async () => {
-    renderSettingsRoute('/dev/system/settings/config-sources')
+    renderSettingsRoute('/admin/system/settings/config-sources')
 
     expect(await screen.findByText('Canonical resume AI prompt source')).toBeInTheDocument()
     expect(screen.getAllByText('config/resume/ai-prompts.md').length).toBeGreaterThan(0)
   })
 
   it('renders the dedicated locations page without keyword or config source sections', async () => {
-    renderSettingsRoute('/dev/system/settings/locations')
+    renderSettingsRoute('/admin/system/settings/locations')
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'System location config' })).toBeInTheDocument()
@@ -308,7 +308,7 @@ describe('System settings routes', () => {
   })
 
   it('renders the keywords route with editable and derived keyword data', async () => {
-    renderSettingsRoute('/dev/system/settings/keywords')
+    renderSettingsRoute('/admin/system/settings/keywords')
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Keywords' })).toBeInTheDocument()
@@ -320,7 +320,7 @@ describe('System settings routes', () => {
   })
 
   it('routes landing quick-start ownership to search profiles from the keywords page', async () => {
-    renderSettingsRoute('/dev/system/settings/keywords')
+    renderSettingsRoute('/admin/system/settings/keywords')
 
     await waitFor(() => {
       expect(screen.getByText('Landing quick starts')).toBeInTheDocument()

--- a/apps/web/src/pages/LoginPage.test.tsx
+++ b/apps/web/src/pages/LoginPage.test.tsx
@@ -6,6 +6,18 @@ const mockNavigate = vi.fn()
 const mockSearchParams = new URLSearchParams()
 const mockLogin = vi.fn()
 
+function loginResult(workspaceSlug: string, role: 'user' | 'admin' = 'user') {
+  return {
+    success: true,
+    user: {
+      id: `${workspaceSlug}-${role}`,
+      status: 'active',
+    },
+    memberships: [{ userId: `${workspaceSlug}-${role}`, workspaceSlug, role }],
+    workspaceRole: role,
+  }
+}
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key,
@@ -42,7 +54,7 @@ describe('LoginPage', () => {
   })
 
   it('submits credentials and navigates to default path on success', async () => {
-    mockLogin.mockResolvedValueOnce(true)
+    mockLogin.mockResolvedValueOnce(loginResult('dev', 'user'))
     const user = userEvent.setup()
 
     render(<LoginPage />)
@@ -55,9 +67,22 @@ describe('LoginPage', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/dev/resumes', { replace: true })
   })
 
+  it('routes an admin-only login to the admin auth settings page by default', async () => {
+    mockLogin.mockResolvedValueOnce(loginResult('admin', 'admin'))
+    const user = userEvent.setup()
+
+    render(<LoginPage />)
+
+    await user.type(screen.getByLabelText(/username/i), 'demo-admin')
+    await user.type(screen.getByLabelText(/password/i), 'demo-admin')
+    await user.click(screen.getByRole('button', { name: /sign in/i }))
+
+    expect(mockNavigate).toHaveBeenCalledWith('/admin/system/settings/auth', { replace: true })
+  })
+
   it('navigates to redirectTo path on success', async () => {
     mockSearchParams.set('redirectTo', '/dev/settings')
-    mockLogin.mockResolvedValueOnce(true)
+    mockLogin.mockResolvedValueOnce(loginResult('admin', 'admin'))
     const user = userEvent.setup()
 
     render(<LoginPage />)
@@ -70,7 +95,7 @@ describe('LoginPage', () => {
   })
 
   it('shows error message on login failure', async () => {
-    mockLogin.mockResolvedValueOnce(false)
+    mockLogin.mockResolvedValueOnce(null)
     const user = userEvent.setup()
 
     render(<LoginPage />)
@@ -84,8 +109,8 @@ describe('LoginPage', () => {
   })
 
   it('disables form fields while submitting', async () => {
-    let resolveLogin: (value: boolean) => void
-    mockLogin.mockImplementationOnce(() => new Promise<boolean>((resolve) => { resolveLogin = resolve }))
+    let resolveLogin: (value: ReturnType<typeof loginResult>) => void
+    mockLogin.mockImplementationOnce(() => new Promise<ReturnType<typeof loginResult>>((resolve) => { resolveLogin = resolve }))
     const user = userEvent.setup()
 
     render(<LoginPage />)
@@ -98,6 +123,6 @@ describe('LoginPage', () => {
     expect(screen.getByLabelText(/password/i)).toBeDisabled()
     expect(screen.getByRole('button', { name: /signing in/i })).toBeDisabled()
 
-    resolveLogin!(true)
+    resolveLogin!(loginResult('dev', 'user'))
   })
 })

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -5,6 +5,23 @@ import { useAuth } from '@/contexts/AuthContext'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import type { CurrentAuth } from '@/lib/auth'
+
+function getDefaultRedirect(auth: CurrentAuth, fallbackWorkspaceSlug: string): string {
+  const adminMembership = auth.memberships.find(
+    (membership) => membership.workspaceSlug === 'admin' && membership.role === 'admin',
+  )
+  if (adminMembership) {
+    return '/admin/system/settings/auth'
+  }
+
+  const firstMembership = auth.memberships[0]
+  if (firstMembership) {
+    return `/${firstMembership.workspaceSlug}/resumes`
+  }
+
+  return `/${fallbackWorkspaceSlug}/resumes`
+}
 
 export function LoginPage() {
   const { t } = useTranslation()
@@ -12,7 +29,7 @@ export function LoginPage() {
   const { slug } = useWorkspace()
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
-  const redirectTo = searchParams.get('redirectTo') || `/${slug}/resumes`
+  const explicitRedirectTo = searchParams.get('redirectTo')
 
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
@@ -24,9 +41,9 @@ export function LoginPage() {
     setError(null)
     setIsSubmitting(true)
 
-    const success = await login(username, password)
-    if (success) {
-      navigate(redirectTo, { replace: true })
+    const result = await login(username, password)
+    if (result) {
+      navigate(explicitRedirectTo || getDefaultRedirect(result, slug), { replace: true })
     } else {
       setError(t('auth.loginFailed', { defaultValue: 'Invalid username or password' }))
     }

--- a/apps/web/src/pages/SummaryRunsPage.test.tsx
+++ b/apps/web/src/pages/SummaryRunsPage.test.tsx
@@ -136,7 +136,7 @@ type SummaryProfile = {
 
 function renderSummaryRunsPage() {
   return render(
-    <MemoryRouter initialEntries={['/dev/system/summaries']}>
+    <MemoryRouter initialEntries={['/admin/system/summaries']}>
       <Routes>
         <Route path="/:teamSlug/system/summaries" element={<SummaryRunsPage />} />
       </Routes>
@@ -602,7 +602,7 @@ describe('SummaryRunsPage', () => {
     expect(await screen.findByText('Summary profiles')).toBeInTheDocument()
     expect(screen.getByText('Changes apply after the next worker restart.')).toBeInTheDocument()
     expect(screen.getByText('Runtime updates can take a few seconds after save. After restart, confirm the rebuilt job in worker status.')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Open worker status' })).toHaveAttribute('href', '/dev/system/settings/operations')
+    expect(screen.getByRole('link', { name: 'Open worker status' })).toHaveAttribute('href', '/admin/system/settings/operations')
     expect(screen.getByDisplayValue('daily-ops')).toBeDisabled()
     expect(screen.getByDisplayValue('Daily Ops')).toBeInTheDocument()
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "verify:critical-path": "tsx scripts/verify-critical-path.ts",
     "verify:workflow-dataset": "tsx scripts/resume/verify-workflow-dataset.ts",
     "clear:workspace-demo-resumes": "tsx scripts/resume/clear-workspace-demo-resumes.ts",
-    "auth:bootstrap-demo": "tsx scripts/auth/manage-user.ts --username demo-admin --email demo-admin@example.com --display-name \"Demo Admin\" --workspace dev --role admin --password-env AUTH_BOOTSTRAP_PASSWORD --output json",
+    "auth:bootstrap-demo": "tsx scripts/auth/manage-user.ts --username demo-admin --email demo-admin@example.com --display-name \"Demo Admin\" --workspace admin --role admin --replace-memberships --password-env AUTH_BOOTSTRAP_PASSWORD --output json",
     "verify:industry-scores": "tsx scripts/verify-industry-scores.ts",
     "verify:industry-scores:round-trip": "tsx scripts/verify-industry-scores.ts --sample sample-job5156-detail-enriched --round-trip",
     "e2e": "tsx scripts/e2e-smoke.ts"

--- a/packages/shared/src/workspace.test.ts
+++ b/packages/shared/src/workspace.test.ts
@@ -2,18 +2,18 @@ import { describe, expect, it } from 'vitest'
 import { isValidWorkspace, getAccessLevel, WORKSPACE_TEAMS, formatWorkspaceSlugList, listWorkspaceSlugs } from './workspace'
 
 describe('WORKSPACE_TEAMS', () => {
-  it('has dev and hr teams', () => {
-    expect(Object.keys(WORKSPACE_TEAMS)).toEqual(['dev', 'hr'])
+  it('has admin, dev, and hr teams', () => {
+    expect(Object.keys(WORKSPACE_TEAMS)).toEqual(['admin', 'dev', 'hr'])
   })
 })
 
 describe('workspace registry helpers', () => {
   it('lists registered workspace slugs in registry order', () => {
-    expect(listWorkspaceSlugs()).toEqual(['dev', 'hr'])
+    expect(listWorkspaceSlugs()).toEqual(['admin', 'dev', 'hr'])
   })
 
   it('formats registered workspace slugs for consumer error messages', () => {
-    expect(formatWorkspaceSlugList()).toBe('dev, hr')
+    expect(formatWorkspaceSlugList()).toBe('admin, dev, hr')
   })
 
   it('keeps the helper list aligned with validation and access levels', () => {
@@ -25,6 +25,10 @@ describe('workspace registry helpers', () => {
 })
 
 describe('isValidWorkspace', () => {
+  it('returns true for admin', () => {
+    expect(isValidWorkspace('admin')).toBe(true)
+  })
+
   it('returns true for dev', () => {
     expect(isValidWorkspace('dev')).toBe(true)
   })
@@ -48,8 +52,12 @@ describe('isValidWorkspace', () => {
 })
 
 describe('getAccessLevel', () => {
-  it('returns admin for dev', () => {
-    expect(getAccessLevel('dev')).toBe('admin')
+  it('returns admin for admin', () => {
+    expect(getAccessLevel('admin')).toBe('admin')
+  })
+
+  it('returns user for dev', () => {
+    expect(getAccessLevel('dev')).toBe('user')
   })
 
   it('returns user for hr', () => {

--- a/packages/shared/src/workspace.ts
+++ b/packages/shared/src/workspace.ts
@@ -1,5 +1,6 @@
 export const WORKSPACE_TEAMS = {
-  dev: { name: "Development", accessLevel: "admin" as const },
+  admin: { name: "Admin", accessLevel: "admin" as const },
+  dev: { name: "Development", accessLevel: "user" as const },
   hr: { name: "HR Team", accessLevel: "user" as const },
 } as const;
 

--- a/scripts/auth/manage-user.test.ts
+++ b/scripts/auth/manage-user.test.ts
@@ -181,9 +181,10 @@ describe("manage-user bootstrap logic", () => {
         "--display-name",
         "Demo Admin",
         "--workspace",
-        "dev",
+        "admin",
         "--role",
         "admin",
+        "--replace-memberships",
         "--password-env",
         "AUTH_BOOTSTRAP_PASSWORD",
         "--output",
@@ -208,8 +209,65 @@ describe("manage-user bootstrap logic", () => {
     const identity = storage.findIdentity("local", "demo-admin", "local");
     expect(identity).not.toBeNull();
 
+    const memberships = storage.listMemberships(identity!.userId);
+    expect(memberships).toEqual([{ userId: identity!.userId, workspaceSlug: "admin", role: "admin" }]);
+
     const credential = storage.findPasswordCredential(identity!.userId);
     expect(credential).not.toBeNull();
     expect(await verifyPassword("demo-admin", credential!)).toBe(true);
+  });
+
+  it("replaces legacy demo-admin workspace memberships when requested", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-manage-user-replace-"));
+    const storage = new AuthStorage(root);
+    const user = storage.createUser({
+      email: "demo-admin@example.com",
+      displayName: "Demo Admin",
+    });
+    storage.linkIdentity({
+      userId: user.id,
+      provider: "local",
+      providerSubject: "demo-admin",
+      providerTenant: "local",
+      email: "demo-admin@example.com",
+      displayName: "Demo Admin",
+    });
+    storage.upsertMembership({ userId: user.id, workspaceSlug: "dev", role: "admin" });
+
+    const result = spawnSync(
+      "node",
+      [
+        "--import",
+        "tsx",
+        manageUserScript,
+        "--username",
+        "demo-admin",
+        "--email",
+        "demo-admin@example.com",
+        "--display-name",
+        "Demo Admin",
+        "--workspace",
+        "admin",
+        "--role",
+        "admin",
+        "--replace-memberships",
+        "--no-password",
+        "--output",
+        "json",
+      ],
+      {
+        cwd: repoRoot,
+        env: { ...process.env, PROJECT_ROOT: root },
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status).toBe(0);
+    const output = JSON.parse(result.stdout) as { success: boolean; totalMemberships: number };
+    expect(output.success).toBe(true);
+    expect(output.totalMemberships).toBe(1);
+    expect(storage.listMemberships(user.id)).toEqual([
+      { userId: user.id, workspaceSlug: "admin", role: "admin" },
+    ]);
   });
 });

--- a/scripts/auth/manage-user.ts
+++ b/scripts/auth/manage-user.ts
@@ -28,6 +28,7 @@ type Args = {
   passwordEnv?: string;
   passwordStdin: boolean;
   noPassword: boolean;
+  replaceMemberships: boolean;
   dryRun: boolean;
   output: "json" | "agent";
 };
@@ -39,6 +40,7 @@ function parseArgs(argv: string[]): Args {
     role: "user",
     passwordStdin: false,
     noPassword: false,
+    replaceMemberships: false,
     dryRun: false,
     output: "json",
   };
@@ -69,6 +71,9 @@ function parseArgs(argv: string[]): Args {
         break;
       case "--no-password":
         args.noPassword = true;
+        break;
+      case "--replace-memberships":
+        args.replaceMemberships = true;
         break;
       case "--dry-run":
         args.dryRun = true;
@@ -255,6 +260,7 @@ async function main() {
       displayName: args.displayName,
       workspace: args.workspace,
       role: args.role,
+      replaceMemberships: args.replaceMemberships,
       passwordProvided: password !== null,
     };
     console.log(JSON.stringify(output, null, 2));
@@ -301,11 +307,15 @@ async function main() {
   const existingMembership = storage.listMemberships(userId).find(
     (m) => m.workspaceSlug === args.workspace,
   );
-  storage.upsertMembership({
-    userId,
-    workspaceSlug: args.workspace,
-    role: args.role,
-  });
+  const membership = { workspaceSlug: args.workspace, role: args.role };
+  if (args.replaceMemberships) {
+    storage.replaceMemberships(userId, [membership]);
+  } else {
+    storage.upsertMembership({
+      userId,
+      ...membership,
+    });
+  }
 
   const memberships = storage.listMemberships(userId);
 

--- a/scripts/e2e-smoke.ts
+++ b/scripts/e2e-smoke.ts
@@ -257,7 +257,7 @@ async function runCollectionTest(page: Page) {
     // Set up CWV observers before navigation
     const vitals = await measureWebVitals(page);
 
-    await page.goto(`${DEFAULT_OPTIONS.baseUrl}/dev/system/settings/operations`);
+    await page.goto(`${DEFAULT_OPTIONS.baseUrl}/admin/system/settings/operations`);
 
     const keywordInput = await preferVisibleLocator(
         page.getByTestId('ops-collection-keyword'),

--- a/scripts/repo-workflow-entrypoints.test.ts
+++ b/scripts/repo-workflow-entrypoints.test.ts
@@ -30,7 +30,7 @@ describe("workflow verifier repo entrypoints", () => {
 
   it("exposes the reusable local demo auth bootstrap script through package.json", () => {
     expect(packageJson.scripts?.["auth:bootstrap-demo"]).toBe(
-      'tsx scripts/auth/manage-user.ts --username demo-admin --email demo-admin@example.com --display-name "Demo Admin" --workspace dev --role admin --password-env AUTH_BOOTSTRAP_PASSWORD --output json',
+      'tsx scripts/auth/manage-user.ts --username demo-admin --email demo-admin@example.com --display-name "Demo Admin" --workspace admin --role admin --replace-memberships --password-env AUTH_BOOTSTRAP_PASSWORD --output json',
     );
   });
 


### PR DESCRIPTION
$## Summary\n- add a dedicated admin workspace and demote dev to a user/data workspace\n- move demo-admin bootstrap to admin and replace legacy memberships for that demo account\n- make login default routing membership-aware for admin-only users\n\n## Verification\n- make check\n- bunx vitest run packages/shared/src/workspace.test.ts apps/api/src/middleware/workspace.test.ts apps/api/src/middleware/__tests__/middleware.test.ts scripts/repo-workflow-entrypoints.test.ts scripts/auth/manage-user.test.ts apps/api/src/middleware/auth.test.ts\n- npm --workspace @trends/web run test -- src/pages/LoginPage.test.tsx src/contexts/WorkspaceContext.test.tsx src/components/Header.test.tsx src/components/SystemSidebar.test.tsx src/pages/SummaryRunsPage.test.tsx src/pages/DebugConfig.test.tsx src/layouts/SystemSettingsLayout.test.tsx src/components/SidebarResetNavigation.test.tsx src/components/JobDescriptionSelect.test.tsx\n- runtime smoke: make dev + AUTH_BOOTSTRAP_PASSWORD=demo-admin npm run auth:bootstrap-demo + Playwright login to /admin/system/settings/auth with protected dev request returning 403\n\n## Notes\n- make check exits 0 with existing React fast-refresh warnings.