### PR TITLE
feat: public share interactive review sessions

### DIFF
--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -42,6 +42,32 @@ async function loadSessionModules(root: string) {
   };
 }
 
+async function createStoredAuthContext(root: string, input: {
+  workspaceSlug: string;
+  role: "user" | "admin";
+}) {
+  const { AuthStorage } = await import("../services/auth-storage");
+  const authStorage = new AuthStorage(root);
+  const user = authStorage.createUser({
+    email: `${input.role}-${input.workspaceSlug}@example.com`,
+    displayName: `${input.role} ${input.workspaceSlug}`,
+  });
+  authStorage.upsertMembership({
+    userId: user.id,
+    workspaceSlug: input.workspaceSlug,
+    role: input.role,
+  });
+
+  return {
+    authContext: createAuthContext({
+      workspaceSlug: input.workspaceSlug,
+      role: input.role,
+      userId: user.id,
+    }),
+    userId: user.id,
+  };
+}
+
 describe("session routes", () => {
   let root = "";
 
@@ -59,7 +85,8 @@ describe("session routes", () => {
   it("creates and rehydrates persisted share session state", async () => {
     root = createFixtureRoot();
     const { createApp } = await loadSessionModules(root);
-    const app = createApp({ authContext: createAuthContext({ workspaceSlug: "hr", role: "user" }) });
+    const { authContext } = await createStoredAuthContext(root, { workspaceSlug: "hr", role: "user" });
+    const app = createApp({ authContext });
 
     const createResponse = await app.request("/api/sessions", {
       method: "POST",
@@ -166,7 +193,8 @@ describe("session routes", () => {
   it("updates and clears persisted share metadata within the workspace scope", async () => {
     root = createFixtureRoot();
     const { createApp } = await loadSessionModules(root);
-    const app = createApp({ authContext: createAuthContext({ workspaceSlug: "hr", role: "user" }) });
+    const { authContext } = await createStoredAuthContext(root, { workspaceSlug: "hr", role: "user" });
+    const app = createApp({ authContext });
 
     const createResponse = await app.request("/api/sessions", {
       method: "POST",
@@ -234,6 +262,64 @@ describe("session routes", () => {
     expect(missingWorkspaceResponse.status).toBe(403);
   });
 
+  it("binds created sessions to the authenticated user instead of client-supplied user ids", async () => {
+    root = createFixtureRoot();
+    const { createApp } = await loadSessionModules(root);
+    const { authContext, userId } = await createStoredAuthContext(root, { workspaceSlug: "hr", role: "user" });
+    const app = createApp({
+      authContext,
+    });
+
+    const createResponse = await app.request("/api/sessions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({
+        userId: "spoofed-user",
+        shareTitle: "Manager review snapshot",
+      }),
+    });
+
+    expect(createResponse.status).toBe(200);
+    const createdPayload = await createResponse.json() as {
+      success: boolean;
+      session: {
+        id: string;
+        userId?: string;
+      };
+    };
+
+    expect(createdPayload.success).toBe(true);
+    expect(createdPayload.session.userId).toBe(userId);
+
+    const updateResponse = await app.request(`/api/sessions/${createdPayload.session.id}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+      },
+      body: JSON.stringify({
+        userId: "other-manager",
+        shareTitle: "Updated manager review snapshot",
+      }),
+    });
+
+    expect(updateResponse.status).toBe(200);
+    const updatedPayload = await updateResponse.json() as {
+      success: boolean;
+      session: {
+        userId?: string;
+        shareTitle?: string;
+      };
+    };
+
+    expect(updatedPayload.success).toBe(true);
+    expect(updatedPayload.session.userId).toBe(userId);
+    expect(updatedPayload.session.shareTitle).toBe("Updated manager review snapshot");
+  });
+
   it("rejects anonymous session reads", async () => {
     root = createFixtureRoot();
     const { createApp } = await loadSessionModules(root);
@@ -251,7 +337,8 @@ describe("session routes", () => {
   it("rejects session creation from users outside the selected workspace", async () => {
     root = createFixtureRoot();
     const { createApp } = await loadSessionModules(root);
-    const app = createApp({ authContext: createAuthContext({ workspaceSlug: "hr", role: "user" }) });
+    const { authContext } = await createStoredAuthContext(root, { workspaceSlug: "hr", role: "user" });
+    const app = createApp({ authContext });
 
     const response = await app.request("/api/sessions", {
       method: "POST",

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -59,7 +59,6 @@ const SessionResponseSchema = z.object({
 });
 
 const SessionCreateSchema = z.object({
-  userId: z.string().optional(),
   jobDescriptionId: z.string().optional(),
   sampleName: z.string().optional(),
   filters: SessionFiltersSchema.optional(),
@@ -68,7 +67,6 @@ const SessionCreateSchema = z.object({
 });
 
 const SessionUpdateSchema = z.object({
-  userId: z.string().optional(),
   jobDescriptionId: z.string().optional(),
   sampleName: z.string().optional(),
   filters: SessionFiltersSchema.optional(),
@@ -116,7 +114,7 @@ app.openapi(createSessionRoute, (c) => {
   const workspaceSlug = c.var.workspaceSlug;
   const session = sessionManager.createSession({
     workspaceSlug,
-    userId: body.userId,
+    userId: c.var.auth?.user.id,
     jobDescriptionId: body.jobDescriptionId,
     sampleName: body.sampleName,
     filters: body.filters,
@@ -184,7 +182,6 @@ app.openapi(updateSessionRoute, (c) => {
   const body = c.req.valid("json");
   const workspaceSlug = c.var.workspaceSlug;
   const session = sessionManager.updateSession(id, {
-    userId: body.userId,
     jobDescriptionId: body.jobDescriptionId,
     sampleName: body.sampleName,
     filters: body.filters,

--- a/apps/web/src/components/search/GoogleSearchBar.tsx
+++ b/apps/web/src/components/search/GoogleSearchBar.tsx
@@ -19,6 +19,7 @@ type GoogleSearchBarProps = {
   onClear: () => void
   onSubmit: (value?: string) => void
   placeholder?: string
+  prefetchSearch?: boolean
 }
 
 function getRecentSearchLabel(item: ResumeSearchRecentItem): string {
@@ -36,6 +37,7 @@ export function GoogleSearchBar({
   onClear,
   onSubmit,
   placeholder,
+  prefetchSearch = true,
 }: GoogleSearchBarProps) {
   const { t } = useTranslation()
   const [focused, setFocused] = useState(false)
@@ -44,7 +46,7 @@ export function GoogleSearchBar({
   const containerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const trimmedValue = value.trim()
-  useSearchPrefetch(trimmedValue)
+  useSearchPrefetch(trimmedValue, prefetchSearch)
   const placeholderLabel = placeholder ?? t('resumes.searchPage.searchBar.placeholder', {
     defaultValue: 'Search resumes by keywords, brands, roles, or locations',
   })

--- a/apps/web/src/components/search/SearchHeader.tsx
+++ b/apps/web/src/components/search/SearchHeader.tsx
@@ -16,6 +16,7 @@ type SearchHeaderProps = {
   loading?: boolean
   location?: string
   queryInput: string
+  prefetchSearch?: boolean
   recentSearches: ResumeSearchRecentItem[]
   sortValue: SearchSortValue
   statusSummary?: {
@@ -41,6 +42,7 @@ export function SearchHeader({
   loading = false,
   location,
   queryInput,
+  prefetchSearch = true,
   recentSearches,
   sortValue,
   statusSummary,
@@ -94,6 +96,7 @@ export function SearchHeader({
           onChange={onChangeQuery}
           onClear={onClearQuery}
           onSubmit={onSubmitQuery}
+          prefetchSearch={prefetchSearch}
         />
       </div>
 

--- a/apps/web/src/hooks/useSearchPrefetch.test.ts
+++ b/apps/web/src/hooks/useSearchPrefetch.test.ts
@@ -38,6 +38,13 @@ describe('useSearchPrefetch', () => {
     expect(result.current).toBeUndefined()
   })
 
+  it('skips query when prefetching is disabled', () => {
+    useQueryMock.mockReturnValue(undefined)
+    const { result } = renderHook(() => useSearchPrefetch('React', false))
+    expect(useQueryMock).toHaveBeenCalledWith('resumes_search:search', 'skip')
+    expect(result.current).toBeUndefined()
+  })
+
   it('trims whitespace from query', () => {
     useQueryMock.mockReturnValue([])
     renderHook(() => useSearchPrefetch('  React  '))

--- a/apps/web/src/hooks/useSearchPrefetch.ts
+++ b/apps/web/src/hooks/useSearchPrefetch.ts
@@ -2,11 +2,11 @@ import { useDeferredValue } from 'react'
 import { useQuery } from 'convex/react'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 
-export function useSearchPrefetch(query: string | undefined) {
+export function useSearchPrefetch(query: string | undefined, enabled = true) {
   const deferredQuery = useDeferredValue(query)
   const trimmed = (deferredQuery ?? '').trim()
   return useQuery(
     api.resumes_search.search,
-    trimmed ? { query: trimmed, limit: 10 } : 'skip',
+    enabled && trimmed ? { query: trimmed, limit: 10 } : 'skip',
   )
 }

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -5092,7 +5092,6 @@ export interface paths {
             requestBody?: {
                 content: {
                     "application/json": {
-                        userId?: string;
                         jobDescriptionId?: string;
                         sampleName?: string;
                         filters?: components["schemas"]["ResumeFilters"] & {
@@ -5387,7 +5386,6 @@ export interface paths {
             requestBody?: {
                 content: {
                     "application/json": {
-                        userId?: string;
                         jobDescriptionId?: string;
                         sampleName?: string;
                         filters?: components["schemas"]["ResumeFilters"] & {

--- a/apps/web/src/pages/PublicSharePage.test.tsx
+++ b/apps/web/src/pages/PublicSharePage.test.tsx
@@ -8,28 +8,73 @@ import { workspaceRef } from '@/lib/workspace-ref'
 
 const {
   apiGetMock,
+  apiPatchMock,
+  apiPostMock,
+  authMock,
   blockCandidatesMock,
+  exportDownloadMock,
   saveActionMock,
   unblockCandidateMock,
   updateStatusMock,
+  useCandidateActionsMock,
+  useSearchPrefetchMock,
   useQueryMock,
 } = vi.hoisted(() => ({
   apiGetMock: vi.fn(),
+  apiPatchMock: vi.fn(),
+  apiPostMock: vi.fn(),
+  authMock: {
+    user: { id: 'manager-1' },
+    isLoading: false,
+  },
   blockCandidatesMock: vi.fn(async () => true),
+  exportDownloadMock: vi.fn(async (baseUrl: string, payload: unknown) => {
+    void baseUrl
+    void payload
+  }),
   saveActionMock: vi.fn(async () => null),
   unblockCandidateMock: vi.fn(async () => true),
   updateStatusMock: vi.fn(async () => true),
+  useCandidateActionsMock: vi.fn(),
+  useSearchPrefetchMock: vi.fn(),
   useQueryMock: vi.fn(),
 }))
 
 vi.mock('@/lib/api-helpers', () => ({
   rawApiClient: {
     GET: (...args: unknown[]) => apiGetMock(...args),
+    PATCH: (...args: unknown[]) => apiPatchMock(...args),
+    POST: (...args: unknown[]) => apiPostMock(...args),
   },
+}))
+
+vi.mock('@/lib/api-client', () => ({
+  apiBaseUrl: '',
+}))
+
+vi.mock('@/lib/resume-export', () => ({
+  submitResumeExportDownload: (baseUrl: string, payload: unknown) =>
+    exportDownloadMock(baseUrl, payload),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => authMock,
 }))
 
 vi.mock('convex/react', () => ({
   useQuery: (...args: unknown[]) => useQueryMock(...args),
+}))
+
+vi.mock('@/hooks/useSearchPrefetch', () => ({
+  useSearchPrefetch: (...args: unknown[]) => useSearchPrefetchMock(...args),
 }))
 
 vi.mock('@/hooks/useCandidateStatus', () => ({
@@ -49,15 +94,7 @@ vi.mock('@/hooks/useCandidateStatus', () => ({
 }))
 
 vi.mock('@/hooks/useCandidateActions', () => ({
-  useCandidateActions: () => ({
-    actionsByResume: {
-      'resume-1': 'star',
-    },
-    ratingsByResume: {
-      'resume-1': 4,
-    },
-    saveAction: saveActionMock,
-  }),
+  useCandidateActions: (...args: unknown[]) => useCandidateActionsMock(...args),
 }))
 
 vi.mock('@/hooks/useCandidateBlocks', () => ({
@@ -122,11 +159,36 @@ function renderPublicShare(path = '/s/public-token-1') {
 describe('PublicSharePage', () => {
   beforeEach(() => {
     apiGetMock.mockReset()
+    apiPatchMock.mockReset()
+    apiPostMock.mockReset()
+    apiPostMock.mockResolvedValue({
+      data: {
+        success: true,
+        session: {
+          id: 'member-review-session-1',
+        },
+      },
+    })
+    authMock.user = { id: 'manager-1' }
+    authMock.isLoading = false
     blockCandidatesMock.mockClear()
+    exportDownloadMock.mockClear()
     saveActionMock.mockClear()
     unblockCandidateMock.mockClear()
     updateStatusMock.mockClear()
+    useCandidateActionsMock.mockReset()
+    useSearchPrefetchMock.mockClear()
+    useCandidateActionsMock.mockReturnValue({
+      actionsByResume: {
+        'resume-1': 'star',
+      },
+      ratingsByResume: {
+        'resume-1': 4,
+      },
+      saveAction: saveActionMock,
+    })
     useQueryMock.mockReset()
+    localStorage.clear()
     workspaceRef.set('dev')
   })
 
@@ -170,14 +232,25 @@ describe('PublicSharePage', () => {
 
     expect(apiGetMock).toHaveBeenCalledWith('/api/public-shares/public-token-1')
     expect(await screen.findByRole('heading', { name: 'Public CNC sales snapshot' })).toBeInTheDocument()
+    expect(screen.getByTestId('public-snapshot-search-shell')).toBeInTheDocument()
+    expect(screen.getByTestId('public-snapshot-query')).toHaveTextContent('CNC sales')
+    expect(screen.getByTestId('public-snapshot-result-count')).toHaveTextContent('1 result')
+    expect(screen.getByTestId('public-snapshot-filter-locations')).toHaveTextContent('locations: Malaysia')
     expect(screen.getByText('Snapshot')).toBeInTheDocument()
     expect(screen.getByText('CNC sales')).toBeInTheDocument()
     expect(screen.getByText('Candidate A')).toBeInTheDocument()
     expect(screen.getByText('Strong CNC sales background')).toBeInTheDocument()
     expect(screen.getByText('91')).toBeInTheDocument()
+    expect(screen.queryByTestId('resume-search-input')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('bulk-export')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Share/i })).not.toBeInTheDocument()
     expect(screen.queryByText(/candidate status/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/actions/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/notes/i)).not.toBeInTheDocument()
+    expect(apiPostMock).not.toHaveBeenCalled()
+    expect(useQueryMock).not.toHaveBeenCalled()
+    expect(useCandidateActionsMock).not.toHaveBeenCalled()
+    expect(useSearchPrefetchMock).not.toHaveBeenCalled()
   })
 
   it('hydrates member-visible shared resume keys and enables review controls', async () => {
@@ -280,11 +353,42 @@ describe('PublicSharePage', () => {
     renderPublicShare()
 
     expect(await screen.findByRole('heading', { name: 'China CNC sales snapshot' })).toBeInTheDocument()
-    expect(screen.getByText('Shared Results List 2 action:true rating:true status:true block:true select:true')).toBeInTheDocument()
+    expect(await screen.findByText('Shared Results List 2 action:true rating:true status:true block:true select:true')).toBeInTheDocument()
     expect(screen.getByText('First shared candidate Candidate A')).toBeInTheDocument()
     expect(screen.getByText('First action star')).toBeInTheDocument()
     expect(screen.getByText('First rating 4')).toBeInTheDocument()
     expect(workspaceRef.get()).toBe('hr')
+    await waitFor(() => {
+      expect(apiPostMock).toHaveBeenCalledWith('/api/sessions', {
+        body: {
+          jobDescriptionId: undefined,
+          filters: {
+            locations: ['China'],
+            minRoleYears: 1,
+            roleFilterType: 'sales',
+            minAge: 25,
+            maxAge: 40,
+          },
+          shareTitle: 'China CNC sales snapshot',
+          searchState: {
+            location: 'China',
+            keywords: ['CNC', '销售', 'China'],
+            filters: {
+              locations: ['China'],
+              minRoleYears: 1,
+              roleFilterType: 'sales',
+              minAge: 25,
+              maxAge: 40,
+            },
+            referenceNote: 'Shared snapshot public-token-1',
+          },
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(useCandidateActionsMock).toHaveBeenLastCalledWith('member-review-session-1', undefined, true)
+    })
+    expect(localStorage.getItem('trends.publicShare.reviewSessionId.hr.manager-1.public-token-1')).toBe('member-review-session-1')
     expect(useQueryMock).toHaveBeenCalledWith(expect.anything(), {
       identityKeys: ['identity-1', 'identity-2'],
     })
@@ -303,6 +407,304 @@ describe('PublicSharePage', () => {
 
     await user.click(screen.getByRole('button', { name: 'Block first' }))
     expect(blockCandidatesMock).toHaveBeenCalledWith(['identity-1'], 'Duplicate')
+  })
+
+  it('renders the member bulk action bar and exports selected snapshot resumes', async () => {
+    const user = userEvent.setup()
+    useQueryMock.mockReturnValue([
+      {
+        _id: 'resume-1',
+        identityKey: 'identity-1',
+        externalId: 'resume-1',
+        content: {
+          name: 'Candidate A',
+          location: 'China',
+          experience: '5 years',
+          education: 'Bachelor',
+          extractedAt: '2026-06-12T09:00:00.000Z',
+        },
+        source: 'job5156',
+        primaryRuleScore: 70,
+        tags: [],
+        crawledAt: 1,
+      },
+      {
+        _id: 'resume-2',
+        identityKey: 'identity-2',
+        externalId: 'resume-2',
+        content: {
+          name: 'Candidate B',
+          location: 'China',
+          experience: '3 years',
+          education: 'Bachelor',
+          extractedAt: '2026-06-12T09:01:00.000Z',
+        },
+        source: 'job5156',
+        primaryRuleScore: 65,
+        tags: [],
+        crawledAt: 2,
+      },
+    ])
+    apiGetMock.mockResolvedValue({
+      data: {
+        success: true,
+        share: {
+          title: 'China CNC sales snapshot',
+          createdAt: '2026-06-12T09:00:00.000Z',
+          snapshot: {
+            scoringMode: 'hybrid',
+            promptVersion: 'prompt-v1',
+            skillConfigVersion: 'skills-v1',
+            modelProvider: 'openai',
+            modelName: 'gpt-test',
+            payload: {
+              search: {
+                query: 'CNC 销售 China',
+                filters: {
+                  locations: ['China'],
+                  minRoleYears: 1,
+                },
+              },
+              results: [
+                {
+                  resumeKey: 'identity-1',
+                  displayName: 'Candidate A',
+                  summary: 'Strong CNC sales background',
+                  score: 91,
+                  recommendation: 'strong_match',
+                  highlights: ['CNC'],
+                },
+                {
+                  resumeKey: 'identity-2',
+                  displayName: 'Candidate B',
+                  summary: 'Good territory sales profile',
+                  score: 72,
+                  recommendation: 'match',
+                  highlights: ['Sales'],
+                },
+              ],
+            },
+          },
+          member: {
+            workspaceSlug: 'hr',
+            canReview: true,
+            searchRun: {
+              id: 'run-1',
+              resumeKeys: ['identity-1', 'identity-2'],
+              query: { text: 'CNC 销售 China', jobDescriptionId: 'jd-1' },
+              filters: {
+                locations: ['China'],
+                minRoleYears: 1,
+              },
+            },
+          },
+        },
+      },
+    })
+
+    renderPublicShare()
+
+    expect(await screen.findByTestId('bulk-export')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(useCandidateActionsMock).toHaveBeenLastCalledWith('member-review-session-1', undefined, true)
+    })
+
+    await user.click(screen.getByTestId('bulk-select-all'))
+    await user.click(screen.getByTestId('bulk-export'))
+
+    expect(exportDownloadMock).toHaveBeenCalledWith('', {
+      format: 'csv',
+      source: 'convex',
+      sessionId: 'member-review-session-1',
+      jobDescriptionId: 'jd-1',
+      entries: [
+        expect.objectContaining({
+          resumeId: 'identity-1',
+          status: 'contacted',
+          userComment: 'Existing note',
+          userRating: 4,
+          match: expect.objectContaining({
+            score: 91,
+            scoreSource: 'ai',
+            summary: 'Strong CNC sales background',
+          }),
+        }),
+        expect.objectContaining({
+          resumeId: 'identity-2',
+          status: 'new',
+          match: expect.objectContaining({
+            score: 72,
+            scoreSource: 'ai',
+            summary: 'Good territory sales profile',
+          }),
+        }),
+      ],
+    })
+  })
+
+  it('presents authenticated members with the resume search shell instead of the snapshot shell', async () => {
+    useQueryMock.mockReturnValue([
+      {
+        _id: 'resume-1',
+        identityKey: 'identity-1',
+        externalId: 'resume-1',
+        content: {
+          name: 'Candidate A',
+          location: 'China',
+          experience: '5 years',
+          education: 'Bachelor',
+          extractedAt: '2026-06-12T09:00:00.000Z',
+        },
+        source: 'job5156',
+        primaryRuleScore: 70,
+        tags: [],
+        crawledAt: 1,
+      },
+      {
+        _id: 'resume-2',
+        identityKey: 'identity-2',
+        externalId: 'resume-2',
+        content: {
+          name: 'Candidate B',
+          location: 'China',
+          experience: '3 years',
+          education: 'Bachelor',
+          extractedAt: '2026-06-12T09:01:00.000Z',
+        },
+        source: '51job',
+        primaryRuleScore: 65,
+        tags: [],
+        crawledAt: 2,
+      },
+    ])
+    apiGetMock.mockResolvedValue({
+      data: {
+        success: true,
+        share: {
+          title: 'China CNC sales snapshot',
+          createdAt: '2026-06-12T09:00:00.000Z',
+          snapshot: {
+            scoringMode: 'hybrid',
+            promptVersion: 'prompt-v1',
+            skillConfigVersion: 'skills-v1',
+            modelProvider: 'openai',
+            modelName: 'gpt-test',
+            payload: {
+              search: {
+                query: 'CNC 销售 China',
+                filters: {
+                  locations: ['China'],
+                  minRoleYears: 1,
+                  roleFilterType: 'sales',
+                  minAge: 25,
+                  maxAge: 40,
+                },
+              },
+              results: [
+                {
+                  resumeKey: 'identity-1',
+                  displayName: 'Candidate A',
+                  summary: 'Strong CNC sales background',
+                  score: 91,
+                  recommendation: 'strong_match',
+                  highlights: ['CNC'],
+                },
+                {
+                  resumeKey: 'identity-2',
+                  displayName: 'Candidate B',
+                  summary: 'Good territory sales profile',
+                  score: 72,
+                  recommendation: 'match',
+                  highlights: ['Sales'],
+                },
+              ],
+            },
+          },
+          member: {
+            workspaceSlug: 'hr',
+            canReview: true,
+            searchRun: {
+              id: 'run-1',
+              resumeKeys: ['identity-1', 'identity-2'],
+              query: { text: 'CNC 销售 China' },
+              filters: {
+                locations: ['China'],
+                minRoleYears: 1,
+                roleFilterType: 'sales',
+                minAge: 25,
+                maxAge: 40,
+              },
+            },
+          },
+        },
+      },
+    })
+
+    renderPublicShare()
+
+    expect(await screen.findByText('Shared Results List 2 action:true rating:true status:true block:true select:true')).toBeInTheDocument()
+    expect(screen.getAllByText('Filters').length).toBeGreaterThan(0)
+    expect(screen.getByText('Resume AI analysis')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Share/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /复制搜索链接|Copy link/i })).toBeInTheDocument()
+    expect(useSearchPrefetchMock).toHaveBeenCalledWith('CNC 销售 China', false)
+    expect(screen.queryByText('Snapshot')).not.toBeInTheDocument()
+  })
+
+  it('keeps member bulk actions disabled until shared resume rows hydrate', async () => {
+    useQueryMock.mockReturnValue(undefined)
+    apiGetMock.mockResolvedValue({
+      data: {
+        success: true,
+        share: {
+          title: 'Hydrating shared snapshot',
+          createdAt: '2026-06-12T09:00:00.000Z',
+          snapshot: {
+            scoringMode: 'hybrid',
+            promptVersion: 'prompt-v1',
+            skillConfigVersion: 'skills-v1',
+            modelProvider: 'openai',
+            modelName: 'gpt-test',
+            payload: {
+              search: {
+                query: 'CNC 销售 China',
+                filters: {
+                  locations: ['China'],
+                },
+              },
+              results: [
+                {
+                  resumeKey: 'identity-1',
+                  displayName: 'Candidate A',
+                  score: 91,
+                },
+              ],
+            },
+          },
+          member: {
+            workspaceSlug: 'hr',
+            canReview: true,
+            searchRun: {
+              id: 'run-1',
+              resumeKeys: ['identity-1'],
+              query: { text: 'CNC 销售 China' },
+              filters: {
+                locations: ['China'],
+              },
+            },
+          },
+        },
+      },
+    })
+
+    renderPublicShare()
+
+    expect(await screen.findByTestId('bulk-select-all')).toBeDisabled()
+    await waitFor(() => {
+      expect(apiPostMock).toHaveBeenCalledWith('/api/sessions', expect.anything())
+    })
+    expect(screen.getByTestId('bulk-select-all')).toBeDisabled()
+    expect(screen.getByTestId('bulk-export')).toBeDisabled()
   })
 
   it('shows an unavailable state for revoked or expired tokens', async () => {

--- a/apps/web/src/pages/PublicSharePage.tsx
+++ b/apps/web/src/pages/PublicSharePage.tsx
@@ -1,18 +1,53 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { AlertTriangle, Clock, Search } from 'lucide-react'
+import { AlertTriangle, Clock, RefreshCw, Search } from 'lucide-react'
 import { useQuery } from 'convex/react'
-import type { WorkspaceSlug } from '@trends/shared'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
+import { formatKeywordQuery, parseKeywordQuery, type WorkspaceSlug } from '@trends/shared'
 
+import { BulkActionBar } from '@/components/BulkActionBar'
+import { FacetBadge } from '@/components/search/FacetBadge'
+import { FacetSidebar } from '@/components/search/FacetSidebar'
+import { MobileFilterSheet } from '@/components/search/MobileFilterSheet'
+import { ModeToggle } from '@/components/ModeToggle'
+import { SearchHeader } from '@/components/search/SearchHeader'
 import { SearchResultsList } from '@/components/search/SearchResultsList'
+import { ShareLinkButton } from '@/components/ShareLinkButton'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { useAuth } from '@/contexts/AuthContext'
 import { WorkspaceProvider } from '@/contexts/WorkspaceContext'
 import { useCandidateActions } from '@/hooks/useCandidateActions'
 import { useCandidateBlocks } from '@/hooks/useCandidateBlocks'
 import { useCandidateStatus } from '@/hooks/useCandidateStatus'
 import { mapResumeDoc } from '@/hooks/useConvexResumes'
+import { useFacetCounts } from '@/hooks/useFacetCounts'
+import { apiBaseUrl } from '@/lib/api-client'
 import { rawApiClient } from '@/lib/api-helpers'
+import {
+  getRoleYears,
+  matchesEducationFilter,
+  matchesSalaryFilter,
+  normalizeFilterToken,
+  toExperienceLevel,
+} from '@/hooks/resume-filter-helpers'
+import {
+  submitResumeExportDownload,
+  type ResumeExportRequestBody,
+} from '@/lib/resume-export'
+import { getResumeAge, parseExperienceYears } from '@/lib/resume-filtering'
+import { recommendationFromScore } from '@/lib/resume-scoring'
+import { getSourceLabelFromHostname } from '@/lib/search-profile-sources'
+import { normalizeOptionalString, normalizeStringList } from '@/lib/taxonomy'
 import type { ResumeSearchResultItem } from '@/components/search/search-types'
-import type { CandidateActionType, CandidateStatus } from '@/types/resume'
+import type { ExperienceLevelFilter } from '@/hooks/useUrlSearchState'
+import {
+  CANDIDATE_STATUS_VALUES,
+  type CandidateActionType,
+  type CandidateStatus,
+  type ResumeExportFormat,
+} from '@/types/resume'
 import { api } from '../../../../packages/convex/convex/_generated/api'
 
 type PublicShareResult = {
@@ -72,6 +107,18 @@ type LoadState =
   | { status: 'not-found' }
   | { status: 'error' }
 
+type SearchSessionResponse = {
+  success: boolean
+  session?: {
+    id?: string
+  }
+}
+
+type ResumeExportEntryMatch =
+  NonNullable<ResumeExportRequestBody['entries'][number]['match']>
+
+const ALL_CANDIDATE_STATUSES = [...CANDIDATE_STATUS_VALUES]
+
 function formatDate(value: string | undefined): string | null {
   if (!value) {
     return null
@@ -91,6 +138,175 @@ function formatFilterValue(value: unknown): string {
     return String(value)
   }
   return ''
+}
+
+function formatSnapshotResultCount(count: number): string {
+  return `${count.toLocaleString()} ${count === 1 ? 'result' : 'results'}`
+}
+
+function getSnapshotFilterTestId(key: string): string {
+  const normalized = key.replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '').toLowerCase()
+  return `public-snapshot-filter-${normalized || 'value'}`
+}
+
+function getSnapshotFilterEntries(filters: Record<string, unknown> | undefined) {
+  return Object.entries(filters ?? {})
+    .map(([key, value]) => ({
+      key,
+      label: formatFilterValue(value),
+    }))
+    .filter((entry) => entry.label.length > 0)
+}
+
+function normalizeFilterStringList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return normalizeStringList(value.filter((entry): entry is string => typeof entry === 'string'))
+  }
+
+  return typeof value === 'string' ? normalizeStringList([value]) : []
+}
+
+function resolveReviewSessionLocation(filters: Record<string, unknown>): string | undefined {
+  const locations = normalizeFilterStringList(filters.locations)
+  return locations.length > 0 ? locations.join(',') : undefined
+}
+
+function resolveReviewSessionJobDescriptionId(query: Record<string, unknown>): string | undefined {
+  const value = query.jobDescriptionId
+  return typeof value === 'string' ? normalizeOptionalString(value) : undefined
+}
+
+function buildReviewSessionBody(params: {
+  member: NonNullable<NonNullable<PublicShareResponse['share']>['member']>
+  searchQuery?: string
+  shareTitle?: string
+  token: string
+}) {
+  const filters = params.member.searchRun.filters
+  const keywords = normalizeStringList(parseKeywordQuery(params.searchQuery ?? '').keywords)
+  const jobDescriptionId = resolveReviewSessionJobDescriptionId(params.member.searchRun.query)
+
+  return {
+    jobDescriptionId,
+    filters,
+    shareTitle: normalizeOptionalString(params.shareTitle),
+    searchState: {
+      location: resolveReviewSessionLocation(filters),
+      keywords,
+      filters,
+      referenceNote: `Shared snapshot ${params.token}`,
+    },
+  }
+}
+
+function getReviewSessionStorageKey(params: {
+  token: string
+  userId: string
+  workspaceSlug: string
+}): string {
+  return `trends.publicShare.reviewSessionId.${params.workspaceSlug}.${params.userId}.${params.token}`
+}
+
+function useMemberReviewSession(params: {
+  enabled: boolean
+  member: NonNullable<NonNullable<PublicShareResponse['share']>['member']>
+  searchQuery?: string
+  shareTitle?: string
+  token: string
+}): string | undefined {
+  const auth = useAuth()
+  const [sessionId, setSessionId] = useState<string | undefined>(undefined)
+
+  const storageKey = useMemo(() => {
+    const userId = auth.user?.id
+    if (!userId) {
+      return undefined
+    }
+
+    return getReviewSessionStorageKey({
+      token: params.token,
+      userId,
+      workspaceSlug: params.member.workspaceSlug,
+    })
+  }, [auth.user?.id, params.member.workspaceSlug, params.token])
+
+  useEffect(() => {
+    if (!storageKey) {
+      setSessionId(undefined)
+      return
+    }
+
+    setSessionId(normalizeOptionalString(localStorage.getItem(storageKey) ?? undefined))
+  }, [storageKey])
+
+  useEffect(() => {
+    if (!params.enabled || auth.isLoading || !auth.user?.id || !storageKey) {
+      return
+    }
+
+    let active = true
+    const resolvedStorageKey = storageKey
+    const body = buildReviewSessionBody({
+      member: params.member,
+      searchQuery: params.searchQuery,
+      shareTitle: params.shareTitle,
+      token: params.token,
+    })
+
+    async function ensureReviewSession() {
+      const storedSessionId = normalizeOptionalString(localStorage.getItem(resolvedStorageKey) ?? undefined)
+      if (storedSessionId) {
+        const { data, error } = await rawApiClient.PATCH<SearchSessionResponse>(
+          `/api/sessions/${storedSessionId}`,
+          { body },
+        )
+        const updatedSessionId = normalizeOptionalString(data?.session?.id)
+        if (!error && data?.success && updatedSessionId) {
+          localStorage.setItem(resolvedStorageKey, updatedSessionId)
+          if (active) {
+            setSessionId(updatedSessionId)
+          }
+          return
+        }
+
+        localStorage.removeItem(resolvedStorageKey)
+      }
+
+      const { data, error } = await rawApiClient.POST<SearchSessionResponse>('/api/sessions', {
+        body,
+      })
+      const createdSessionId = normalizeOptionalString(data?.session?.id)
+      if (error || !data?.success || !createdSessionId) {
+        console.error('Failed to create public share review session', error ?? data)
+        if (active) {
+          setSessionId(undefined)
+        }
+        return
+      }
+
+      localStorage.setItem(resolvedStorageKey, createdSessionId)
+      if (active) {
+        setSessionId(createdSessionId)
+      }
+    }
+
+    void ensureReviewSession()
+
+    return () => {
+      active = false
+    }
+  }, [
+    auth.isLoading,
+    auth.user?.id,
+    params.enabled,
+    params.member,
+    params.searchQuery,
+    params.shareTitle,
+    params.token,
+    storageKey,
+  ])
+
+  return params.enabled ? sessionId : undefined
 }
 
 function EmptyPublicShareState({ title, description }: { title: string; description: string }) {
@@ -131,45 +347,303 @@ function buildSnapshotAnalysis(result: PublicShareResult | undefined): ResumeSea
   }
 }
 
+function buildSharedExportMatch(
+  item: ResumeSearchResultItem,
+): ResumeExportEntryMatch | undefined {
+  if (typeof item.score !== 'number' || !Number.isFinite(item.score)) {
+    return undefined
+  }
+
+  const analysis = item.analysis
+  const usesAiScore = item.scoreSource === 'ai' && Boolean(analysis)
+
+  return {
+    score: item.score,
+    recommendation: recommendationFromScore(item.score),
+    scoreSource: usesAiScore ? 'ai' : 'rule',
+    ...(usesAiScore && analysis?.summary
+      ? { summary: analysis.summary }
+      : {}),
+    ...(usesAiScore && analysis?.breakdown
+      ? { breakdown: analysis.breakdown }
+      : {}),
+  }
+}
+
+function buildSharedExportEntry(
+  item: ResumeSearchResultItem,
+  userRating?: number,
+): ResumeExportRequestBody['entries'][number] {
+  const match = buildSharedExportMatch(item)
+  const userComment = normalizeOptionalString(item.statusMeta?.notes)
+
+  return {
+    resumeId: item.key,
+    status: item.status,
+    ...(match ? { match } : {}),
+    ...(typeof item.resume.primaryRuleScore === 'number'
+      ? { ruleScore: item.resume.primaryRuleScore }
+      : {}),
+    ...(userComment ? { userComment } : {}),
+    ...(typeof userRating === 'number' ? { userRating } : {}),
+  }
+}
+
+function isHighScoreResult(item: ResumeSearchResultItem): boolean {
+  return typeof item.score === 'number' && item.score >= 80
+}
+
+function getSnapshotFilterString(filters: Record<string, unknown>, key: string): string | undefined {
+  const value = filters[key]
+  return typeof value === 'string' ? normalizeOptionalString(value) : undefined
+}
+
+function countActiveSnapshotFilters(params: {
+  idOrNameSearch?: string
+  maxAge?: number
+  maxSalary?: number
+  minAge?: number
+  minRoleYears?: number
+  minSalary?: number
+  minScore?: number
+  selectedBrands: string[]
+  selectedCompanies: string[]
+  selectedEducation: string[]
+  selectedExperienceLevel?: ExperienceLevelFilter
+  selectedSources: string[]
+  selectedStatuses: CandidateStatus[]
+  selectedTags: string[]
+}): number {
+  let count = 0
+  if (params.idOrNameSearch) count += 1
+  if (typeof params.minScore === 'number') count += 1
+  if (typeof params.minRoleYears === 'number') count += 1
+  if (typeof params.minAge === 'number' || typeof params.maxAge === 'number') count += 1
+  if (typeof params.minSalary === 'number' || typeof params.maxSalary === 'number') count += 1
+  if (params.selectedBrands.length > 0) count += 1
+  if (params.selectedCompanies.length > 0) count += 1
+  if (params.selectedEducation.length > 0) count += 1
+  if (params.selectedExperienceLevel) count += 1
+  if (params.selectedSources.length > 0) count += 1
+  if (params.selectedTags.length > 0) count += 1
+  if (params.selectedStatuses.length !== ALL_CANDIDATE_STATUSES.length) count += 1
+  return count
+}
+
+function matchesSelectedValues(values: string[] | undefined, selected: string[]): boolean {
+  if (selected.length === 0) {
+    return true
+  }
+
+  const normalizedValues = new Set((values ?? []).map(normalizeFilterToken).filter(Boolean))
+  return selected.some((value) => normalizedValues.has(normalizeFilterToken(value)))
+}
+
+function toggleStringValue(values: string[], value: string): string[] {
+  const normalized = value.trim()
+  if (!normalized) {
+    return values
+  }
+
+  return values.some((item) => normalizeFilterToken(item) === normalizeFilterToken(normalized))
+    ? values.filter((item) => normalizeFilterToken(item) !== normalizeFilterToken(normalized))
+    : [...values, normalized]
+}
+
+function toggleStatusValue(values: CandidateStatus[], value: CandidateStatus): CandidateStatus[] {
+  return values.includes(value)
+    ? values.filter((item) => item !== value)
+    : [...values, value]
+}
+
+function getSharedResultSearchText(item: ResumeSearchResultItem): string {
+  const resume = item.resume
+  return [
+    item.key,
+    item.identityKey,
+    String(resume.resumeId),
+    resume.externalId,
+    resume.name,
+    resume.location,
+    resume.jobIntention,
+    resume.experience,
+    resume.education,
+    resume.expectedSalary,
+    resume.selfIntro,
+    ...(resume.tags ?? []),
+    ...(resume.ingestData?.industryTags ?? []),
+    ...(resume.ingestData?.companyHits ?? []),
+    ...(resume.ingestData?.brandHits?.map((hit) => hit.brand) ?? []),
+  ]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join(' ')
+    .toLowerCase()
+}
+
+function sortSharedResults(
+  left: ResumeSearchResultItem,
+  right: ResumeSearchResultItem,
+  sortValue: 'score' | 'newest' | 'experience',
+): number {
+  if (sortValue === 'newest') {
+    return (right.resume.crawledAt ?? 0) - (left.resume.crawledAt ?? 0)
+  }
+
+  if (sortValue === 'experience') {
+    return parseExperienceYears(right.resume.experience) - parseExperienceYears(left.resume.experience)
+  }
+
+  return (right.score ?? 0) - (left.score ?? 0)
+}
+
+function getStatusFacetCounts(items: ResumeSearchResultItem[]): Record<string, number> {
+  return items.reduce<Record<string, number>>((counts, item) => {
+    counts[item.status] = (counts[item.status] ?? 0) + 1
+    return counts
+  }, {})
+}
+
+function getStatusSummary(items: ResumeSearchResultItem[]) {
+  return {
+    new: items.filter((item) => item.status === 'new').length,
+    shortlisted: items.filter((item) => item.status === 'shortlisted').length,
+    rejected: items.filter((item) => item.status === 'rejected').length,
+    total: items.length,
+  }
+}
+
+function PublicSnapshotSearchShell({
+  createdAt,
+  expiresAt,
+  filters,
+  query,
+  resultCount,
+}: {
+  createdAt: string | null
+  expiresAt: string | null
+  filters: Record<string, unknown> | undefined
+  query?: string
+  resultCount: number
+}) {
+  const filterEntries = getSnapshotFilterEntries(filters)
+  const displayQuery = normalizeOptionalString(query) ?? 'Shared snapshot'
+
+  return (
+    <section className="space-y-4" data-testid="public-snapshot-search-shell">
+      <div className="mx-auto max-w-5xl">
+        <div className="relative flex min-h-14 items-center gap-3 overflow-hidden rounded-full border bg-background/95 px-5 shadow-[0_12px_40px_-28px_rgba(15,23,42,0.85)]">
+          <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <div
+            aria-label="Shared snapshot query"
+            className="min-w-0 flex-1 truncate text-base font-medium text-slate-900"
+            data-testid="public-snapshot-query"
+          >
+            {displayQuery}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3 rounded-[1.5rem] border bg-white/80 px-4 py-3 shadow-sm lg:flex-row lg:items-center lg:justify-between">
+        <div className="min-w-0 space-y-2">
+          <div className="text-sm font-medium text-slate-900">
+            <span data-testid="public-snapshot-result-count">
+              {formatSnapshotResultCount(resultCount)}
+            </span>
+            <span className="text-muted-foreground"> in this public snapshot</span>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="outline">Snapshot</Badge>
+            {createdAt ? (
+              <Badge variant="outline" className="gap-1.5">
+                <Clock className="h-3.5 w-3.5" />
+                {createdAt}
+              </Badge>
+            ) : null}
+            {expiresAt ? (
+              <Badge variant="outline">
+                Expires {expiresAt}
+              </Badge>
+            ) : null}
+            {filterEntries.map((entry) => (
+              <Badge
+                key={entry.key}
+                variant="outline"
+                data-testid={getSnapshotFilterTestId(entry.key)}
+              >
+                {entry.key}: {entry.label}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
 function StaticPublicShareResults({ results }: { results: PublicShareResult[] }) {
   return (
-    <section className="space-y-3">
-      <div className="text-sm font-medium text-foreground">
-        Results
+    <section className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-sm font-medium text-foreground">
+          Results
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {formatSnapshotResultCount(results.length)}
+        </div>
       </div>
       {results.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No public results are included in this snapshot.</p>
+        <div className="rounded-[1.5rem] border bg-white/80 p-6 text-sm text-muted-foreground shadow-sm">
+          No public results are included in this snapshot.
+        </div>
       ) : (
-        <div className="divide-y rounded-md border">
-          {results.map((result) => (
-            <article key={result.resumeKey} className="grid gap-3 p-4 md:grid-cols-[1fr_auto]">
-              <div className="space-y-2">
-                <div className="space-y-1">
-                  <h2 className="text-base font-semibold text-foreground">
-                    {result.displayName ?? result.resumeKey}
-                  </h2>
-                  {result.headline && <p className="text-sm text-muted-foreground">{result.headline}</p>}
-                  {result.location && <p className="text-xs text-muted-foreground">{result.location}</p>}
+        <div className="space-y-4">
+          {results.map((result, index) => (
+            <article
+              key={result.resumeKey}
+              className="rounded-[1.5rem] border bg-white/80 p-4 shadow-sm"
+              data-result-index={index}
+            >
+              <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto]">
+                <div className="min-w-0 space-y-3">
+                  <div className="space-y-1">
+                    <h2 className="text-base font-semibold text-foreground">
+                      {result.displayName ?? result.resumeKey}
+                    </h2>
+                    {result.headline && <p className="text-sm text-muted-foreground">{result.headline}</p>}
+                    {result.location && <p className="text-xs text-muted-foreground">{result.location}</p>}
+                  </div>
+                  {result.summary && <p className="text-sm leading-6 text-foreground">{result.summary}</p>}
+                  {result.highlights && result.highlights.length > 0 ? (
+                    <div className="flex flex-wrap gap-2">
+                      {result.highlights.map((highlight) => (
+                        <span key={highlight} className="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                          {highlight}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
+                  {result.skills && result.skills.length > 0 ? (
+                    <div className="flex flex-wrap gap-2">
+                      {result.skills.slice(0, 8).map((skill) => (
+                        <span key={skill} className="rounded-full border px-2.5 py-1 text-xs text-muted-foreground">
+                          {skill}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
                 </div>
-                {result.summary && <p className="text-sm leading-6 text-foreground">{result.summary}</p>}
-                {result.highlights && result.highlights.length > 0 && (
-                  <div className="flex flex-wrap gap-2">
-                    {result.highlights.map((highlight) => (
-                      <span key={highlight} className="rounded-md bg-muted px-2 py-1 text-xs text-muted-foreground">
-                        {highlight}
-                      </span>
-                    ))}
+                {typeof result.score === 'number' && (
+                  <div className="min-w-20 rounded-2xl border bg-background px-3 py-2 text-left md:text-center">
+                    <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                      Score
+                    </div>
+                    <div className="text-2xl font-semibold text-foreground">{result.score}</div>
+                    {result.recommendation && (
+                      <div className="text-xs text-muted-foreground">{result.recommendation}</div>
+                    )}
                   </div>
                 )}
               </div>
-              {typeof result.score === 'number' && (
-                <div className="min-w-16 text-left md:text-right">
-                  <div className="text-2xl font-semibold text-foreground">{result.score}</div>
-                  {result.recommendation && (
-                    <div className="text-xs text-muted-foreground">{result.recommendation}</div>
-                  )}
-                </div>
-              )}
             </article>
           ))}
         </div>
@@ -182,23 +656,58 @@ function MemberPublicShareResults({
   member,
   results,
   searchQuery,
+  shareTitle,
+  token,
 }: {
   member: NonNullable<NonNullable<PublicShareResponse['share']>['member']>
   results: PublicShareResult[]
   searchQuery?: string
+  shareTitle?: string
+  token: string
 }) {
+  const { t } = useTranslation()
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [exportFormat, setExportFormat] = useState<ResumeExportFormat>('csv')
+  const [filtersOpen, setFiltersOpen] = useState(false)
+  const [queryInput, setQueryInput] = useState(searchQuery ?? '')
+  const [sortValue, setSortValue] = useState<'score' | 'newest' | 'experience'>('score')
+  const [idOrNameSearch, setIdOrNameSearch] = useState<string | undefined>(undefined)
+  const [minScore, setMinScore] = useState<number | undefined>(undefined)
+  const [minRoleYears, setMinRoleYears] = useState<number | undefined>(undefined)
+  const [minAge, setMinAge] = useState<number | undefined>(undefined)
+  const [maxAge, setMaxAge] = useState<number | undefined>(undefined)
+  const [minSalary, setMinSalary] = useState<number | undefined>(undefined)
+  const [maxSalary, setMaxSalary] = useState<number | undefined>(undefined)
+  const [selectedBrands, setSelectedBrands] = useState<string[]>([])
+  const [selectedCompanies, setSelectedCompanies] = useState<string[]>([])
+  const [selectedEducation, setSelectedEducation] = useState<string[]>([])
+  const [selectedExperienceLevel, setSelectedExperienceLevel] = useState<ExperienceLevelFilter | undefined>(undefined)
+  const [selectedSources, setSelectedSources] = useState<string[]>([])
+  const [selectedStatuses, setSelectedStatuses] = useState<CandidateStatus[]>(ALL_CANDIDATE_STATUSES)
+  const [selectedTags, setSelectedTags] = useState<string[]>([])
+  const selectedClusters: string[] = []
+  const location = resolveReviewSessionLocation(member.searchRun.filters)
+  const roleFilterType = getSnapshotFilterString(member.searchRun.filters, 'roleFilterType')
+  const jobDescriptionId = resolveReviewSessionJobDescriptionId(member.searchRun.query)
+  const reviewSessionId = useMemberReviewSession({
+    enabled: member.canReview,
+    member,
+    searchQuery,
+    shareTitle,
+    token,
+  })
+  const canReview = member.canReview && Boolean(reviewSessionId)
   const docs = useQuery(api.resumes.getResumeDocsByIdentityKeys, {
     identityKeys: member.searchRun.resumeKeys,
   })
-  const { statusByIdentity, updateStatus } = useCandidateStatus(member.canReview)
+  const { statusByIdentity, updateStatus } = useCandidateStatus(canReview)
   const { actionsByResume, ratingsByResume, saveAction } = useCandidateActions(
-    member.searchRun.id,
+    reviewSessionId,
     undefined,
-    member.canReview,
+    canReview,
   )
-  const { blocksByIdentity, blockCandidates, unblockCandidate } = useCandidateBlocks(member.canReview)
+  const { blocksByIdentity, blockCandidates, unblockCandidate } = useCandidateBlocks(canReview)
   const snapshotByKey = useMemo(() => {
     const map = new Map<string, PublicShareResult>()
     results.forEach((result) => {
@@ -238,6 +747,138 @@ function MemberPublicShareResults({
       }
     })
   }, [blocksByIdentity, docs, snapshotByKey, statusByIdentity])
+  const facetCounts = useFacetCounts(items)
+  const statusFacetCounts = useMemo(() => getStatusFacetCounts(items), [items])
+  const statusSummary = useMemo(() => getStatusSummary(items), [items])
+  const displayItems = useMemo(() => {
+    const normalizedIdOrName = normalizeFilterToken(idOrNameSearch ?? '')
+    return items
+      .filter((item) => {
+        if (!selectedStatuses.includes(item.status)) {
+          return false
+        }
+        if (typeof minScore === 'number' && (item.score ?? 0) < minScore) {
+          return false
+        }
+        if (typeof minRoleYears === 'number' && getRoleYears(item.resume, roleFilterType ?? '') < minRoleYears) {
+          return false
+        }
+
+        const age = getResumeAge(item.resume)
+        if (typeof minAge === 'number' && (age === null || age < minAge)) {
+          return false
+        }
+        if (typeof maxAge === 'number' && (age === null || age > maxAge)) {
+          return false
+        }
+        if (!matchesSalaryFilter(item.resume.expectedSalary, minSalary, maxSalary)) {
+          return false
+        }
+        if (!matchesSelectedValues(item.resume.ingestData?.industryTags, selectedTags)) {
+          return false
+        }
+        if (!matchesSelectedValues(
+          item.resume.ingestData?.brandHits
+            ?.filter((hit) => hit.context !== 'employer')
+            .map((hit) => hit.brand),
+          selectedBrands,
+        )) {
+          return false
+        }
+        if (!matchesSelectedValues(item.resume.ingestData?.companyHits, selectedCompanies)) {
+          return false
+        }
+        if (!matchesEducationFilter(item.resume.education, selectedEducation)) {
+          return false
+        }
+        if (selectedExperienceLevel && toExperienceLevel(item.resume.ingestData?.experienceLevel) !== selectedExperienceLevel) {
+          return false
+        }
+        if (selectedSources.length > 0) {
+          const sourceLabel = getSourceLabelFromHostname(item.resume.source)
+          if (!sourceLabel || !matchesSelectedValues([sourceLabel], selectedSources)) {
+            return false
+          }
+        }
+        if (normalizedIdOrName && !getSharedResultSearchText(item).includes(normalizedIdOrName)) {
+          return false
+        }
+        return true
+      })
+      .sort((left, right) => sortSharedResults(left, right, sortValue))
+  }, [
+    idOrNameSearch,
+    items,
+    maxAge,
+    maxSalary,
+    minAge,
+    minRoleYears,
+    minSalary,
+    minScore,
+    roleFilterType,
+    selectedBrands,
+    selectedCompanies,
+    selectedEducation,
+    selectedExperienceLevel,
+    selectedSources,
+    selectedStatuses,
+    selectedTags,
+    sortValue,
+  ])
+  const highScoreCount = useMemo(
+    () => displayItems.filter(isHighScoreResult).length,
+    [displayItems],
+  )
+  const filterCount = useMemo(
+    () => countActiveSnapshotFilters({
+      idOrNameSearch,
+      maxAge,
+      maxSalary,
+      minAge,
+      minRoleYears,
+      minSalary,
+      minScore,
+      selectedBrands,
+      selectedCompanies,
+      selectedEducation,
+      selectedExperienceLevel,
+      selectedSources,
+      selectedStatuses,
+      selectedTags,
+    }),
+    [
+      idOrNameSearch,
+      maxAge,
+      maxSalary,
+      minAge,
+      minRoleYears,
+      minSalary,
+      minScore,
+      selectedBrands,
+      selectedCompanies,
+      selectedEducation,
+      selectedExperienceLevel,
+      selectedSources,
+      selectedStatuses,
+      selectedTags,
+    ],
+  )
+  const shareState = useMemo(() => ({
+    location,
+    keywords: parseKeywordQuery(searchQuery ?? '').keywords,
+    filters: member.searchRun.filters,
+    jobDescriptionId,
+  }), [jobDescriptionId, location, member.searchRun.filters, searchQuery])
+  const analysisTitle = t('resumes.searchPage.analysis.title', {
+    defaultValue: 'Resume AI analysis',
+  })
+  const analysisDescription = t('resumes.searchPage.analysis.description', {
+    defaultValue: 'Generate per-resume AI summaries and breakdowns for the loaded search results.',
+  })
+  const analyzeLoadedLabel = t('resumes.searchPage.analysis.analyzeLoaded', {
+    count: displayItems.length,
+    defaultValue: 'Analyze loaded {{count}}',
+  })
 
   const handleToggleExpanded = useCallback((key: string) => {
     setExpandedIds((current) => {
@@ -259,6 +900,22 @@ function MemberPublicShareResults({
       }
       return next
     })
+  }, [])
+
+  const handleSelectAll = useCallback(() => {
+    setSelectedIds(new Set(displayItems.map((item) => item.key)))
+  }, [displayItems])
+
+  const handleSelectHighScore = useCallback(() => {
+    setSelectedIds(new Set(
+      displayItems
+        .filter(isHighScoreResult)
+        .map((item) => item.key),
+    ))
+  }, [displayItems])
+
+  const handleClearSelection = useCallback(() => {
+    setSelectedIds(new Set())
   }, [])
 
   const handleAction = useCallback(
@@ -294,98 +951,339 @@ function MemberPublicShareResults({
     [blockCandidates, unblockCandidate],
   )
 
+  const handleSetAgeRange = useCallback((nextMinAge: number | undefined, nextMaxAge: number | undefined) => {
+    setMinAge(nextMinAge)
+    setMaxAge(nextMaxAge)
+  }, [])
+
+  const handleSetSalaryRange = useCallback((nextMinSalary: number | undefined, nextMaxSalary: number | undefined) => {
+    setMinSalary(nextMinSalary)
+    setMaxSalary(nextMaxSalary)
+  }, [])
+
+  const handleClearFilters = useCallback(() => {
+    setIdOrNameSearch(undefined)
+    setMinScore(undefined)
+    setMinRoleYears(undefined)
+    setMinAge(undefined)
+    setMaxAge(undefined)
+    setMinSalary(undefined)
+    setMaxSalary(undefined)
+    setSelectedBrands([])
+    setSelectedCompanies([])
+    setSelectedEducation([])
+    setSelectedExperienceLevel(undefined)
+    setSelectedSources([])
+    setSelectedStatuses(ALL_CANDIDATE_STATUSES)
+    setSelectedTags([])
+  }, [])
+
+  const handleStatusFilterChange = useCallback((statuses: CandidateStatus[] | undefined) => {
+    setSelectedStatuses(statuses && statuses.length > 0 ? statuses : ALL_CANDIDATE_STATUSES)
+  }, [])
+
+  const toggleStatus = useCallback((status: CandidateStatus) => {
+    setSelectedStatuses((current) => toggleStatusValue(current, status))
+  }, [])
+
+  const ensureShareSession = useCallback(async () => reviewSessionId, [reviewSessionId])
+
+  const applyExtractedKeywords = useCallback((keywords: string[]) => {
+    setQueryInput(formatKeywordQuery(keywords))
+  }, [])
+
+  const handleBulkAction = useCallback(
+    async (action: 'shortlist' | 'reject' | 'block' | 'export', format?: ResumeExportFormat) => {
+      if (!canReview || selectedIds.size === 0) {
+        return
+      }
+
+      const selectedItems = displayItems.filter((item) => selectedIds.has(item.key))
+      if (selectedItems.length === 0) {
+        return
+      }
+
+      if (action === 'export') {
+        if (!reviewSessionId) {
+          return
+        }
+
+        const jobDescriptionId = resolveReviewSessionJobDescriptionId(member.searchRun.query)
+        const exportRequest: ResumeExportRequestBody = {
+          format: format ?? exportFormat,
+          source: 'convex',
+          sessionId: reviewSessionId,
+          ...(jobDescriptionId ? { jobDescriptionId } : {}),
+          entries: selectedItems.map((item) =>
+            buildSharedExportEntry(item, ratingsByResume[item.resume.resumeId])
+          ),
+        }
+
+        try {
+          await submitResumeExportDownload(apiBaseUrl, exportRequest)
+          toast.info(`Started export for ${selectedItems.length} resumes`)
+        } catch (error) {
+          console.error('Failed to export shared snapshot results', error)
+          const message =
+            error instanceof Error && error.message.trim().length > 0
+              ? error.message
+              : 'Export failed. Please try again.'
+          toast.error(message)
+        }
+        return
+      }
+
+      if (action === 'block') {
+        const blocked = await blockCandidates(
+          selectedItems.map((item) => item.identityKey),
+          'bulk_block',
+        )
+        if (blocked) {
+          handleClearSelection()
+        }
+        return
+      }
+
+      const nextStatus: CandidateStatus = action === 'shortlist' ? 'shortlisted' : 'rejected'
+      await Promise.all(
+        selectedItems.map((item) =>
+          saveAction({ resumeId: item.resume.resumeId, actionType: action }),
+        ),
+      )
+      await Promise.all(
+        selectedItems.map((item) =>
+          updateStatus(item.identityKey, nextStatus),
+        ),
+      )
+      handleClearSelection()
+    },
+    [
+      blockCandidates,
+      canReview,
+      displayItems,
+      exportFormat,
+      handleClearSelection,
+      member.searchRun.query,
+      ratingsByResume,
+      reviewSessionId,
+      saveAction,
+      selectedIds,
+      updateStatus,
+    ],
+  )
+
+  const facetSidebarProps = {
+    facetCounts,
+    minAge,
+    maxAge,
+    minScore,
+    minRoleYears,
+    minSalary,
+    maxSalary,
+    selectedBrands,
+    selectedClusters,
+    selectedCompanies,
+    selectedEducation,
+    selectedExperienceLevel,
+    selectedSources,
+    selectedStatuses,
+    selectedTags,
+    onClearAll: handleClearFilters,
+    onSetAgeRange: handleSetAgeRange,
+    onSetExperienceLevel: setSelectedExperienceLevel,
+    onSetMinRoleYears: setMinRoleYears,
+    onSetMinScore: setMinScore,
+    onSetSalaryRange: handleSetSalaryRange,
+    onToggleBrand: (value: string) => setSelectedBrands((current) => toggleStringValue(current, value)),
+    onToggleCompany: (value: string) => setSelectedCompanies((current) => toggleStringValue(current, value)),
+    onToggleCluster: () => {},
+    onToggleEducation: (value: string) => setSelectedEducation((current) => toggleStringValue(current, value)),
+    onToggleSource: (value: string) => setSelectedSources((current) => toggleStringValue(current, value)),
+    onToggleStatus: toggleStatus,
+    onToggleTag: (value: string) => setSelectedTags((current) => toggleStringValue(current, value)),
+    idOrNameSearch,
+    onSetIdOrNameSearch: setIdOrNameSearch,
+    loadedCount: items.length,
+  }
+
   return (
-    <section className="space-y-3">
-      <div className="text-sm font-medium text-foreground">
-        Results
-      </div>
-      <SearchResultsList
-        expandedIds={expandedIds}
-        hasMore={false}
-        items={items}
+    <div className="space-y-6">
+      <h1 className="sr-only">{shareTitle ?? 'Shared resume search'}</h1>
+      <SearchHeader
+        activeQuery={queryInput}
+        activeResultCount={displayItems.length}
+        activeResultCountIsLowerBound={false}
+        jobDescriptionId={jobDescriptionId}
         loading={docs === undefined}
-        onLoadMore={() => {}}
-        onToggleExpanded={handleToggleExpanded}
-        selectedIds={selectedIds}
-        actionsByResume={actionsByResume}
-        ratingsByResume={ratingsByResume}
-        onToggleSelect={member.canReview ? handleToggleSelect : undefined}
-        onAction={member.canReview ? handleAction : undefined}
-        onRating={member.canReview ? handleRating : undefined}
-        onCandidateStatusChange={member.canReview ? handleCandidateStatusChange : undefined}
-        onToggleBlock={member.canReview ? handleToggleBlock : undefined}
-        searchQuery={searchQuery}
-        showAiScore
+        location={location}
+        prefetchSearch={false}
+        queryInput={queryInput}
+        recentSearches={[]}
+        sortValue={sortValue}
+        statusSummary={statusSummary}
+        onApplyRecentSearch={() => {}}
+        onApplyExtractedKeywords={applyExtractedKeywords}
+        onChangeQuery={setQueryInput}
+        onClearQuery={() => setQueryInput('')}
+        onSubmitQuery={(value) => {
+          if (typeof value === 'string') {
+            setQueryInput(value)
+          }
+        }}
+        onSortChange={setSortValue}
       />
-    </section>
+
+      <div className="flex gap-6">
+        <div className="hidden w-72 shrink-0 min-[1440px]:block">
+          <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto pb-4">
+            <FacetSidebar {...facetSidebarProps} />
+          </div>
+        </div>
+
+        <div className="hidden shrink-0 md:block min-[1440px]:hidden">
+          <div className="sticky top-24">
+            <FacetBadge
+              activeCount={filterCount}
+              onClick={() => setFiltersOpen(true)}
+            />
+          </div>
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-[1.5rem] border bg-white/80 px-4 py-3 shadow-sm">
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-slate-900">
+                {analysisTitle}
+              </div>
+              <p className="text-sm text-slate-600">
+                {analysisDescription}
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <ModeToggle
+                mode="ai"
+                onModeChange={() => {}}
+                disabled
+              />
+              <Button
+                type="button"
+                size="sm"
+                data-testid="resume-analyze-button"
+                className="h-10 gap-2 rounded-full px-4"
+                disabled
+              >
+                <RefreshCw className="h-4 w-4" />
+                {analyzeLoadedLabel}
+              </Button>
+              <ShareLinkButton
+                shareTitle={shareTitle ?? 'Shared resume search'}
+                state={shareState}
+                ensureApiSession={ensureShareSession}
+              />
+            </div>
+          </div>
+
+          <div className="sticky top-14 z-20 -mx-1 bg-background/95 px-1 py-1 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+            <BulkActionBar
+              totalCount={displayItems.length}
+              selectedCount={selectedIds.size}
+              highScoreCount={highScoreCount}
+              exportFormat={exportFormat}
+              disabled={!canReview || docs === undefined}
+              onExportFormatChange={setExportFormat}
+              onSelectAll={handleSelectAll}
+              onSelectHighScore={handleSelectHighScore}
+              onClearSelection={handleClearSelection}
+              onBulkAction={handleBulkAction}
+              statusFilter={selectedStatuses}
+              onStatusFilterChange={handleStatusFilterChange}
+              onStatusToggle={toggleStatus}
+              statusFacetCounts={statusFacetCounts}
+            />
+          </div>
+
+          <SearchResultsList
+            expandedIds={expandedIds}
+            hasMore={false}
+            items={displayItems}
+            loading={docs === undefined}
+            onLoadMore={() => {}}
+            onToggleExpanded={handleToggleExpanded}
+            selectedIds={selectedIds}
+            actionsByResume={actionsByResume}
+            ratingsByResume={ratingsByResume}
+            onToggleSelect={canReview ? handleToggleSelect : undefined}
+            onAction={canReview ? handleAction : undefined}
+            onRating={canReview ? handleRating : undefined}
+            onCandidateStatusChange={canReview ? handleCandidateStatusChange : undefined}
+            onToggleBlock={canReview ? handleToggleBlock : undefined}
+            searchQuery={queryInput}
+            showAiScore
+          />
+        </div>
+      </div>
+
+      <div className="fixed bottom-5 right-5 z-30 md:hidden">
+        <FacetBadge
+          floating
+          activeCount={filterCount}
+          onClick={() => setFiltersOpen(true)}
+        />
+      </div>
+
+      <MobileFilterSheet
+        open={filtersOpen}
+        onOpenChange={setFiltersOpen}
+        {...facetSidebarProps}
+      />
+    </div>
   )
 }
 
-function PublicShareReady({ share }: { share: NonNullable<PublicShareResponse['share']> }) {
+function PublicShareReady({
+  share,
+  token,
+}: {
+  share: NonNullable<PublicShareResponse['share']>
+  token: string
+}) {
   const createdAt = formatDate(share.createdAt)
   const expiresAt = formatDate(share.expiresAt)
   const payload = share.snapshot.payload
   const results = payload.results
-  const filters = payload.search?.filters ? Object.entries(payload.search.filters) : []
+
+  if (share.member) {
+    return (
+      <MemberPublicShareResults
+        member={share.member}
+        results={results}
+        searchQuery={payload.search?.query}
+        shareTitle={share.title ?? payload.title}
+        token={token}
+      />
+    )
+  }
 
   return (
-    <div className="mx-auto max-w-6xl space-y-8 py-6">
-      <header className="space-y-4 border-b pb-6">
-        <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-          <span className="rounded-md border px-2 py-1 font-medium text-foreground">Snapshot</span>
-          {createdAt && (
-            <span className="inline-flex items-center gap-1.5">
-              <Clock className="h-4 w-4" />
-              {createdAt}
-            </span>
-          )}
-        </div>
-        <div className="space-y-2">
-          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
-            {share.title ?? payload.title ?? 'Public resume snapshot'}
-          </h1>
-          {share.description && (
-            <p className="max-w-3xl text-sm leading-6 text-muted-foreground">{share.description}</p>
-          )}
-          {expiresAt && (
-            <p className="text-xs text-muted-foreground">Expires {expiresAt}</p>
-          )}
-        </div>
+    <div className="mx-auto max-w-6xl space-y-6 py-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+          {share.title ?? payload.title ?? 'Public resume snapshot'}
+        </h1>
+        {share.description && (
+          <p className="max-w-3xl text-sm leading-6 text-muted-foreground">{share.description}</p>
+        )}
       </header>
 
-      {(payload.search?.query || filters.length > 0) && (
-        <section className="space-y-3">
-          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-            <Search className="h-4 w-4" />
-            Search
-          </div>
-          {payload.search?.query && (
-            <p className="text-sm text-muted-foreground">{payload.search.query}</p>
-          )}
-          {filters.length > 0 && (
-            <div className="flex flex-wrap gap-2">
-              {filters.map(([key, value]) => {
-                const label = formatFilterValue(value)
-                return label ? (
-                  <span key={key} className="rounded-md border px-2 py-1 text-xs text-muted-foreground">
-                    {key}: {label}
-                  </span>
-                ) : null
-              })}
-            </div>
-          )}
-        </section>
-      )}
+      <PublicSnapshotSearchShell
+        createdAt={createdAt}
+        expiresAt={expiresAt}
+        filters={payload.search?.filters}
+        query={payload.search?.query}
+        resultCount={results.length}
+      />
 
-      {share.member ? (
-        <MemberPublicShareResults
-          member={share.member}
-          results={results}
-          searchQuery={payload.search?.query}
-        />
-      ) : (
-        <StaticPublicShareResults results={results} />
-      )}
+      <StaticPublicShareResults results={results} />
 
       <footer className="border-t pt-4 text-xs text-muted-foreground">
         {share.snapshot.scoringMode} · {share.snapshot.promptVersion} · {share.snapshot.skillConfigVersion}
@@ -477,10 +1375,10 @@ export function PublicSharePage() {
   if (share.member) {
     return (
       <WorkspaceProvider workspaceSlug={share.member.workspaceSlug as WorkspaceSlug} surface="workspace">
-        <PublicShareReady share={share} />
+        <PublicShareReady share={share} token={token ?? ''} />
       </WorkspaceProvider>
     )
   }
 
-  return <PublicShareReady share={share} />
+  return <PublicShareReady share={share} token={token ?? ''} />
 }


### PR DESCRIPTION
## Summary
- Strip client-supplied `userId` from session create/update payloads so the API uses the authenticated identity (`c.var.auth?.user.id`).
- Add `enabled` flag to `useSearchPrefetch` and a `prefetchSearch` prop on `SearchHeader`/`GoogleSearchBar` so public share can opt out of prefetching against the member-only resume index.
- Expand `PublicSharePage` with interactive member review: facet sidebar, bulk actions, share-link button, authenticated review-session persistence via `localStorage`, export flow.

## Test plan
- [x] `make check` passes (typecheck, lint, OpenAPI gen, governance sync)
- [x] `apps/api/src/routes/sessions.test.ts` — 5/5 pass (incl. new "binds created sessions to the authenticated user" test)
- [x] `apps/web/src/hooks/useSearchPrefetch.test.ts` — all pass (incl. `enabled=false` skip case)
- [x] `apps/web/src/pages/PublicSharePage.test.tsx` — 11/11 pass
- [ ] Manual smoke against `make dev` stack via `/playwright-cli` (deferred — no running dev stack this cycle)