### PR TITLE
feat: add admin password reset route behind experimental flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,7 @@ VITE_DEFAULT_LOCALE=zh-Hans   # Frontend UI / static content default language
 # Auth
 # Local demo auth helper password for `bun run auth:bootstrap-demo`.
 AUTH_BOOTSTRAP_PASSWORD=demo-admin
+# AUTH_ADMIN_RESET_ENABLED=true    # Experimental: admin password reset via POST /api/admin/reset-password. Default off.
 # AUTH_ALLOWED_ORIGINS=http://localhost:5173  # Comma-separated CORS origins
 # AUTH_SESSION_TTL_SECONDS=604800   # Session lifetime (default 7 days)
 # AUTH_OIDC_ENABLED=true            # Enable Casdoor OIDC login

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -40,6 +40,7 @@ import {
   resumesMatchRoutes,
 } from "./routes/index.js";
 import { createAuthRoutes } from "./routes/auth.js";
+import { createAdminUserRoutes } from "./routes/admin_users.js";
 import { config } from "./services/config.js";
 import type { AuthEventStorage } from "./services/auth-event-storage.js";
 import type { AuthStorage } from "./services/auth-storage.js";
@@ -188,6 +189,12 @@ export function createApp(options: CreateAppOptions = {}) {
     storage: options.authStorage,
     eventStorage: options.authEventStorage,
     ttlSeconds: options.authTtlSeconds,
+  }));
+  app.route("/", createAdminUserRoutes({
+    storage: options.authStorage,
+    eventStorage: options.authEventStorage,
+    adminResetEnabled: config.auth.adminResetEnabled,
+    authMiddleware,
   }));
   app.route("/", aiSummaryRoutes);
   app.route("/", taxonomyRoutes);

--- a/apps/api/src/routes/admin_users.test.ts
+++ b/apps/api/src/routes/admin_users.test.ts
@@ -1,0 +1,334 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createAuthMiddleware } from "../middleware/auth.js";
+import { workspaceMiddleware } from "../middleware/workspace.js";
+import { AuthSessionService } from "../services/auth-session-service.js";
+import { AuthEventStorage } from "../services/auth-event-storage.js";
+import { AuthStorage } from "../services/auth-storage.js";
+import { config } from "../services/config.js";
+import { resetResumeScreeningDb } from "../services/database.js";
+import { hashPassword, verifyPassword } from "../services/local-password-provider.js";
+import { createAdminUserRoutes } from "./admin_users.js";
+
+async function seedLocalUser(storage: AuthStorage, overrides: { username?: string; password?: string; email?: string; workspace?: string; role?: "user" | "admin" } = {}) {
+  const username = overrides.username ?? "hr-admin";
+  const user = storage.createUser({ email: overrides.email ?? "hr@example.com", displayName: "HR Admin" });
+  storage.linkIdentity({
+    userId: user.id,
+    provider: "local",
+    providerSubject: username,
+    providerTenant: "local",
+    email: user.email,
+    displayName: user.displayName,
+  });
+  storage.upsertMembership({ userId: user.id, workspaceSlug: overrides.workspace ?? "hr", role: overrides.role ?? "admin" });
+  storage.savePasswordCredential({
+    userId: user.id,
+    ...(await hashPassword(overrides.password ?? "secret-pass")),
+    mustChangePassword: false,
+  });
+  return { user, username, password: overrides.password ?? "secret-pass" };
+}
+
+async function seedDevAdmin(storage: AuthStorage) {
+  return seedLocalUser(storage, {
+    username: "dev-admin-user",
+    password: "dev-admin-pass",
+    email: "dev@example.com",
+    workspace: "dev",
+    role: "admin",
+  });
+}
+
+function createTestApp(
+  storage: AuthStorage,
+  eventStorage: AuthEventStorage,
+  options: { adminResetEnabled?: boolean } = {},
+) {
+  const adminResetEnabled = options.adminResetEnabled ?? true;
+  const middleware = createAuthMiddleware({ storage, ttlSeconds: 3600, eventStorage });
+  const app = new OpenAPIHono();
+  app.use("*", workspaceMiddleware);
+  app.use("*", middleware.optionalAuth);
+  app.use("/api/*", middleware.requireCsrf);
+  app.route("/", createAdminUserRoutes({
+    storage,
+    eventStorage,
+    adminResetEnabled,
+    authMiddleware: middleware,
+  }));
+  return app;
+}
+
+function authHeaders(workspace: string, session: { token: string; csrfToken: string }) {
+  return {
+    "Content-Type": "application/json",
+    "X-Workspace-Slug": workspace,
+    "X-CSRF-Token": session.csrfToken,
+    Cookie: `${config.auth.sessionCookieName}=${session.token}`,
+  };
+}
+
+describe("POST /api/admin/reset-password", () => {
+  let originalAdminReset: boolean | undefined;
+
+  beforeEach(() => {
+    originalAdminReset = (config.auth as { adminResetEnabled?: boolean }).adminResetEnabled;
+  });
+
+  afterEach(() => {
+    (config.auth as { adminResetEnabled?: boolean }).adminResetEnabled = originalAdminReset;
+    resetResumeScreeningDb();
+    vi.restoreAllMocks();
+  });
+
+  it("returns 404 when AUTH_ADMIN_RESET_ENABLED is false", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "admin-reset-off-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(storage.db);
+    const devAdmin = await seedDevAdmin(storage);
+    await seedLocalUser(storage, { username: "target-user" });
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const session = sessions.createSession(devAdmin.user.id);
+    const app = createTestApp(storage, eventStorage, { adminResetEnabled: false });
+
+    const res = await app.request("/api/admin/reset-password", {
+      method: "POST",
+      headers: authHeaders("dev", session),
+      body: JSON.stringify({ username: "target-user" }),
+    });
+
+    expect(res.status).toBe(404);
+    const events = eventStorage.listRecent({ limit: 50 });
+    expect(events.some((e) => e.type === "password_reset_completed")).toBe(false);
+  });
+
+  it("resets password, revokes sessions, and records event when dev-admin resets a local user", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "admin-reset-ok-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(storage.db);
+    const devAdmin = await seedDevAdmin(storage);
+    const target = await seedLocalUser(storage, { username: "target-user", password: "old-pass" });
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const targetSession1 = sessions.createSession(target.user.id);
+    const targetSession2 = sessions.createSession(target.user.id);
+    const adminSession = sessions.createSession(devAdmin.user.id);
+    const app = createTestApp(storage, eventStorage);
+
+    const res = await app.request("/api/admin/reset-password", {
+      method: "POST",
+      headers: authHeaders("dev", adminSession),
+      body: JSON.stringify({ username: "target-user" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.temporaryPassword).toEqual(expect.any(String));
+    expect(body.temporaryPassword.length).toBeGreaterThanOrEqual(16);
+
+    // Credential rotated
+    const updated = storage.findPasswordCredential(target.user.id);
+    expect(updated).not.toBeNull();
+    expect(await verifyPassword(body.temporaryPassword, updated!)).toBe(true);
+    expect(await verifyPassword("old-pass", updated!)).toBe(false);
+
+    // All target sessions revoked
+    expect(sessions.resolveSession(targetSession1.token)).toBeNull();
+    expect(sessions.resolveSession(targetSession2.token)).toBeNull();
+    // Admin session untouched
+    expect(sessions.resolveSession(adminSession.token)).not.toBeNull();
+
+    // Event recorded
+    const events = eventStorage.listRecent({ limit: 50 });
+    const resetEvent = events.find((e) => e.type === "password_reset_completed");
+    expect(resetEvent).toBeDefined();
+    expect(resetEvent!.userId).toBe(target.user.id);
+    expect(resetEvent!.metadata?.resetByUserId).toBe(devAdmin.user.id);
+    expect(resetEvent!.metadata?.provider).toBe("local");
+  });
+
+  it("returns 404 with precise message when username has no local identity", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "admin-reset-noid-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(storage.db);
+    const devAdmin = await seedDevAdmin(storage);
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const session = sessions.createSession(devAdmin.user.id);
+    const app = createTestApp(storage, eventStorage);
+
+    const res = await app.request("/api/admin/reset-password", {
+      method: "POST",
+      headers: authHeaders("dev", session),
+      body: JSON.stringify({ username: "ghost-user" }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toContain("No local password identity found");
+    expect(body.error).toContain("ghost-user");
+  });
+
+  it("returns 404 when target identity is Casdoor-only (not local)", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "admin-reset-casdoor-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(storage.db);
+    const devAdmin = await seedDevAdmin(storage);
+    // Seed a Casdoor-only identity (no local provider identity)
+    const casdoorUser = storage.createUser({ email: "casdoor@example.com", displayName: "Casdoor User" });
+    storage.linkIdentity({
+      userId: casdoorUser.id,
+      provider: "casdoor",
+      providerSubject: "casdoor-subject",
+      providerTenant: "https://casdoor.example.com",
+      email: casdoorUser.email,
+      displayName: casdoorUser.displayName,
+    });
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const session = sessions.createSession(devAdmin.user.id);
+    const app = createTestApp(storage, eventStorage);
+
+    const res = await app.request("/api/admin/reset-password", {
+      method: "POST",
+      headers: authHeaders("dev", session),
+      body: JSON.stringify({ username: "casdoor-subject" }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toContain("No local password identity found");
+  });
+
+  it("returns 403 when caller is hr-admin (non-dev workspace)", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "admin-reset-hradmin-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(storage.db);
+    const hrAdmin = await seedLocalUser(storage, { username: "hr-admin", workspace: "hr", role: "admin" });
+    await seedLocalUser(storage, { username: "target-user" });
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const session = sessions.createSession(hrAdmin.user.id);
+    const app = createTestApp(storage, eventStorage);
+
+    const res = await app.request("/api/admin/reset-password", {
+      method: "POST",
+      headers: authHeaders("hr", session),
+      body: JSON.stringify({ username: "target-user" }),
+    });
+
+    expect(res.status).toBe(403);
+    const events = eventStorage.listRecent({ limit: 50 });
+    expect(events.some((e) => e.type === "password_reset_completed")).toBe(false);
+  });
+
+  it("returns 403 when caller is dev-user (non-admin role)", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "admin-reset-devuser-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(storage.db);
+    const devUser = await seedLocalUser(storage, { username: "dev-user", workspace: "dev", role: "user" });
+    await seedLocalUser(storage, { username: "target-user" });
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const session = sessions.createSession(devUser.user.id);
+    const app = createTestApp(storage, eventStorage);
+
+    const res = await app.request("/api/admin/reset-password", {
+      method: "POST",
+      headers: authHeaders("dev", session),
+      body: JSON.stringify({ username: "target-user" }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 401 when caller is unauthenticated", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "admin-reset-unauth-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(storage.db);
+    await seedLocalUser(storage, { username: "target-user" });
+    const app = createTestApp(storage, eventStorage);
+
+    const res = await app.request("/api/admin/reset-password", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-Workspace-Slug": "dev" },
+      body: JSON.stringify({ username: "target-user" }),
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("does not leak the temporary password in event metadata", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "admin-reset-noleak-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(storage.db);
+    const devAdmin = await seedDevAdmin(storage);
+    const target = await seedLocalUser(storage, { username: "target-user" });
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const session = sessions.createSession(devAdmin.user.id);
+    const app = createTestApp(storage, eventStorage);
+
+    const res = await app.request("/api/admin/reset-password", {
+      method: "POST",
+      headers: authHeaders("dev", session),
+      body: JSON.stringify({ username: "target-user" }),
+    });
+    const body = await res.json();
+
+    const events = eventStorage.listRecent({ limit: 50 });
+    const resetEvent = events.find((e) => e.type === "password_reset_completed");
+    expect(resetEvent).toBeDefined();
+    const metadataKeys = Object.keys(resetEvent!.metadata ?? {});
+    expect(metadataKeys.sort()).toEqual(["provider", "resetByUserId"]);
+    // The temp password must not appear anywhere in metadata values
+    const metadataJson = JSON.stringify(resetEvent!.metadata ?? {});
+    expect(metadataJson).not.toContain(body.temporaryPassword);
+  });
+
+  it("rotates the credential so the old password fails and the temp password works", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "admin-reset-rotate-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(storage.db);
+    const devAdmin = await seedDevAdmin(storage);
+    const target = await seedLocalUser(storage, { username: "target-user", password: "old-pass-123" });
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const session = sessions.createSession(devAdmin.user.id);
+    const app = createTestApp(storage, eventStorage);
+
+    const res = await app.request("/api/admin/reset-password", {
+      method: "POST",
+      headers: authHeaders("dev", session),
+      body: JSON.stringify({ username: "target-user" }),
+    });
+    const body = await res.json();
+    const updated = storage.findPasswordCredential(target.user.id);
+
+    expect(await verifyPassword(body.temporaryPassword, updated!)).toBe(true);
+    expect(await verifyPassword("old-pass-123", updated!)).toBe(false);
+  });
+
+  it("returns 400 when dev-admin attempts to reset own password", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "admin-reset-self-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(storage.db);
+    const devAdmin = await seedDevAdmin(storage);
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const session = sessions.createSession(devAdmin.user.id);
+    const app = createTestApp(storage, eventStorage);
+
+    const res = await app.request("/api/admin/reset-password", {
+      method: "POST",
+      headers: authHeaders("dev", session),
+      body: JSON.stringify({ username: "dev-admin-user" }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/change-password/i);
+    // No reset happened
+    const events = eventStorage.listRecent({ limit: 50 });
+    expect(events.some((e) => e.type === "password_reset_completed")).toBe(false);
+  });
+});

--- a/apps/api/src/routes/admin_users.ts
+++ b/apps/api/src/routes/admin_users.ts
@@ -1,0 +1,180 @@
+import { randomBytes } from "node:crypto";
+
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+
+import { AuthEventStorage } from "../services/auth-event-storage.js";
+import { AuthStorage } from "../services/auth-storage.js";
+import { config } from "../services/config.js";
+import { hashPassword } from "../services/local-password-provider.js";
+import type { createAuthMiddleware } from "../middleware/auth.js";
+
+const ResetPasswordRequestSchema = z.object({
+  username: z.string().min(1),
+});
+
+const ResetPasswordResponseSchema = z.object({
+  success: z.literal(true),
+  temporaryPassword: z.string(),
+});
+
+const ErrorResponseSchema = z.object({
+  success: z.literal(false),
+  error: z.string(),
+});
+
+type AdminUserRoutesOptions = {
+  storage?: AuthStorage;
+  eventStorage?: AuthEventStorage;
+  adminResetEnabled: boolean;
+  authMiddleware: ReturnType<typeof createAuthMiddleware>;
+};
+
+export function createAdminUserRoutes(options: AdminUserRoutesOptions) {
+  const app = new OpenAPIHono();
+
+  let storage = options.storage;
+  let eventStorage = options.eventStorage;
+
+  function getStorage(): AuthStorage {
+    storage ??= new AuthStorage(config.projectRoot);
+    return storage;
+  }
+
+  function getEventStorage(): AuthEventStorage {
+    eventStorage ??= new AuthEventStorage(config.projectRoot);
+    return eventStorage;
+  }
+
+  // All admin user routes require admin membership.
+  app.use("/api/admin/*", options.authMiddleware.requireAdmin);
+
+  const resetPasswordRoute = createRoute({
+    method: "post",
+    path: "/api/admin/reset-password",
+    tags: ["admin"],
+    request: {
+      body: {
+        content: {
+          "application/json": {
+            schema: ResetPasswordRequestSchema,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Password reset; temporary password returned",
+        content: {
+          "application/json": {
+            schema: ResetPasswordResponseSchema,
+          },
+        },
+      },
+      400: {
+        description: "Self-reset blocked",
+        content: {
+          "application/json": {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+      401: {
+        description: "Authentication required",
+        content: {
+          "application/json": {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+      403: {
+        description: "Admin access required",
+        content: {
+          "application/json": {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+      404: {
+        description: "Feature disabled or identity not found",
+        content: {
+          "application/json": {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+    },
+  });
+
+  app.openapi(resetPasswordRoute, async (c) => {
+    // Flag gate: 404 when disabled (do not advertise the endpoint).
+    if (!options.adminResetEnabled) {
+      return c.json({ success: false as const, error: "Not found" }, 404);
+    }
+
+    const auth = c.var.auth;
+    if (!auth) {
+      return c.json({ success: false as const, error: "Authentication required" }, 401);
+    }
+
+    // System-admin gate: must be called from the dev workspace (ADR D4).
+    if (c.var.workspaceSlug !== "dev") {
+      return c.json({ success: false as const, error: "Admin access required" }, 403);
+    }
+
+    const { username } = c.req.valid("json");
+
+    // Local-identity lookup (same pattern as loginRoute).
+    const identity = getStorage().findIdentity("local", username, "local");
+    if (!identity) {
+      return c.json(
+        {
+          success: false as const,
+          error: `No local password identity found for username '${username}'`,
+        },
+        404,
+      );
+    }
+
+    // Self-reset footgun: point to the self-service path.
+    if (identity.userId === auth.user.id) {
+      return c.json(
+        {
+          success: false as const,
+          error: "Cannot reset your own password via admin reset; use POST /api/auth/change-password",
+        },
+        400,
+      );
+    }
+
+    // Server-generated temporary password — admin never types a password.
+    const temporaryPassword = randomBytes(16).toString("base64url");
+
+    // Update the credential. mustChangePassword stays false — the flag is a
+    // no-op (login flow does not enforce it) and setting true would repeat the
+    // dead-field anti-pattern removed in #1262.
+    getStorage().savePasswordCredential({
+      userId: identity.userId,
+      ...(await hashPassword(temporaryPassword)),
+      mustChangePassword: false,
+    });
+
+    // Revoke all target sessions (no exception — target must re-authenticate).
+    getStorage().revokeAllSessionsByUser(identity.userId);
+
+    // Audit trail. Safe metadata only — never the temporary password.
+    getEventStorage().append({
+      type: "password_reset_completed",
+      userId: identity.userId,
+      workspaceSlug: c.var.workspaceSlug,
+      sessionId: auth.sessionId,
+      metadata: {
+        resetByUserId: auth.user.id,
+        provider: "local",
+      },
+    });
+
+    return c.json({ success: true as const, temporaryPassword }, 200);
+  });
+
+  return app;
+}

--- a/apps/api/src/services/auth-event-types.ts
+++ b/apps/api/src/services/auth-event-types.ts
@@ -4,6 +4,7 @@ export type AuthEventType =
   | "login_throttled"
   | "logout"
   | "sessions_revoked"
+  | "password_reset_completed"
   | "csrf_reject"
   | "workspace_access_denied"
   | "admin_access_denied"

--- a/apps/api/src/services/config.ts
+++ b/apps/api/src/services/config.ts
@@ -36,6 +36,7 @@ export const config = {
     csrfCookieName: process.env.AUTH_CSRF_COOKIE_NAME || "trends_csrf",
     sessionTtlSeconds: parseInt(process.env.AUTH_SESSION_TTL_SECONDS || "604800", 10),
     secureCookies: isProduction,
+    adminResetEnabled: process.env.AUTH_ADMIN_RESET_ENABLED === "true",
     allowedOrigins: (process.env.AUTH_ALLOWED_ORIGINS || "")
       .split(",")
       .map((origin) => origin.trim())

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -920,6 +920,103 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/reset-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        username: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Password reset; temporary password returned */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            temporaryPassword: string;
+                        };
+                    };
+                };
+                /** @description Self-reset blocked */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Admin access required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Feature disabled or identity not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/resumes/search-summary": {
         parameters: {
             query?: never;

--- a/scripts/check-auth-env.test.ts
+++ b/scripts/check-auth-env.test.ts
@@ -6,6 +6,7 @@ function makeInput(overrides: Partial<AuthEnvInput> = {}): AuthEnvInput {
     mode: 'local',
     CONVEX_WRITE_SECRET: '',
     AUTH_ALLOWED_ORIGINS: '',
+    AUTH_ADMIN_RESET_ENABLED: '',
     AUTH_OIDC_ENABLED: '',
     AUTH_OIDC_ISSUER: '',
     AUTH_OIDC_CLIENT_ID: '',
@@ -109,6 +110,18 @@ describe('checkAuthEnv', () => {
         AUTH_ALLOWED_ORIGINS: 'https://trends.pt-mes.com',
       }))
       expect(result.errors).toHaveLength(0)
+    })
+
+    it('errors when AUTH_ADMIN_RESET_ENABLED is true in production mode', () => {
+      const result = checkAuthEnv(makeInput({
+        mode: 'production',
+        CONVEX_WRITE_SECRET: 'secret',
+        AUTH_ALLOWED_ORIGINS: 'https://trends.pt-mes.com',
+        AUTH_ADMIN_RESET_ENABLED: 'true',
+      }))
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining('AUTH_ADMIN_RESET_ENABLED')])
+      )
     })
 
     it('validates OIDC redirect URI host matches an allowed origin host', () => {

--- a/scripts/check-auth-env.ts
+++ b/scripts/check-auth-env.ts
@@ -17,6 +17,7 @@ export interface AuthEnvInput {
   mode: AuthEnvMode
   CONVEX_WRITE_SECRET: string
   AUTH_ALLOWED_ORIGINS: string
+  AUTH_ADMIN_RESET_ENABLED: string
   AUTH_OIDC_ENABLED: string
   AUTH_OIDC_ISSUER: string
   AUTH_OIDC_CLIENT_ID: string
@@ -42,6 +43,15 @@ export function checkAuthEnv(input: AuthEnvInput): CheckResult {
   // Production/preview: require AUTH_ALLOWED_ORIGINS
   if (isProdLike && !input.AUTH_ALLOWED_ORIGINS) {
     errors.push('AUTH_ALLOWED_ORIGINS is required in ' + input.mode + ' mode')
+  }
+
+  // AUTH_ADMIN_RESET_ENABLED: experimental admin password reset — warn on
+  // accidental prod/preview enablement. Prod CAN enable it deliberately.
+  if (isProdLike && input.AUTH_ADMIN_RESET_ENABLED === 'true') {
+    errors.push(
+      'AUTH_ADMIN_RESET_ENABLED is enabled — admin password reset should not be on by default in '
+      + input.mode + ' mode; set explicitly only if you intend to use it'
+    )
   }
 
   // OIDC validation: when enabled, all required fields must be set
@@ -109,6 +119,7 @@ function resolveInput(mode: AuthEnvMode, envFilePath?: string): AuthEnvInput {
     mode,
     CONVEX_WRITE_SECRET: get('CONVEX_WRITE_SECRET'),
     AUTH_ALLOWED_ORIGINS: get('AUTH_ALLOWED_ORIGINS'),
+    AUTH_ADMIN_RESET_ENABLED: get('AUTH_ADMIN_RESET_ENABLED'),
     AUTH_OIDC_ENABLED: get('AUTH_OIDC_ENABLED'),
     AUTH_OIDC_ISSUER: get('AUTH_OIDC_ISSUER'),
     AUTH_OIDC_CLIENT_ID: get('AUTH_OIDC_CLIENT_ID'),

--- a/scripts/route-auth-policy.json
+++ b/scripts/route-auth-policy.json
@@ -59,6 +59,10 @@
     "class": "admin",
     "reason": "Resume admin operations use per-route requireAdmin middleware."
   },
+  "admin_users.ts": {
+    "class": "admin",
+    "reason": "Admin password reset uses requireAdmin middleware plus an inline dev-workspace check."
+  },
   "resumes_diagnostics.ts": {
     "class": "admin",
     "reason": "Resume diagnostic routes use requireAdmin middleware."


### PR DESCRIPTION
## Summary

Final slice of the Trends auth production refactor. Adds `POST /api/admin/reset-password` — a dev-admin can generate a server-side temporary password for a local user. The target user's sessions are fully revoked; the admin relays the one-time password out-of-band. Gated behind `AUTH_ADMIN_RESET_ENABLED` (default false, route returns 404 when disabled). Self-reset is blocked (400) with a pointer to `/api/auth/change-password`.

All 13 decisions resolved via grill-me (see work item spec):
- **Server-generated temp password** — admin passes `{ username }`, never types a password
- **Full session revocation** — `revokeAllSessionsByUser(targetUserId)`, no exception
- **Dev-workspace-only** — inline `workspaceSlug === "dev"` check (ADR D4)
- **Local-identity-only** — 404 for Casdoor/missing identities with precise message
- **mustChangePassword: false** — flag is a no-op at login; don't repeat dead-field pattern (#1262)
- **check-auth-env.ts guard** — errors on accidental prod enablement

## Test plan

- [x] `make check` passes (typecheck + lint + governance + route-auth matrix)
- [x] `bunx vitest run apps/api/src/routes/admin_users.test.ts` — 10 tests pass
- [x] `bunx vitest run scripts/check-auth-env.test.ts` — 15 tests pass (1 new)
- [x] RED→GREEN: all 10 tests written first, confirmed failing, then implementation made them pass
- [x] Route-auth policy matrix updated

### 10 tests
1. Flag-off → 404
2. Flag-on + dev-admin + local user → 200 + tempPassword + sessions revoked + event
3. Non-existent username → 404 with precise message
4. Casdoor-only username → 404 (local lookup misses)
5. hr-admin (non-dev) → 403
6. dev-user (non-admin) → 403
7. Unauthenticated → 401
8. No temp-password leak in event metadata
9. Old password fails; temp password works
10. Self-reset → 400 with change-password pointer

## Auth refactor series (all merged or in this PR)
1. ~~#1259 login brute-force protection~~ (merged)
2. ~~#1260 session lifecycle revocation~~ (merged)
3. ~~#1261 unify dual requireAdmin~~ (merged)
4. ~~#1262 dead auth schema/config cleanup~~ (merged)
5. **#1263 admin password reset (experimental)** ← this PR