### PR TITLE
feat: revoke other sessions on password change + add logout-everywhere endpoint

### DIFF
--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -590,6 +590,86 @@ describe("auth routes", () => {
     });
     expect(fromIp2.status).toBe(401);
   });
+
+  it("changePassword revokes all other sessions for the user", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-cp-revoke-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(storage.db);
+    const user = await seedLocalUser(storage);
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+
+    // Current session (the one making the change-password request)
+    const currentSession = sessions.createSession(user.id);
+    // A second "other device" session that should be revoked
+    const otherSession = sessions.createSession(user.id);
+
+    const app = createTestApp(storage, eventStorage);
+
+    const response = await app.request("/api/auth/change-password", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "hr",
+        "X-CSRF-Token": currentSession.csrfToken,
+        Cookie: `${config.auth.sessionCookieName}=${currentSession.token}`,
+      },
+      body: JSON.stringify({ currentPassword: "secret-pass", newPassword: "new-secret-pass-2" }),
+    });
+
+    expect(response.status).toBe(200);
+    // Current session survives
+    expect(sessions.resolveSession(currentSession.token)).not.toBeNull();
+    // Other session is revoked
+    expect(sessions.resolveSession(otherSession.token)).toBeNull();
+    // sessions_revoked event recorded
+    const events = eventStorage.listRecent({ limit: 50 });
+    expect(events.some((e) => e.type === "sessions_revoked" && e.reason === "password_change")).toBe(true);
+  });
+
+  it("revoke-all endpoint revokes all sessions except the caller's current one", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-revoke-all-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(storage.db);
+    const user = await seedLocalUser(storage);
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+
+    const currentSession = sessions.createSession(user.id);
+    const otherSession = sessions.createSession(user.id);
+
+    const app = createTestApp(storage, eventStorage);
+
+    const response = await app.request("/api/auth/sessions/revoke-all", {
+      method: "POST",
+      headers: {
+        "X-Workspace-Slug": "hr",
+        "X-CSRF-Token": currentSession.csrfToken,
+        Cookie: `${config.auth.sessionCookieName}=${currentSession.token}`,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    // Current session survives
+    expect(sessions.resolveSession(currentSession.token)).not.toBeNull();
+    // Other session is revoked
+    expect(sessions.resolveSession(otherSession.token)).toBeNull();
+    // sessions_revoked event recorded with reason revoke_all
+    const events = eventStorage.listRecent({ limit: 50 });
+    expect(events.some((e) => e.type === "sessions_revoked" && e.reason === "revoke_all")).toBe(true);
+  });
+
+  it("revoke-all endpoint rejects unauthenticated requests", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-revoke-all-auth-"));
+    const storage = new AuthStorage(root);
+    await seedLocalUser(storage);
+    const app = createTestApp(storage);
+
+    const response = await app.request("/api/auth/sessions/revoke-all", {
+      method: "POST",
+      headers: { "X-Workspace-Slug": "hr" },
+    });
+
+    expect(response.status).toBe(401);
+  });
 });
 
 describe("GET /api/auth/options", () => {

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,4 +1,5 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import type { Context } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 
 import { getAdminAccessError } from "../middleware/auth.js";
@@ -10,12 +11,22 @@ import {
 } from "../middleware/login-rate-limit.js";
 import { AuthEventStorage } from "../services/auth-event-storage.js";
 import type { AuthEvent } from "../services/auth-event-types.js";
-import { AuthSessionService } from "../services/auth-session-service.js";
+import { AuthSessionService, hashSecret } from "../services/auth-session-service.js";
 import { AuthStorage } from "../services/auth-storage.js";
 import type { AuthContext, AuthProvider, AuthUser, WorkspaceMembership, WorkspaceRole } from "../services/auth-types.js";
 import { config } from "../services/config.js";
 import { hashPassword, verifyPassword } from "../services/local-password-provider.js";
 import { CasdoorOidcProvider } from "../services/oidc-provider.js";
+
+/**
+ * Derive the current session's token hash from the request cookie, for use as
+ * the `exceptTokenHash` argument to `revokeAllSessionsByUser`. Returns
+ * `undefined` when no session cookie is present.
+ */
+function currentSessionTokenHash(c: Context): string | undefined {
+  const token = getCookie(c, config.auth.sessionCookieName);
+  return token ? hashSecret(token) : undefined;
+}
 
 type AuthRoutesOptions = {
   storage?: AuthStorage;
@@ -575,6 +586,64 @@ export function createAuthRoutes(options: AuthRoutesOptions = {}) {
       ...(await hashPassword(newPassword)),
       mustChangePassword: false,
     });
+
+    // Revoke all other sessions for this user — a compromised password, once
+    // changed, must kick the attacker out. Preserve the caller's current
+    // session so the legitimate user isn't forced to re-login immediately.
+    const exceptTokenHash = currentSessionTokenHash(c);
+    authStorage.revokeAllSessionsByUser(auth.user.id, exceptTokenHash);
+    getEventStorage().append({
+      type: "sessions_revoked",
+      userId: auth.user.id,
+      workspaceSlug: c.var.workspaceSlug,
+      reason: "password_change",
+      sessionId: auth.sessionId,
+    });
+
+    return c.json({ success: true as const }, 200);
+  });
+
+  const revokeAllSessionsRoute = createRoute({
+    method: "post",
+    path: "/api/auth/sessions/revoke-all",
+    tags: ["auth"],
+    responses: {
+      200: {
+        description: "All other sessions revoked",
+        content: {
+          "application/json": {
+            schema: SuccessResponseSchema,
+          },
+        },
+      },
+      401: {
+        description: "Authentication required",
+        content: {
+          "application/json": {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+    },
+  });
+
+  app.openapi(revokeAllSessionsRoute, (c) => {
+    const auth = c.var.auth;
+    if (!auth) {
+      return c.json({ success: false as const, error: "Authentication required" }, 401);
+    }
+
+    const exceptTokenHash = currentSessionTokenHash(c);
+    const authStorage = getStorage();
+    authStorage.revokeAllSessionsByUser(auth.user.id, exceptTokenHash);
+    getEventStorage().append({
+      type: "sessions_revoked",
+      userId: auth.user.id,
+      workspaceSlug: c.var.workspaceSlug,
+      reason: "revoke_all",
+      sessionId: auth.sessionId,
+    });
+
     return c.json({ success: true as const }, 200);
   });
 

--- a/apps/api/src/services/auth-event-types.ts
+++ b/apps/api/src/services/auth-event-types.ts
@@ -3,6 +3,7 @@ export type AuthEventType =
   | "login_failure"
   | "login_throttled"
   | "logout"
+  | "sessions_revoked"
   | "csrf_reject"
   | "workspace_access_denied"
   | "admin_access_denied"

--- a/apps/api/src/services/auth-storage.test.ts
+++ b/apps/api/src/services/auth-storage.test.ts
@@ -307,3 +307,104 @@ describe("auth sqlite schema", () => {
     ]);
   });
 });
+
+describe("auth session revocation by user", () => {
+  afterEach(() => {
+    resetResumeScreeningDb();
+  });
+
+  it("listSessionsByUser returns all non-revoked sessions for a user", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-session-list-"));
+    const storage = new AuthStorage(root);
+    const user = storage.createUser({ email: "u@example.com", displayName: "U" });
+
+    storage.createSession({
+      userId: user.id,
+      tokenHash: "hash-1",
+      csrfTokenHash: "csrf-1",
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    });
+    storage.createSession({
+      userId: user.id,
+      tokenHash: "hash-2",
+      csrfTokenHash: "csrf-2",
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    });
+
+    const sessions = storage.listSessionsByUser(user.id);
+    expect(sessions).toHaveLength(2);
+    expect(sessions.map((s) => s.tokenHash).sort()).toEqual(["hash-1", "hash-2"]);
+  });
+
+  it("revokeAllSessionsByUser revokes every session for the user", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-session-revoke-all-"));
+    const storage = new AuthStorage(root);
+    const user = storage.createUser({ email: "u@example.com", displayName: "U" });
+
+    storage.createSession({
+      userId: user.id,
+      tokenHash: "hash-1",
+      csrfTokenHash: "csrf-1",
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    });
+    storage.createSession({
+      userId: user.id,
+      tokenHash: "hash-2",
+      csrfTokenHash: "csrf-2",
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    });
+
+    const revoked = storage.revokeAllSessionsByUser(user.id);
+    expect(revoked).toBe(2);
+    expect(storage.listSessionsByUser(user.id)).toHaveLength(0);
+  });
+
+  it("revokeAllSessionsByUser preserves an excepted token hash", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-session-except-"));
+    const storage = new AuthStorage(root);
+    const user = storage.createUser({ email: "u@example.com", displayName: "U" });
+
+    storage.createSession({
+      userId: user.id,
+      tokenHash: "keep-me",
+      csrfTokenHash: "csrf-keep",
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    });
+    storage.createSession({
+      userId: user.id,
+      tokenHash: "revoke-me",
+      csrfTokenHash: "csrf-revoke",
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    });
+
+    const revoked = storage.revokeAllSessionsByUser(user.id, "keep-me");
+    expect(revoked).toBe(1);
+    const remaining = storage.listSessionsByUser(user.id);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.tokenHash).toBe("keep-me");
+  });
+
+  it("revokeAllSessionsByUser does not touch other users' sessions", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-session-isolation-"));
+    const storage = new AuthStorage(root);
+    const userA = storage.createUser({ email: "a@example.com", displayName: "A" });
+    const userB = storage.createUser({ email: "b@example.com", displayName: "B" });
+
+    storage.createSession({
+      userId: userA.id,
+      tokenHash: "hash-a",
+      csrfTokenHash: "csrf-a",
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    });
+    storage.createSession({
+      userId: userB.id,
+      tokenHash: "hash-b",
+      csrfTokenHash: "csrf-b",
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    });
+
+    storage.revokeAllSessionsByUser(userA.id);
+    expect(storage.listSessionsByUser(userA.id)).toHaveLength(0);
+    expect(storage.listSessionsByUser(userB.id)).toHaveLength(1);
+  });
+});

--- a/apps/api/src/services/auth-storage.ts
+++ b/apps/api/src/services/auth-storage.ts
@@ -90,6 +90,7 @@ type UserRow = {
 export type StoredAuthSession = {
   id: string;
   userId: string;
+  tokenHash: string;
   csrfTokenHash: string;
   expiresAt: string;
 };
@@ -103,6 +104,7 @@ export type StoredPasswordCredential = PasswordCredential & {
 type SessionRow = {
   id?: unknown;
   user_id?: unknown;
+  token_hash?: unknown;
   csrf_token_hash?: unknown;
   expires_at?: unknown;
   revoked_at?: unknown;
@@ -957,6 +959,7 @@ export class AuthStorage {
     return {
       id,
       userId: input.userId,
+      tokenHash: input.tokenHash,
       csrfTokenHash: input.csrfTokenHash,
       expiresAt: input.expiresAt,
     };
@@ -964,7 +967,7 @@ export class AuthStorage {
 
   findSessionByTokenHash(tokenHash: string): StoredAuthSession | null {
     const row = this.db.prepare(`
-      SELECT id, user_id, csrf_token_hash, expires_at, revoked_at
+      SELECT id, user_id, token_hash, csrf_token_hash, expires_at, revoked_at
       FROM auth_sessions
       WHERE token_hash = ?
     `).get(tokenHash) as SessionRow | undefined;
@@ -973,6 +976,7 @@ export class AuthStorage {
       !row
       || typeof row.id !== "string"
       || typeof row.user_id !== "string"
+      || typeof row.token_hash !== "string"
       || typeof row.csrf_token_hash !== "string"
       || typeof row.expires_at !== "string"
       || row.revoked_at
@@ -987,6 +991,7 @@ export class AuthStorage {
     return {
       id: row.id,
       userId: row.user_id,
+      tokenHash: row.token_hash,
       csrfTokenHash: row.csrf_token_hash,
       expiresAt: row.expires_at,
     };
@@ -998,6 +1003,60 @@ export class AuthStorage {
       SET revoked_at = ?
       WHERE token_hash = ? AND revoked_at IS NULL
     `).run(toIsoNow(), tokenHash);
+  }
+
+  /**
+   * List all non-revoked sessions for a user. Expiry filtering is applied in
+   * JS (via Date.parse) to match the existing findSessionByTokenHash pattern —
+   * ISO-string SQL comparison is fragile across timezone-offset formats.
+   */
+  listSessionsByUser(userId: string): StoredAuthSession[] {
+    const rows = this.db.prepare(`
+      SELECT id, user_id, token_hash, csrf_token_hash, expires_at, revoked_at
+      FROM auth_sessions
+      WHERE user_id = ? AND revoked_at IS NULL
+    `).all(userId) as SessionRow[];
+
+    const now = Date.now();
+    return rows
+      .filter((row): row is SessionRow & Record<"id" | "user_id" | "token_hash" | "csrf_token_hash" | "expires_at", string> => (
+        typeof row.id === "string"
+        && typeof row.user_id === "string"
+        && typeof row.token_hash === "string"
+        && typeof row.csrf_token_hash === "string"
+        && typeof row.expires_at === "string"
+      ))
+      .filter((row) => Date.parse(row.expires_at) > now)
+      .map((row) => ({
+        id: row.id,
+        userId: row.user_id,
+        tokenHash: row.token_hash,
+        csrfTokenHash: row.csrf_token_hash,
+        expiresAt: row.expires_at,
+      }));
+  }
+
+  /**
+   * Revoke every non-revoked session for a user. Optionally preserve one
+   * token hash (e.g. the caller's current session on change-password).
+   * Returns the count of revoked sessions.
+   */
+  revokeAllSessionsByUser(userId: string, exceptTokenHash?: string): number {
+    const now = toIsoNow();
+    if (exceptTokenHash) {
+      const result = this.db.prepare(`
+        UPDATE auth_sessions
+        SET revoked_at = ?
+        WHERE user_id = ? AND revoked_at IS NULL AND token_hash != ?
+      `).run(now, userId, exceptTokenHash);
+      return result.changes;
+    }
+    const result = this.db.prepare(`
+      UPDATE auth_sessions
+      SET revoked_at = ?
+      WHERE user_id = ? AND revoked_at IS NULL
+    `).run(now, userId);
+    return result.changes;
   }
 
   saveOidcState(state: StoredOidcState): void {

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -304,6 +304,57 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/auth/sessions/revoke-all": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description All other sessions revoked */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                        };
+                    };
+                };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/auth/casdoor/login": {
         parameters: {
             query?: never;


### PR DESCRIPTION
## Summary

- **changePassword now revokes all other sessions for the user** after a successful credential update, closing the stolen-password-survives-reset security defect. The attacker's session token is rejected on next request while the legitimate caller's current session survives.
- **New `POST /api/auth/sessions/revoke-all` endpoint** for logout-everywhere (legitimate user, or admin force-logout) — revokes all caller sessions except the current one.
- New storage primitives `AuthStorage.listSessionsByUser(userId)` and `revokeAllSessionsByUser(userId, exceptTokenHash?)` — foundation for future admin session-list surface and the account-recovery slice.
- `StoredAuthSession` now surfaces `tokenHash` (was internal); `createSession` and `findSessionByTokenHash` populate it.
- New `AuthEventType: sessions_revoked` (reason: `password_change` or `revoke_all`).
- Shared `currentSessionTokenHash(c)` helper deduplicates cookie+hash derivation.

Second slice of the Trends auth production refactor. See work item `projects/trends/work/2026-06-15-session-lifecycle-production-gaps/`. Preserves the Trends-owned session model (opaque tokens, sha256-hashed at rest) per the 2026-06-09 directive.

## Test plan

- [x] `bunx vitest run apps/api/src/routes/auth.test.ts apps/api/src/services/auth-storage.test.ts apps/api/src/middleware/auth.test.ts` — 49 tests pass (7 new + 42 existing)
- [x] `make check` passes (typecheck + lint + governance + route-auth matrix)
- [x] RED→GREEN: new tests written first, confirmed failing, then implementation made them pass
- [x] Regression: existing login/logout/CSRF/session tests unaffected

### New tests (7)
**Storage (`auth-storage.test.ts`):**
- `listSessionsByUser` returns all non-revoked sessions
- `revokeAllSessionsByUser` revokes every session
- `revokeAllSessionsByUser` preserves an excepted token hash
- `revokeAllSessionsByUser` does not touch other users' sessions

**Routes (`auth.test.ts`):**
- `changePassword` revokes all other sessions (current survives) + emits `sessions_revoked`/`password_change`
- `revoke-all` endpoint revokes all except current + emits `sessions_revoked`/`revoke_all`
- `revoke-all` endpoint rejects unauthenticated requests (401)

### Out of scope (deferred)
- Per-user session count cap (queued separately)
- Sliding-window session refresh (fixed 7-day TTL retained)
- Disable-user session revocation (no disable-user path exists yet — CLI or admin route; will wire when added)