### PR TITLE
refactor: remove dead auth schema columns and config keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,6 @@ VITE_DEFAULT_LOCALE=zh-Hans   # Frontend UI / static content default language
 # Auth
 # Local demo auth helper password for `bun run auth:bootstrap-demo`.
 AUTH_BOOTSTRAP_PASSWORD=demo-admin
-# AUTH_DEV_BYPASS=true              # Skip auth checks in local dev (never use in production)
 # AUTH_ALLOWED_ORIGINS=http://localhost:5173  # Comma-separated CORS origins
 # AUTH_SESSION_TTL_SECONDS=604800   # Session lifetime (default 7 days)
 # AUTH_OIDC_ENABLED=true            # Enable Casdoor OIDC login

--- a/apps/api/src/services/auth-storage.test.ts
+++ b/apps/api/src/services/auth-storage.test.ts
@@ -1,7 +1,8 @@
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, mkdirSync as fsMkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
+import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { AuthEventStorage } from "./auth-event-storage.js";
@@ -33,6 +34,57 @@ describe("auth sqlite schema", () => {
         "auth_provider_membership_grants",
       ]),
     );
+  });
+
+  it("does not carry dead auth columns on the users table", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-dead-cols-"));
+    const db = getResumeScreeningDb(root);
+
+    const columns = db
+      .prepare("PRAGMA table_info(users)")
+      .all() as Array<{ name: string }>;
+    const columnNames = columns.map((row) => row.name);
+
+    // Removed per ADR D1/D3 — authorization is membership-derived, "team" is
+    // a URL alias only, and last_active_at was never updated post-creation.
+    expect(columnNames).not.toContain("role");
+    expect(columnNames).not.toContain("team_id");
+    expect(columnNames).not.toContain("last_active_at");
+  });
+
+  it("drops dead auth columns when migrating an existing users table", () => {
+    // Simulate a restored prod DB that still has the legacy columns.
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-migrate-"));
+    const outputDir = path.join(root, "output");
+    fsMkdirSync(outputDir, { recursive: true });
+    const rawDb = new Database(path.join(outputDir, "resume_screening.db"));
+    rawDb.exec(`
+      CREATE TABLE users (
+        id TEXT PRIMARY KEY,
+        email TEXT,
+        name TEXT,
+        display_name TEXT,
+        status TEXT DEFAULT 'active',
+        role TEXT DEFAULT 'recruiter',
+        team_id TEXT,
+        created_at TEXT NOT NULL,
+        last_active_at TEXT,
+        settings TEXT
+      );
+    `);
+    rawDb.close();
+
+    // initSchema runs via getResumeScreeningDb and must idempotently drop the
+    // dead columns.
+    const db = getResumeScreeningDb(root);
+    const columns = db
+      .prepare("PRAGMA table_info(users)")
+      .all() as Array<{ name: string }>;
+    const columnNames = columns.map((row) => row.name);
+
+    expect(columnNames).not.toContain("role");
+    expect(columnNames).not.toContain("team_id");
+    expect(columnNames).not.toContain("last_active_at");
   });
 
   it("creates a user, local identity, and workspace membership", () => {

--- a/apps/api/src/services/auth-storage.ts
+++ b/apps/api/src/services/auth-storage.ts
@@ -217,14 +217,13 @@ export class AuthStorage {
     const id = randomUUID();
     const now = toIsoNow();
     this.db.prepare(`
-      INSERT INTO users (id, email, name, display_name, status, created_at, last_active_at)
-      VALUES (?, ?, ?, ?, 'active', ?, ?)
+      INSERT INTO users (id, email, name, display_name, status, created_at)
+      VALUES (?, ?, ?, ?, 'active', ?)
     `).run(
       id,
       input.email ?? null,
       input.displayName ?? null,
       input.displayName ?? null,
-      now,
       now,
     );
 

--- a/apps/api/src/services/config.ts
+++ b/apps/api/src/services/config.ts
@@ -36,8 +36,6 @@ export const config = {
     csrfCookieName: process.env.AUTH_CSRF_COOKIE_NAME || "trends_csrf",
     sessionTtlSeconds: parseInt(process.env.AUTH_SESSION_TTL_SECONDS || "604800", 10),
     secureCookies: isProduction,
-    devBypassEnabled: process.env.AUTH_DEV_BYPASS === "true" && !isProduction,
-    devUserId: process.env.AUTH_DEV_USER_ID || "dev-admin",
     allowedOrigins: (process.env.AUTH_ALLOWED_ORIGINS || "")
       .split(",")
       .map((origin) => origin.trim())

--- a/apps/api/src/services/database.ts
+++ b/apps/api/src/services/database.ts
@@ -84,10 +84,7 @@ function initSchema(db: Database.Database): void {
       name TEXT,
       display_name TEXT,
       status TEXT DEFAULT 'active',
-      role TEXT DEFAULT 'recruiter',
-      team_id TEXT,
       created_at TEXT NOT NULL,
-      last_active_at TEXT,
       settings TEXT
     );
 
@@ -419,6 +416,14 @@ function initSchema(db: Database.Database): void {
   if (existingTables.has("auth_provider_membership_grants")) {
     ensureColumn(db, "auth_provider_membership_grants", "membership_created", "INTEGER NOT NULL DEFAULT 1");
   }
+
+  // Drop dead auth columns (ADR D1/D3). Idempotent — no-op on fresh DBs
+  // (CREATE TABLE above no longer declares them) and on DBs already migrated.
+  if (existingTables.has("users")) {
+    dropColumnIfExists(db, "users", "role");
+    dropColumnIfExists(db, "users", "team_id");
+    dropColumnIfExists(db, "users", "last_active_at");
+  }
 }
 
 function isDuplicateColumnError(error: unknown, column: string): boolean {
@@ -444,4 +449,23 @@ function ensureColumn(
     }
     throw error;
   }
+}
+
+/**
+ * Idempotently drop a column from a table. No-op if the column does not exist
+ * (e.g. fresh DBs created after the column was removed from CREATE TABLE, or
+ * DBs already migrated). Used to retire dead schema fields on restored prod
+ * databases without a separate migration runner.
+ */
+function dropColumnIfExists(
+  db: Database.Database,
+  table: string,
+  column: string
+): void {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: unknown }>;
+  const exists = rows.some((row) => row.name === column);
+  if (!exists) {
+    return;
+  }
+  db.exec(`ALTER TABLE ${table} DROP COLUMN ${column}`);
 }

--- a/scripts/check-auth-env.test.ts
+++ b/scripts/check-auth-env.test.ts
@@ -6,7 +6,6 @@ function makeInput(overrides: Partial<AuthEnvInput> = {}): AuthEnvInput {
     mode: 'local',
     CONVEX_WRITE_SECRET: '',
     AUTH_ALLOWED_ORIGINS: '',
-    AUTH_DEV_BYPASS: '',
     AUTH_OIDC_ENABLED: '',
     AUTH_OIDC_ISSUER: '',
     AUTH_OIDC_CLIENT_ID: '',
@@ -21,13 +20,6 @@ describe('checkAuthEnv', () => {
     it('passes with all auth values empty', () => {
       const result = checkAuthEnv(makeInput({ mode: 'local' }))
       expect(result.errors).toHaveLength(0)
-    })
-
-    it('warns when AUTH_DEV_BYPASS is true', () => {
-      const result = checkAuthEnv(makeInput({ mode: 'local', AUTH_DEV_BYPASS: 'true' }))
-      expect(result.warnings).toEqual(
-        expect.arrayContaining([expect.stringContaining('AUTH_DEV_BYPASS')])
-      )
     })
 
     it('passes when OIDC enabled with all required fields', () => {
@@ -107,18 +99,6 @@ describe('checkAuthEnv', () => {
       const result = checkAuthEnv(makeInput({ mode: 'production' }))
       expect(result.errors).toEqual(
         expect.arrayContaining([expect.stringContaining('AUTH_ALLOWED_ORIGINS')])
-      )
-    })
-
-    it('errors when AUTH_DEV_BYPASS is true', () => {
-      const result = checkAuthEnv(makeInput({
-        mode: 'production',
-        CONVEX_WRITE_SECRET: 'secret',
-        AUTH_ALLOWED_ORIGINS: 'https://trends.pt-mes.com',
-        AUTH_DEV_BYPASS: 'true',
-      }))
-      expect(result.errors).toEqual(
-        expect.arrayContaining([expect.stringContaining('AUTH_DEV_BYPASS')])
       )
     })
 

--- a/scripts/check-auth-env.ts
+++ b/scripts/check-auth-env.ts
@@ -17,7 +17,6 @@ export interface AuthEnvInput {
   mode: AuthEnvMode
   CONVEX_WRITE_SECRET: string
   AUTH_ALLOWED_ORIGINS: string
-  AUTH_DEV_BYPASS: string
   AUTH_OIDC_ENABLED: string
   AUTH_OIDC_ISSUER: string
   AUTH_OIDC_CLIENT_ID: string
@@ -43,16 +42,6 @@ export function checkAuthEnv(input: AuthEnvInput): CheckResult {
   // Production/preview: require AUTH_ALLOWED_ORIGINS
   if (isProdLike && !input.AUTH_ALLOWED_ORIGINS) {
     errors.push('AUTH_ALLOWED_ORIGINS is required in ' + input.mode + ' mode')
-  }
-
-  // AUTH_DEV_BYPASS must not be enabled in production
-  if (isProdLike && input.AUTH_DEV_BYPASS === 'true') {
-    errors.push('AUTH_DEV_BYPASS must not be enabled in ' + input.mode + ' mode')
-  }
-
-  // Local: warn if dev bypass is on (informational)
-  if (!isProdLike && input.AUTH_DEV_BYPASS === 'true') {
-    warnings.push('AUTH_DEV_BYPASS is enabled — auth checks are bypassed in local mode')
   }
 
   // OIDC validation: when enabled, all required fields must be set
@@ -120,7 +109,6 @@ function resolveInput(mode: AuthEnvMode, envFilePath?: string): AuthEnvInput {
     mode,
     CONVEX_WRITE_SECRET: get('CONVEX_WRITE_SECRET'),
     AUTH_ALLOWED_ORIGINS: get('AUTH_ALLOWED_ORIGINS'),
-    AUTH_DEV_BYPASS: get('AUTH_DEV_BYPASS'),
     AUTH_OIDC_ENABLED: get('AUTH_OIDC_ENABLED'),
     AUTH_OIDC_ISSUER: get('AUTH_OIDC_ISSUER'),
     AUTH_OIDC_CLIENT_ID: get('AUTH_OIDC_CLIENT_ID'),


### PR DESCRIPTION
## Summary

Removes four dead auth fields that were defined but never read at runtime, per [ADR D1/D3](projects/trends/architecture/decisions/2026-06-15-team-workspace-user-admin-vocabulary-coherence.md):

- **`users.role`** — default `'recruiter'`, but authorization uses `workspace_memberships.role` via `hasWorkspaceRole`. Zero runtime readers.
- **`users.team_id`** — zero references anywhere. "team" is a URL alias for workspace (ADR D1), no Team entity.
- **`users.last_active_at`** — set at user creation, never updated or read.
- **`config.auth.devBypassEnabled` / `devUserId`** — defined from `AUTH_DEV_BYPASS` / `AUTH_DEV_USER_ID` env vars, but never consumed by any middleware or route.

**Migration is idempotent.** New `dropColumnIfExists(db, table, column)` helper in `database.ts` guards `ALTER TABLE DROP COLUMN` with a `PRAGMA table_info` check. Fresh DBs never get the columns (removed from `CREATE TABLE`); restored prod DBs with legacy columns have them dropped on startup. Requires SQLite >= 3.35 (current bundled: 3.53.1).

Also cleans up `scripts/check-auth-env.ts` — removes the `AUTH_DEV_BYPASS` interface field, validation checks, env getter, and the two tests covering them.

Fourth (final ready) slice of the Trends auth production refactor. See work item `projects/trends/work/2026-06-15-dead-auth-schema-config-cleanup/`.

## Test plan

- [x] `make check` passes (typecheck + lint + governance + route-auth matrix)
- [x] `bunx vitest run apps/api/src/services/auth-storage.test.ts apps/api/src/routes/auth.test.ts scripts/check-auth-env.test.ts` — 48 tests pass
- [x] RED→GREEN: 2 new schema tests (fresh-DB drift + restored-prod-DB migration) written first, confirmed failing, then implementation made them pass
- [x] Consumer grep clean: no remaining `users.role`, `team_id`, `last_active_at`, `devBypassEnabled`, `devUserId`, `AUTH_DEV_BYPASS`, `AUTH_DEV_USER_ID` in production source
- [x] `createUser` INSERT updated to match new column list
- [x] `manage-user.ts --role` is workspace membership role, not the removed column

### New tests (2)
- Fresh DB: `users` table has no `role`, `team_id`, or `last_active_at` columns
- Restored prod DB simulation: `initSchema` drops legacy columns idempotently via `dropColumnIfExists`

### Out of scope
- Per-user session cap (queued separately)
- Sliding-window session refresh
- MFA / email verification (deferred — see account-recovery-mfa-gap work item)