### PR TITLE
Enable shared resume review snapshots

### DIFF
--- a/apps/api/src/routes/public-shares.test.ts
+++ b/apps/api/src/routes/public-shares.test.ts
@@ -72,6 +72,16 @@ type PublicShareReadResponse = {
         results: Array<Record<string, unknown>>;
       };
     };
+    member?: {
+      workspaceSlug: string;
+      canReview: boolean;
+      searchRun: {
+        id: string;
+        resumeKeys: string[];
+        query: Record<string, unknown>;
+        filters: Record<string, unknown>;
+      };
+    };
   };
 };
 
@@ -175,6 +185,84 @@ describe("public share routes", () => {
     expect(readPayload.share.snapshot.payload.results[0]).not.toHaveProperty("actions");
     expect(readPayload.share.snapshot.payload.results[0]).not.toHaveProperty("notes");
     expect(readPayload.share.snapshot.payload.results[0]).not.toHaveProperty("auditLog");
+    expect(readPayload.share).not.toHaveProperty("member");
+  });
+
+  it("exposes search-run resume keys only to authenticated members of the share workspace", async () => {
+    root = createFixtureRoot();
+    const { createApp } = await loadPublicShareModules(root);
+    const adminApp = createApp({ authContext: createAuthContext({ workspaceSlug: "hr", role: "admin" }) });
+    const publicApp = createApp();
+    const memberApp = createApp({ authContext: createAuthContext({ workspaceSlug: "hr", role: "user" }) });
+    const otherWorkspaceApp = createApp({ authContext: createAuthContext({ workspaceSlug: "dev", role: "user" }) });
+
+    const createResponse = await adminApp.request("/api/public-shares", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({
+        title: "China CNC sales snapshot",
+        sessionId: "session-1",
+        search: {
+          query: "CNC 销售 China",
+          filters: {
+            locations: ["China"],
+            minRoleYears: 1,
+            roleFilterType: "sales",
+            minAge: 25,
+            maxAge: 40,
+          },
+        },
+        analysis: {
+          scoringMode: "hybrid",
+          promptVersion: "prompt-v1",
+          skillConfigVersion: "skills-v1",
+          modelProvider: "openai",
+          modelName: "gpt-test",
+        },
+        results: Array.from({ length: 3 }, (_, index) => ({
+          resumeKey: `identity-${index + 1}`,
+          displayName: `Candidate ${index + 1}`,
+        })),
+      }),
+    });
+
+    const createPayload = await createResponse.json() as PublicShareCreateResponse;
+    const token = extractToken(createPayload.share.publicPath);
+
+    const publicResponse = await publicApp.request(`/api/public-shares/${token}`);
+    const publicPayload = await publicResponse.json() as PublicShareReadResponse;
+    expect(publicPayload.share).not.toHaveProperty("member");
+
+    const memberResponse = await memberApp.request(`/api/public-shares/${token}`, {
+      headers: {
+        "X-Workspace-Slug": "dev",
+      },
+    });
+    expect(memberResponse.status).toBe(200);
+    const memberPayload = await memberResponse.json() as PublicShareReadResponse;
+    expect(memberPayload.share.member).toEqual({
+      workspaceSlug: "hr",
+      canReview: true,
+      searchRun: {
+        id: expect.any(String),
+        resumeKeys: ["identity-1", "identity-2", "identity-3"],
+        query: { text: "CNC 销售 China" },
+        filters: {
+          locations: ["China"],
+          minRoleYears: 1,
+          roleFilterType: "sales",
+          minAge: 25,
+          maxAge: 40,
+        },
+      },
+    });
+
+    const otherWorkspaceResponse = await otherWorkspaceApp.request(`/api/public-shares/${token}`);
+    const otherWorkspacePayload = await otherWorkspaceResponse.json() as PublicShareReadResponse;
+    expect(otherWorkspacePayload.share).not.toHaveProperty("member");
   });
 
   it("rejects public share creation when the actor lacks the create scope", async () => {

--- a/apps/api/src/routes/public-shares.ts
+++ b/apps/api/src/routes/public-shares.ts
@@ -82,6 +82,17 @@ const AnalysisSnapshotResponseSchema = z.object({
   createdAt: z.string(),
 });
 
+const PublicShareMemberResponseSchema = z.object({
+  workspaceSlug: z.string(),
+  canReview: z.boolean(),
+  searchRun: z.object({
+    id: z.string(),
+    resumeKeys: z.array(z.string()),
+    query: z.record(z.string(), z.unknown()),
+    filters: z.record(z.string(), z.unknown()),
+  }),
+});
+
 const PublicShareCreateResponseSchema = z.object({
   success: z.literal(true),
   share: z.object({
@@ -104,6 +115,7 @@ const PublicShareReadResponseSchema = z.object({
     createdAt: z.string(),
     expiresAt: z.string().optional(),
     snapshot: AnalysisSnapshotResponseSchema,
+    member: PublicShareMemberResponseSchema.optional(),
   }),
 });
 
@@ -284,6 +296,24 @@ app.openapi(getPublicShareRoute, (c) => {
     },
   });
 
+  const canReadMemberSnapshot = Boolean(
+    lookup.searchRun
+    && c.var.auth
+    && hasWorkspacePermission({
+      auth: c.var.auth,
+      workspaceSlug: lookup.share.workspaceSlug,
+      permission: "resume:search",
+    })
+  );
+  const canReview = Boolean(
+    c.var.auth
+    && hasWorkspacePermission({
+      auth: c.var.auth,
+      workspaceSlug: lookup.share.workspaceSlug,
+      permission: "candidate:mutate",
+    })
+  );
+
   return c.json({
     success: true as const,
     share: {
@@ -304,6 +334,20 @@ app.openapi(getPublicShareRoute, (c) => {
         payload: lookup.snapshot.payload,
         createdAt: lookup.snapshot.createdAt,
       },
+      ...(canReadMemberSnapshot && lookup.searchRun
+        ? {
+          member: {
+            workspaceSlug: lookup.share.workspaceSlug,
+            canReview,
+            searchRun: {
+              id: lookup.searchRun.id,
+              resumeKeys: lookup.searchRun.resumeKeys,
+              query: lookup.searchRun.query,
+              filters: lookup.searchRun.safeFilters,
+            },
+          },
+        }
+        : {}),
     },
   }, 200);
 });

--- a/apps/web/src/components/ResumeList.test.tsx
+++ b/apps/web/src/components/ResumeList.test.tsx
@@ -1,6 +1,11 @@
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ResumeList } from './ResumeList'
+
+const { apiPostMock } = vi.hoisted(() => ({
+  apiPostMock: vi.fn(),
+}))
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -53,6 +58,12 @@ vi.mock('@/hooks/useConvexResumes', () => ({
   useConvexResumeDetail: () => ({ resume: null, loading: false }),
 }))
 
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: {
+    POST: (...args: unknown[]) => apiPostMock(...args),
+  },
+}))
+
 vi.mock('@/lib/resume-scoring', () => ({
   buildResumeKey: (_resume: Record<string, unknown>, idx: number) => `key-${idx}`,
   hasIngestData: () => false,
@@ -99,8 +110,26 @@ vi.mock('@/components/CollectResumesButton', () => ({
 }))
 
 vi.mock('@/components/ShareLinkButton', () => ({
-  ShareLinkButton: () => (
-    <div data-testid="share-link-button" />
+  ShareLinkButton: (props: {
+    shareTitle: string
+    state: unknown
+    createPublicShare?: (options: {
+      shareTitle: string
+      searchState: unknown
+    }) => Promise<unknown>
+  }) => (
+    <button
+      type="button"
+      data-testid="share-link-button"
+      onClick={() => {
+        void props.createPublicShare?.({
+          shareTitle: props.shareTitle,
+          searchState: props.state,
+        })
+      }}
+    >
+      Share
+    </button>
   ),
 }))
 
@@ -197,6 +226,14 @@ describe('ResumeList', () => {
   beforeEach(() => {
     mockResumeListState = { ...baseMockState }
     vi.clearAllMocks()
+    apiPostMock.mockResolvedValue({
+      data: {
+        success: true,
+        share: {
+          publicPath: '/s/public-token-1',
+        },
+      },
+    })
   })
 
   it('renders empty state when no resumes and not loading', () => {
@@ -337,5 +374,61 @@ describe('ResumeList', () => {
   it('renders bulk-action-bar', () => {
     render(<ResumeList />)
     expect(screen.getByTestId('bulk-action-bar')).toBeInTheDocument()
+  })
+
+  it('creates public shares from every loaded displayed resume', async () => {
+    const user = userEvent.setup()
+    mockResumeListState.activeSessionId = 'legacy-session-1'
+    mockResumeListState.shareTitle = 'China · CNC'
+    mockResumeListState.shareState = {
+      location: 'China',
+      keywords: ['CNC'],
+      requiredKeywords: ['销售'],
+      filters: {
+        minRoleYears: 1,
+        roleFilterType: 'sales',
+        minAge: 25,
+        maxAge: 40,
+      },
+    }
+    mockResumeListState.displayedResumes = Array.from({ length: 101 }, (_, index) => ({
+      key: `key-${index + 1}`,
+      identityKey: `identity-${index + 1}`,
+      resume: {
+        name: `Candidate ${index + 1}`,
+        profileUrl: `https://example.com/${index + 1}`,
+        activityStatus: 'Active',
+        age: '30',
+        experience: '5 years',
+        education: 'Bachelor',
+        location: 'China',
+        selfIntro: 'CNC sales',
+        jobIntention: 'Sales',
+        expectedSalary: '10k',
+        workHistory: [],
+        extractedAt: '2026-01-01T00:00:00.000Z',
+      },
+      match: undefined,
+      ruleScore: undefined,
+      action: undefined,
+      blocked: false,
+      status: undefined,
+      statusMeta: undefined,
+      userRating: undefined,
+    })) as unknown as Array<Record<string, unknown>>
+
+    render(<ResumeList />)
+
+    await user.click(screen.getByTestId('share-link-button'))
+
+    await waitFor(() => {
+      expect(apiPostMock).toHaveBeenCalled()
+    })
+    const request = apiPostMock.mock.calls[0]?.[1] as { body: { results: Array<Record<string, unknown>> } } | undefined
+    expect(request?.body.results).toHaveLength(101)
+    expect(request?.body.results[100]).toMatchObject({
+      resumeKey: 'identity-101',
+      displayName: 'Candidate 101',
+    })
   })
 })

--- a/apps/web/src/components/ResumeList.tsx
+++ b/apps/web/src/components/ResumeList.tsx
@@ -241,7 +241,7 @@ export function ResumeList() {
   const createPublicShare = useCallback(async (
     options: CreatePublicShareOptions
   ): Promise<PublicShareCreateResult | undefined> => {
-    const results = displayedResumes.slice(0, 100).map((entry, index) => ({
+    const results = displayedResumes.map((entry, index) => ({
       resumeKey: entry.identityKey || entry.key || buildResumeKey(entry.resume, index),
       displayName: entry.resume.name,
       headline: entry.resume.jobIntention || entry.resume.experience,

--- a/apps/web/src/hooks/useConvexResumes.ts
+++ b/apps/web/src/hooks/useConvexResumes.ts
@@ -127,7 +127,7 @@ export type ConvexResumeItem = ResumeItem & {
   }>
 }
 
-type ResumeListDocLike = {
+export type ResumeListDocLike = {
   _id: Doc<'resumes'>['_id']
   identityKey?: string
   age?: number
@@ -636,7 +636,7 @@ function readMockConvexResumePayload(): MockConvexResumePayload | null {
   return value as MockConvexResumePayload
 }
 
-function mapResumeDoc(doc: ResumeListDocLike): ConvexResumeItem {
+export function mapResumeDoc(doc: ResumeListDocLike): ConvexResumeItem {
   const content = isRecord(doc.content) ? doc.content : {}
   const candidateName = toStringValue(content.name);
   const seekMarket = doc.source?.includes("seek") ? inferSeekMarket(doc.source) : undefined;

--- a/apps/web/src/hooks/useResumeSearchState.ts
+++ b/apps/web/src/hooks/useResumeSearchState.ts
@@ -1965,6 +1965,7 @@ export function useResumeSearchState() {
     queryInput,
     recentSearches,
     results,
+    sessionKey,
     selectedClusterTags,
     selectedRawTags,
     searchHistoryLoading: canLoadOperationalState && recentSearchHistoryRecords === undefined,

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -5723,6 +5723,20 @@ export interface paths {
                                     };
                                     createdAt: string;
                                 };
+                                member?: {
+                                    workspaceSlug: string;
+                                    canReview: boolean;
+                                    searchRun: {
+                                        id: string;
+                                        resumeKeys: string[];
+                                        query: {
+                                            [key: string]: unknown;
+                                        };
+                                        filters: {
+                                            [key: string]: unknown;
+                                        };
+                                    };
+                                };
                             };
                         };
                     };

--- a/apps/web/src/pages/PublicSharePage.test.tsx
+++ b/apps/web/src/pages/PublicSharePage.test.tsx
@@ -1,17 +1,112 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { PublicSharePage } from './PublicSharePage'
+import { workspaceRef } from '@/lib/workspace-ref'
 
-const { apiGetMock } = vi.hoisted(() => ({
+const {
+  apiGetMock,
+  blockCandidatesMock,
+  saveActionMock,
+  unblockCandidateMock,
+  updateStatusMock,
+  useQueryMock,
+} = vi.hoisted(() => ({
   apiGetMock: vi.fn(),
+  blockCandidatesMock: vi.fn(async () => true),
+  saveActionMock: vi.fn(async () => null),
+  unblockCandidateMock: vi.fn(async () => true),
+  updateStatusMock: vi.fn(async () => true),
+  useQueryMock: vi.fn(),
 }))
 
 vi.mock('@/lib/api-helpers', () => ({
   rawApiClient: {
     GET: (...args: unknown[]) => apiGetMock(...args),
   },
+}))
+
+vi.mock('convex/react', () => ({
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+}))
+
+vi.mock('@/hooks/useCandidateStatus', () => ({
+  useCandidateStatus: () => ({
+    statusByIdentity: {
+      'identity-1': {
+        _id: 'status-1',
+        identityKey: 'identity-1',
+        workspaceSlug: 'hr',
+        status: 'contacted',
+        notes: 'Existing note',
+        updatedAt: 1,
+      },
+    },
+    updateStatus: updateStatusMock,
+  }),
+}))
+
+vi.mock('@/hooks/useCandidateActions', () => ({
+  useCandidateActions: () => ({
+    actionsByResume: {
+      'resume-1': 'star',
+    },
+    ratingsByResume: {
+      'resume-1': 4,
+    },
+    saveAction: saveActionMock,
+  }),
+}))
+
+vi.mock('@/hooks/useCandidateBlocks', () => ({
+  useCandidateBlocks: () => ({
+    blocksByIdentity: {},
+    blockCandidates: blockCandidatesMock,
+    unblockCandidate: unblockCandidateMock,
+  }),
+}))
+
+vi.mock('@/components/search/SearchResultsList', () => ({
+  SearchResultsList: ({
+    actionsByResume,
+    items,
+    onAction,
+    onCandidateStatusChange,
+    onRating,
+    onToggleBlock,
+    onToggleSelect,
+    ratingsByResume,
+    selectedIds,
+  }: {
+    actionsByResume?: Record<string, string>
+    items: Array<{ identityKey: string; key: string; resume: { resumeId: string; name: string } }>
+    onAction?: (resumeId: string, action: 'star') => void
+    onCandidateStatusChange?: (identityKey: string, status: 'shortlisted', notes?: string) => void
+    onRating?: (resumeId: string, rating: number) => void
+    onToggleBlock?: (identityKey: string, blocked: boolean, reason?: string) => void
+    onToggleSelect?: (key: string) => void
+    ratingsByResume?: Record<string, number>
+    selectedIds?: Set<string>
+  }) => (
+    <div>
+      <div>
+        Shared Results List {items.length} action:{String(Boolean(onAction))} rating:
+        {String(Boolean(onRating))} status:{String(Boolean(onCandidateStatusChange))} block:
+        {String(Boolean(onToggleBlock))} select:{String(Boolean(onToggleSelect))}
+      </div>
+      <div>First shared candidate {items[0]?.resume.name}</div>
+      <div>First action {actionsByResume?.[items[0]?.resume.resumeId] ?? 'none'}</div>
+      <div>First rating {ratingsByResume?.[items[0]?.resume.resumeId] ?? 'none'}</div>
+      <div>Selected {Array.from(selectedIds ?? new Set()).join('|') || 'none'}</div>
+      <button type="button" onClick={() => onToggleSelect?.(items[0].key)}>Select first</button>
+      <button type="button" onClick={() => onAction?.(items[0].resume.resumeId, 'star')}>Star first</button>
+      <button type="button" onClick={() => onRating?.(items[0].resume.resumeId, 5)}>Rate first</button>
+      <button type="button" onClick={() => onCandidateStatusChange?.(items[0].identityKey, 'shortlisted', 'Shared note')}>Status first</button>
+      <button type="button" onClick={() => onToggleBlock?.(items[0].identityKey, false, 'Duplicate')}>Block first</button>
+    </div>
+  ),
 }))
 
 function renderPublicShare(path = '/s/public-token-1') {
@@ -27,6 +122,12 @@ function renderPublicShare(path = '/s/public-token-1') {
 describe('PublicSharePage', () => {
   beforeEach(() => {
     apiGetMock.mockReset()
+    blockCandidatesMock.mockClear()
+    saveActionMock.mockClear()
+    unblockCandidateMock.mockClear()
+    updateStatusMock.mockClear()
+    useQueryMock.mockReset()
+    workspaceRef.set('dev')
   })
 
   it('fetches and renders a public-safe immutable snapshot', async () => {
@@ -77,6 +178,131 @@ describe('PublicSharePage', () => {
     expect(screen.queryByText(/candidate status/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/actions/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/notes/i)).not.toBeInTheDocument()
+  })
+
+  it('hydrates member-visible shared resume keys and enables review controls', async () => {
+    const user = userEvent.setup()
+    useQueryMock.mockReturnValue([
+      {
+        _id: 'resume-1',
+        identityKey: 'identity-1',
+        externalId: 'resume-1',
+        content: {
+          name: 'Candidate A',
+          location: 'China',
+          experience: '5 years',
+          education: 'Bachelor',
+          extractedAt: '2026-06-12T09:00:00.000Z',
+        },
+        source: 'job5156',
+        tags: [],
+        crawledAt: 1,
+      },
+      {
+        _id: 'resume-2',
+        identityKey: 'identity-2',
+        externalId: 'resume-2',
+        content: {
+          name: 'Candidate B',
+          location: 'China',
+          experience: '3 years',
+          education: 'Bachelor',
+          extractedAt: '2026-06-12T09:01:00.000Z',
+        },
+        source: 'job5156',
+        tags: [],
+        crawledAt: 2,
+      },
+    ])
+    apiGetMock.mockResolvedValue({
+      data: {
+        success: true,
+        share: {
+          title: 'China CNC sales snapshot',
+          createdAt: '2026-06-12T09:00:00.000Z',
+          snapshot: {
+            scoringMode: 'hybrid',
+            promptVersion: 'prompt-v1',
+            skillConfigVersion: 'skills-v1',
+            modelProvider: 'openai',
+            modelName: 'gpt-test',
+            payload: {
+              search: {
+                query: 'CNC 销售 China',
+                filters: {
+                  locations: ['China'],
+                  minRoleYears: 1,
+                  roleFilterType: 'sales',
+                  minAge: 25,
+                  maxAge: 40,
+                },
+              },
+              results: [
+                {
+                  resumeKey: 'identity-1',
+                  displayName: 'Candidate A',
+                  summary: 'Strong CNC sales background',
+                  score: 91,
+                  recommendation: 'strong_match',
+                  highlights: ['CNC'],
+                },
+                {
+                  resumeKey: 'identity-2',
+                  displayName: 'Candidate B',
+                  summary: 'Good territory sales profile',
+                  score: 84,
+                  recommendation: 'match',
+                  highlights: ['Sales'],
+                },
+              ],
+            },
+          },
+          member: {
+            workspaceSlug: 'hr',
+            canReview: true,
+            searchRun: {
+              id: 'run-1',
+              resumeKeys: ['identity-1', 'identity-2'],
+              query: { text: 'CNC 销售 China' },
+              filters: {
+                locations: ['China'],
+                minRoleYears: 1,
+                roleFilterType: 'sales',
+                minAge: 25,
+                maxAge: 40,
+              },
+            },
+          },
+        },
+      },
+    })
+
+    renderPublicShare()
+
+    expect(await screen.findByRole('heading', { name: 'China CNC sales snapshot' })).toBeInTheDocument()
+    expect(screen.getByText('Shared Results List 2 action:true rating:true status:true block:true select:true')).toBeInTheDocument()
+    expect(screen.getByText('First shared candidate Candidate A')).toBeInTheDocument()
+    expect(screen.getByText('First action star')).toBeInTheDocument()
+    expect(screen.getByText('First rating 4')).toBeInTheDocument()
+    expect(workspaceRef.get()).toBe('hr')
+    expect(useQueryMock).toHaveBeenCalledWith(expect.anything(), {
+      identityKeys: ['identity-1', 'identity-2'],
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Select first' }))
+    expect(screen.getByText('Selected identity-1')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Star first' }))
+    expect(saveActionMock).toHaveBeenCalledWith({ resumeId: 'resume-1', actionType: 'star' })
+
+    await user.click(screen.getByRole('button', { name: 'Rate first' }))
+    expect(saveActionMock).toHaveBeenCalledWith({ resumeId: 'resume-1', actionType: 'rating', actionData: { rating: 5 } })
+
+    await user.click(screen.getByRole('button', { name: 'Status first' }))
+    expect(updateStatusMock).toHaveBeenCalledWith('identity-1', 'shortlisted', 'Shared note')
+
+    await user.click(screen.getByRole('button', { name: 'Block first' }))
+    expect(blockCandidatesMock).toHaveBeenCalledWith(['identity-1'], 'Duplicate')
   })
 
   it('shows an unavailable state for revoked or expired tokens', async () => {

--- a/apps/web/src/pages/PublicSharePage.tsx
+++ b/apps/web/src/pages/PublicSharePage.tsx
@@ -1,8 +1,19 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { AlertTriangle, Clock, Search } from 'lucide-react'
+import { useQuery } from 'convex/react'
+import type { WorkspaceSlug } from '@trends/shared'
 
+import { SearchResultsList } from '@/components/search/SearchResultsList'
+import { WorkspaceProvider } from '@/contexts/WorkspaceContext'
+import { useCandidateActions } from '@/hooks/useCandidateActions'
+import { useCandidateBlocks } from '@/hooks/useCandidateBlocks'
+import { useCandidateStatus } from '@/hooks/useCandidateStatus'
+import { mapResumeDoc } from '@/hooks/useConvexResumes'
 import { rawApiClient } from '@/lib/api-helpers'
+import type { ResumeSearchResultItem } from '@/components/search/search-types'
+import type { CandidateActionType, CandidateStatus } from '@/types/resume'
+import { api } from '../../../../packages/convex/convex/_generated/api'
 
 type PublicShareResult = {
   resumeKey: string
@@ -39,6 +50,16 @@ type PublicShareResponse = {
           filters?: Record<string, unknown>
         }
         results: PublicShareResult[]
+      }
+    }
+    member?: {
+      workspaceSlug: string
+      canReview: boolean
+      searchRun: {
+        id: string
+        resumeKeys: string[]
+        query: Record<string, unknown>
+        filters: Record<string, unknown>
       }
     }
   }
@@ -83,6 +104,293 @@ function EmptyPublicShareState({ title, description }: { title: string; descript
         <p className="text-sm leading-6 text-muted-foreground">{description}</p>
       </div>
     </section>
+  )
+}
+
+function buildSnapshotAnalysis(result: PublicShareResult | undefined): ResumeSearchResultItem['analysis'] {
+  if (!result) {
+    return undefined
+  }
+
+  if (
+    typeof result.score !== 'number'
+    && !result.summary
+    && !result.recommendation
+    && !result.highlights?.length
+    && !result.concerns?.length
+  ) {
+    return undefined
+  }
+
+  return {
+    score: result.score ?? 0,
+    summary: result.summary ?? '',
+    highlights: result.highlights ?? [],
+    recommendation: result.recommendation ?? '',
+    concerns: result.concerns,
+  }
+}
+
+function StaticPublicShareResults({ results }: { results: PublicShareResult[] }) {
+  return (
+    <section className="space-y-3">
+      <div className="text-sm font-medium text-foreground">
+        Results
+      </div>
+      {results.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No public results are included in this snapshot.</p>
+      ) : (
+        <div className="divide-y rounded-md border">
+          {results.map((result) => (
+            <article key={result.resumeKey} className="grid gap-3 p-4 md:grid-cols-[1fr_auto]">
+              <div className="space-y-2">
+                <div className="space-y-1">
+                  <h2 className="text-base font-semibold text-foreground">
+                    {result.displayName ?? result.resumeKey}
+                  </h2>
+                  {result.headline && <p className="text-sm text-muted-foreground">{result.headline}</p>}
+                  {result.location && <p className="text-xs text-muted-foreground">{result.location}</p>}
+                </div>
+                {result.summary && <p className="text-sm leading-6 text-foreground">{result.summary}</p>}
+                {result.highlights && result.highlights.length > 0 && (
+                  <div className="flex flex-wrap gap-2">
+                    {result.highlights.map((highlight) => (
+                      <span key={highlight} className="rounded-md bg-muted px-2 py-1 text-xs text-muted-foreground">
+                        {highlight}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+              {typeof result.score === 'number' && (
+                <div className="min-w-16 text-left md:text-right">
+                  <div className="text-2xl font-semibold text-foreground">{result.score}</div>
+                  {result.recommendation && (
+                    <div className="text-xs text-muted-foreground">{result.recommendation}</div>
+                  )}
+                </div>
+              )}
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function MemberPublicShareResults({
+  member,
+  results,
+  searchQuery,
+}: {
+  member: NonNullable<NonNullable<PublicShareResponse['share']>['member']>
+  results: PublicShareResult[]
+  searchQuery?: string
+}) {
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const docs = useQuery(api.resumes.getResumeDocsByIdentityKeys, {
+    identityKeys: member.searchRun.resumeKeys,
+  })
+  const { statusByIdentity, updateStatus } = useCandidateStatus(member.canReview)
+  const { actionsByResume, ratingsByResume, saveAction } = useCandidateActions(
+    member.searchRun.id,
+    undefined,
+    member.canReview,
+  )
+  const { blocksByIdentity, blockCandidates, unblockCandidate } = useCandidateBlocks(member.canReview)
+  const snapshotByKey = useMemo(() => {
+    const map = new Map<string, PublicShareResult>()
+    results.forEach((result) => {
+      map.set(result.resumeKey, result)
+    })
+    return map
+  }, [results])
+
+  const items = useMemo<ResumeSearchResultItem[]>(() => {
+    if (!docs) {
+      return []
+    }
+
+    return docs.map((doc) => {
+      const resume = mapResumeDoc(doc)
+      const identityKey = resume.identityKey?.trim() || String(resume.resumeId)
+      const snapshot = snapshotByKey.get(identityKey) ?? snapshotByKey.get(String(resume.resumeId))
+      const statusMeta = statusByIdentity[identityKey]
+      const block = blocksByIdentity[identityKey]
+      const analysis = buildSnapshotAnalysis(snapshot) ?? resume.analysis
+      const score = typeof snapshot?.score === 'number'
+        ? snapshot.score
+        : typeof analysis?.score === 'number'
+          ? analysis.score
+          : resume.primaryRuleScore
+
+      return {
+        key: identityKey,
+        identityKey,
+        resume,
+        blocked: Boolean(block),
+        analysis,
+        score,
+        scoreSource: typeof snapshot?.score === 'number' || analysis ? 'ai' : 'rule',
+        status: statusMeta?.status ?? 'new',
+        statusMeta,
+      }
+    })
+  }, [blocksByIdentity, docs, snapshotByKey, statusByIdentity])
+
+  const handleToggleExpanded = useCallback((key: string) => {
+    setExpandedIds((current) => {
+      if (current.has(key)) {
+        return new Set()
+      }
+
+      return new Set([key])
+    })
+  }, [])
+
+  const handleToggleSelect = useCallback((key: string) => {
+    setSelectedIds((current) => {
+      const next = new Set(current)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }, [])
+
+  const handleAction = useCallback(
+    (resumeId: string, actionType: CandidateActionType) => {
+      void saveAction({ resumeId, actionType })
+    },
+    [saveAction],
+  )
+
+  const handleRating = useCallback(
+    (resumeId: string, rating: number) => {
+      void saveAction({ resumeId, actionType: 'rating', actionData: { rating } })
+    },
+    [saveAction],
+  )
+
+  const handleCandidateStatusChange = useCallback(
+    (identityKey: string, status: CandidateStatus, notes?: string) => {
+      void updateStatus(identityKey, status, notes)
+    },
+    [updateStatus],
+  )
+
+  const handleToggleBlock = useCallback(
+    (identityKey: string, blocked: boolean, reason?: string) => {
+      if (blocked) {
+        void unblockCandidate(identityKey)
+        return
+      }
+
+      void blockCandidates([identityKey], reason)
+    },
+    [blockCandidates, unblockCandidate],
+  )
+
+  return (
+    <section className="space-y-3">
+      <div className="text-sm font-medium text-foreground">
+        Results
+      </div>
+      <SearchResultsList
+        expandedIds={expandedIds}
+        hasMore={false}
+        items={items}
+        loading={docs === undefined}
+        onLoadMore={() => {}}
+        onToggleExpanded={handleToggleExpanded}
+        selectedIds={selectedIds}
+        actionsByResume={actionsByResume}
+        ratingsByResume={ratingsByResume}
+        onToggleSelect={member.canReview ? handleToggleSelect : undefined}
+        onAction={member.canReview ? handleAction : undefined}
+        onRating={member.canReview ? handleRating : undefined}
+        onCandidateStatusChange={member.canReview ? handleCandidateStatusChange : undefined}
+        onToggleBlock={member.canReview ? handleToggleBlock : undefined}
+        searchQuery={searchQuery}
+        showAiScore
+      />
+    </section>
+  )
+}
+
+function PublicShareReady({ share }: { share: NonNullable<PublicShareResponse['share']> }) {
+  const createdAt = formatDate(share.createdAt)
+  const expiresAt = formatDate(share.expiresAt)
+  const payload = share.snapshot.payload
+  const results = payload.results
+  const filters = payload.search?.filters ? Object.entries(payload.search.filters) : []
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-8 py-6">
+      <header className="space-y-4 border-b pb-6">
+        <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+          <span className="rounded-md border px-2 py-1 font-medium text-foreground">Snapshot</span>
+          {createdAt && (
+            <span className="inline-flex items-center gap-1.5">
+              <Clock className="h-4 w-4" />
+              {createdAt}
+            </span>
+          )}
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+            {share.title ?? payload.title ?? 'Public resume snapshot'}
+          </h1>
+          {share.description && (
+            <p className="max-w-3xl text-sm leading-6 text-muted-foreground">{share.description}</p>
+          )}
+          {expiresAt && (
+            <p className="text-xs text-muted-foreground">Expires {expiresAt}</p>
+          )}
+        </div>
+      </header>
+
+      {(payload.search?.query || filters.length > 0) && (
+        <section className="space-y-3">
+          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+            <Search className="h-4 w-4" />
+            Search
+          </div>
+          {payload.search?.query && (
+            <p className="text-sm text-muted-foreground">{payload.search.query}</p>
+          )}
+          {filters.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {filters.map(([key, value]) => {
+                const label = formatFilterValue(value)
+                return label ? (
+                  <span key={key} className="rounded-md border px-2 py-1 text-xs text-muted-foreground">
+                    {key}: {label}
+                  </span>
+                ) : null
+              })}
+            </div>
+          )}
+        </section>
+      )}
+
+      {share.member ? (
+        <MemberPublicShareResults
+          member={share.member}
+          results={results}
+          searchQuery={payload.search?.query}
+        />
+      ) : (
+        <StaticPublicShareResults results={results} />
+      )}
+
+      <footer className="border-t pt-4 text-xs text-muted-foreground">
+        {share.snapshot.scoringMode} · {share.snapshot.promptVersion} · {share.snapshot.skillConfigVersion}
+      </footer>
+    </div>
   )
 }
 
@@ -165,107 +473,14 @@ export function PublicSharePage() {
   }
 
   const { share } = state
-  const createdAt = formatDate(share.createdAt)
-  const expiresAt = formatDate(share.expiresAt)
-  const payload = share.snapshot.payload
-  const results = payload.results
-  const filters = payload.search?.filters ? Object.entries(payload.search.filters) : []
 
-  return (
-    <div className="mx-auto max-w-6xl space-y-8 py-6">
-      <header className="space-y-4 border-b pb-6">
-        <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-          <span className="rounded-md border px-2 py-1 font-medium text-foreground">Snapshot</span>
-          {createdAt && (
-            <span className="inline-flex items-center gap-1.5">
-              <Clock className="h-4 w-4" />
-              {createdAt}
-            </span>
-          )}
-        </div>
-        <div className="space-y-2">
-          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
-            {share.title ?? payload.title ?? 'Public resume snapshot'}
-          </h1>
-          {share.description && (
-            <p className="max-w-3xl text-sm leading-6 text-muted-foreground">{share.description}</p>
-          )}
-          {expiresAt && (
-            <p className="text-xs text-muted-foreground">Expires {expiresAt}</p>
-          )}
-        </div>
-      </header>
+  if (share.member) {
+    return (
+      <WorkspaceProvider workspaceSlug={share.member.workspaceSlug as WorkspaceSlug} surface="workspace">
+        <PublicShareReady share={share} />
+      </WorkspaceProvider>
+    )
+  }
 
-      {(payload.search?.query || filters.length > 0) && (
-        <section className="space-y-3">
-          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-            <Search className="h-4 w-4" />
-            Search
-          </div>
-          {payload.search?.query && (
-            <p className="text-sm text-muted-foreground">{payload.search.query}</p>
-          )}
-          {filters.length > 0 && (
-            <div className="flex flex-wrap gap-2">
-              {filters.map(([key, value]) => {
-                const label = formatFilterValue(value)
-                return label ? (
-                  <span key={key} className="rounded-md border px-2 py-1 text-xs text-muted-foreground">
-                    {key}: {label}
-                  </span>
-                ) : null
-              })}
-            </div>
-          )}
-        </section>
-      )}
-
-      <section className="space-y-3">
-        <div className="text-sm font-medium text-foreground">
-          Results
-        </div>
-        {results.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No public results are included in this snapshot.</p>
-        ) : (
-          <div className="divide-y rounded-md border">
-            {results.map((result) => (
-              <article key={result.resumeKey} className="grid gap-3 p-4 md:grid-cols-[1fr_auto]">
-                <div className="space-y-2">
-                  <div className="space-y-1">
-                    <h2 className="text-base font-semibold text-foreground">
-                      {result.displayName ?? result.resumeKey}
-                    </h2>
-                    {result.headline && <p className="text-sm text-muted-foreground">{result.headline}</p>}
-                    {result.location && <p className="text-xs text-muted-foreground">{result.location}</p>}
-                  </div>
-                  {result.summary && <p className="text-sm leading-6 text-foreground">{result.summary}</p>}
-                  {result.highlights && result.highlights.length > 0 && (
-                    <div className="flex flex-wrap gap-2">
-                      {result.highlights.map((highlight) => (
-                        <span key={highlight} className="rounded-md bg-muted px-2 py-1 text-xs text-muted-foreground">
-                          {highlight}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                </div>
-                {typeof result.score === 'number' && (
-                  <div className="min-w-16 text-left md:text-right">
-                    <div className="text-2xl font-semibold text-foreground">{result.score}</div>
-                    {result.recommendation && (
-                      <div className="text-xs text-muted-foreground">{result.recommendation}</div>
-                    )}
-                  </div>
-                )}
-              </article>
-            ))}
-          </div>
-        )}
-      </section>
-
-      <footer className="border-t pt-4 text-xs text-muted-foreground">
-        {share.snapshot.scoringMode} · {share.snapshot.promptVersion} · {share.snapshot.skillConfigVersion}
-      </footer>
-    </div>
-  )
+  return <PublicShareReady share={share} />
 }

--- a/apps/web/src/pages/ResumeSearchPage.test.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.test.tsx
@@ -54,10 +54,14 @@ vi.mock('react-i18next', () => ({
 }))
 
 const {
+  apiPostMock,
+  shareLinkButtonPropsMock,
   useIndustryKeywordsMock,
   useAiSearchSummaryMock,
   useResumeSearchStateMock,
 } = vi.hoisted(() => ({
+  apiPostMock: vi.fn(),
+  shareLinkButtonPropsMock: vi.fn(),
   useIndustryKeywordsMock: vi.fn(),
   useAiSearchSummaryMock: vi.fn(),
   useResumeSearchStateMock: vi.fn(),
@@ -85,6 +89,38 @@ vi.mock('@/lib/feature-flags', () => ({
 
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => authMock.value,
+}))
+
+vi.mock('@/lib/api-helpers', () => ({
+  rawApiClient: {
+    POST: (...args: unknown[]) => apiPostMock(...args),
+  },
+}))
+
+vi.mock('@/components/ShareLinkButton', () => ({
+  ShareLinkButton: (props: {
+    shareTitle: string
+    state: unknown
+    createPublicShare?: (options: {
+      shareTitle: string
+      searchState: unknown
+    }) => Promise<unknown>
+  }) => {
+    shareLinkButtonPropsMock(props)
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          void props.createPublicShare?.({
+            shareTitle: props.shareTitle,
+            searchState: props.state,
+          })
+        }}
+      >
+        Create public share
+      </button>
+    )
+  },
 }))
 
 vi.mock('@/hooks/useAiSearchSummary', () => ({
@@ -532,6 +568,7 @@ function createResumeSearchState(overrides: Record<string, unknown> = {}) {
     queryInput: '',
     recentSearches: [],
     searchHistoryLoading: false,
+    sessionKey: 'search-session-1',
     selectedClusterTags: [] as string[],
     selectedRawTags: [] as string[],
     setAiModeEnabled: vi.fn(),
@@ -574,6 +611,14 @@ function createResumeSearchState(overrides: Record<string, unknown> = {}) {
 describe('ResumeSearchPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    apiPostMock.mockResolvedValue({
+      data: {
+        success: true,
+        share: {
+          publicPath: '/s/public-token-1',
+        },
+      },
+    })
     featureFlagsMock.resumeAiSummaryEnabled = false
     authMock.value = {
       user: { id: 'user-1', displayName: 'Tester', status: 'active' },
@@ -1020,6 +1065,79 @@ describe('ResumeSearchPage', () => {
     await user.click(screen.getByRole('button', { name: /Analyze loaded 2/i }))
 
     expect(state.analyzeResults).toHaveBeenCalledTimes(1)
+  })
+
+  it('creates a public share from all loaded filtered search results', async () => {
+    const user = userEvent.setup()
+    const filteredResults = Array.from({ length: 101 }, (_, index) => createResult(index + 1))
+    const state = createResumeSearchState({
+      activeQuery: 'CNC 销售',
+      filteredResults,
+      isLanding: false,
+      parsedState: createParsedState({
+        query: 'CNC 销售',
+        location: 'China',
+        keywords: ['CNC', '销售'],
+        filters: {
+          minRoleYears: 1,
+          roleFilterType: 'sales',
+          minAge: 25,
+          maxAge: 40,
+        },
+      }),
+      queryInput: 'CNC 销售',
+      sessionKey: 'session-china-cnc',
+    })
+    useResumeSearchStateMock.mockReturnValue(state)
+
+    render(<ResumeSearchPage />)
+
+    expect(shareLinkButtonPropsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shareTitle: 'China · CNC 销售',
+        state: expect.objectContaining({
+          location: 'China',
+          keywords: ['CNC', '销售'],
+          filters: expect.objectContaining({
+            minRoleYears: 1,
+            roleFilterType: 'sales',
+            minAge: 25,
+            maxAge: 40,
+          }),
+        }),
+        createPublicShare: expect.any(Function),
+      }),
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Create public share' }))
+
+    expect(apiPostMock).toHaveBeenCalledWith('/api/public-shares', {
+      body: expect.objectContaining({
+        title: 'China · CNC 销售',
+        sessionId: 'session-china-cnc',
+        search: {
+          query: 'CNC 销售 China',
+          filters: {
+            locations: ['China'],
+            minRoleYears: 1,
+            roleFilterType: 'sales',
+            minAge: 25,
+            maxAge: 40,
+          },
+        },
+        results: expect.any(Array),
+      }),
+    })
+    const request = apiPostMock.mock.calls[0]?.[1] as { body: { results: Array<Record<string, unknown>> } } | undefined
+    expect(request?.body.results).toHaveLength(101)
+    expect(request?.body.results[0]).toMatchObject({
+      resumeKey: 'identity-1',
+      displayName: 'Candidate 1',
+    })
+    expect(request?.body.results[100]).toMatchObject({
+      resumeKey: 'identity-101',
+      displayName: 'Candidate 101',
+    })
   })
 
   it('wires the AI mode toggle and keeps the analyze button disabled while original mode is selected', async () => {

--- a/apps/web/src/pages/ResumeSearchPage.tsx
+++ b/apps/web/src/pages/ResumeSearchPage.tsx
@@ -14,12 +14,25 @@ import { MobileFilterSheet } from '@/components/search/MobileFilterSheet'
 import { SearchHeader } from '@/components/search/SearchHeader'
 import { SearchHero } from '@/components/search/SearchHero'
 import { SearchResultsList } from '@/components/search/SearchResultsList'
+import {
+  ShareLinkButton,
+  type CreatePublicShareOptions,
+  type PublicShareCreateResult,
+} from '@/components/ShareLinkButton'
 import { Button } from '@/components/ui/button'
 import { useAiSearchSummary } from '@/hooks/useAiSearchSummary'
 import { useIndustryKeywords } from '@/hooks/useIndustryKeywords'
 import { useResumeSearchState } from '@/hooks/useResumeSearchState'
 import { useAuth } from '@/contexts/AuthContext'
+import { rawApiClient } from '@/lib/api-helpers'
 import { isResumeAiSummaryEnabled } from '@/lib/feature-flags'
+
+type PublicShareCreateResponse = {
+  success: boolean
+  share?: {
+    publicPath?: string
+  }
+}
 
 export function ResumeSearchPage() {
   const { t } = useTranslation()
@@ -54,6 +67,7 @@ export function ResumeSearchPage() {
     parsedState,
     queryInput,
     recentSearches,
+    sessionKey,
     searchHistoryLoading,
     selectedClusterTags,
     selectedRawTags,
@@ -123,6 +137,88 @@ export function ResumeSearchPage() {
     selectedExperienceLevel: parsedState.selectedExperienceLevel,
     results: filteredResults,
   })
+  const shareState = useMemo(() => ({
+    location: parsedState.location,
+    keywords: parsedState.keywords,
+    requiredKeywords: parsedState.requiredKeywords,
+    filters: parsedState.filters,
+    selectedTags: parsedState.selectedTags,
+    selectedCompanies: parsedState.selectedCompanies,
+    selectedExperienceLevel: parsedState.selectedExperienceLevel,
+    jobDescriptionId: parsedState.jobDescriptionId,
+  }), [parsedState])
+  const shareTitle = useMemo(() => {
+    const normalizedLocation = parsedState.location?.trim()
+    const normalizedQuery = (activeQuery ?? queryInput).trim()
+    const title = [normalizedLocation, normalizedQuery]
+      .filter((value): value is string => Boolean(value))
+      .join(' · ')
+    return title || 'Resume search snapshot'
+  }, [activeQuery, parsedState.location, queryInput])
+  const ensureShareSession = useCallback(async () => undefined, [])
+  const createPublicShare = useCallback(async (
+    options: CreatePublicShareOptions,
+  ): Promise<PublicShareCreateResult | undefined> => {
+    if (filteredResults.length === 0) {
+      return undefined
+    }
+
+    const filters = {
+      ...(options.searchState.filters ?? {}),
+      ...(options.searchState.location
+        ? { locations: [options.searchState.location] }
+        : {}),
+    }
+    const query = [
+      ...(options.searchState.keywords ?? []),
+      ...(options.searchState.requiredKeywords ?? []),
+      options.searchState.location,
+    ]
+      .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+      .join(' ')
+
+    const results = filteredResults.map((item) => {
+      const analysis = item.analysis ?? item.resume.analysis
+      return {
+        resumeKey: item.identityKey || item.key || String(item.resume.resumeId),
+        displayName: item.resume.name,
+        headline: item.resume.jobIntention || item.resume.experience,
+        location: item.resume.location,
+        summary: analysis?.summary || item.resume.selfIntro,
+        score: item.score ?? analysis?.score,
+        recommendation: analysis?.recommendation,
+        highlights: analysis?.highlights ?? [],
+        concerns: analysis?.concerns ?? [],
+        skills: item.resume.skills ?? item.resume.tags ?? [],
+      }
+    })
+
+    const { data, error } = await rawApiClient.POST<PublicShareCreateResponse>('/api/public-shares', {
+      body: {
+        title: options.shareTitle,
+        sessionId: sessionKey,
+        search: {
+          query,
+          filters,
+        },
+        analysis: {
+          scoringMode: aiModeEnabled ? 'hybrid' : 'rules_only',
+          promptVersion: 'current',
+          skillConfigVersion: 'current',
+          modelProvider: 'trends',
+          modelName: 'workspace-analysis',
+        },
+        results,
+      },
+    })
+
+    if (error || !data?.success || !data.share?.publicPath) {
+      console.error('Failed to create public share', error ?? data)
+      return undefined
+    }
+
+    return { publicPath: data.share.publicPath }
+  }, [aiModeEnabled, filteredResults, sessionKey])
   const applyExtractedKeywords = (keywords: string[]) => {
     collapseExpandedCards()
     const query = formatKeywordQuery(keywords)
@@ -420,6 +516,12 @@ export function ResumeSearchPage() {
                     )}
                   </Button>
                   <AnalysisTaskMonitor />
+                  <ShareLinkButton
+                    shareTitle={shareTitle}
+                    state={shareState}
+                    ensureApiSession={ensureShareSession}
+                    createPublicShare={canManageCandidateData ? createPublicShare : undefined}
+                  />
                 </div>
               </div>
 

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -231,6 +231,7 @@ export {
     scanResumePageSlim,
     getResumes,
     getResumeDocsByIds,
+    getResumeDocsByIdentityKeys,
     collectSearchIndexDocIds,
     getResumesByIds,
 } from "./resumes_search.js";

--- a/packages/convex/convex/resumes_search.ts
+++ b/packages/convex/convex/resumes_search.ts
@@ -999,6 +999,45 @@ export const getResumeDocsByIds = query({
     },
 });
 
+export const getResumeDocsByIdentityKeys = query({
+    args: {
+        identityKeys: v.array(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const keys = Array.from(
+            new Set(
+                args.identityKeys
+                    .map((key) => key.trim())
+                    .filter((key) => key.length > 0)
+            )
+        ).slice(0, 2000);
+        const docs: Doc<"resumes">[] = [];
+        const seenDocIds = new Set<string>();
+
+        for (const key of keys) {
+            let doc = await ctx.db
+                .query("resumes")
+                .withIndex("by_identityKey", (q) => q.eq("identityKey", key))
+                .order("desc")
+                .first();
+
+            if (!doc) {
+                const resumeId = ctx.db.normalizeId("resumes", key);
+                doc = resumeId ? await ctx.db.get(resumeId) : null;
+            }
+
+            if (!doc || doc.isArchived === true || seenDocIds.has(String(doc._id))) {
+                continue;
+            }
+
+            seenDocIds.add(String(doc._id));
+            docs.push(doc);
+        }
+
+        return docs.map((doc) => projectResumeListDoc(doc));
+    },
+});
+
 // ---------------------------------------------------------------------------
 // Internal queries
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Keep anonymous /s/<public-token> as a sanitized immutable resume-search snapshot.
- Add authenticated member mode for the same share URL: workspace-scoped hydration, interactive resume review cards, status/action/rating/notes/block callbacks behind permissions.
- Snapshot all loaded filtered results from active /resumes share creation, including the China CNC sales filter shape, and remove the legacy 100-result truncation.

## Verification
- npm test -- apps/api/src/routes/public-shares.test.ts apps/api/src/services/public-share-storage.test.ts
- npm --workspace @trends/web test -- PublicSharePage.test.tsx ResumeSearchPage.test.tsx ResumeList.test.tsx
- npm --workspace @trends/api run typecheck
- npm --workspace @trends/web run typecheck
- make check
- skillwiki validate spec/plan/log for public-share-run-snapshot-architecture

## Browser Smoke
- Anonymous /s/<public-token> renders the static sanitized snapshot and no review/member markers.
- Authenticated member /s/<public-token> hydrates the real resume card list and shows review controls.
- Candidate note POST reached /api/candidate-status locally, but local persistence proof is blocked by the same direct endpoint returning 500 under the current Convex write-secret configuration.