### PR TITLE
refactor: migrate resume keyword search to digest-first architecture (Phase 1A)

### DIFF
--- a/packages/convex/__tests__/experience-filter-convex-test.test.ts
+++ b/packages/convex/__tests__/experience-filter-convex-test.test.ts
@@ -8,9 +8,10 @@
 import { createTest } from "./test-helpers.js";
 import { describe, expect, it } from "vitest";
 import { api } from "../convex/_generated/api.js";
+import { buildResumeDigest } from "../convex/lib/resume_digests.js";
 
 
-// Helper: insert a resume for filter testing
+// Helper: insert a resume for filter testing + mirror production digest upsert
 let _counter = 0;
 async function insertResume(
   t: ReturnType<typeof createTest>,
@@ -18,7 +19,7 @@ async function insertResume(
 ) {
   _counter += 1;
   return t.run(async (ctx) => {
-    return ctx.db.insert("resumes", {
+    const resumeId = await ctx.db.insert("resumes", {
       externalId: `ext-${_counter}`,
       content: { name: `User ${_counter}` },
       hash: `hash-${_counter}`,
@@ -29,6 +30,11 @@ async function insertResume(
       primaryRuleScore: 50,
       ...overrides,
     });
+    const resume = await ctx.db.get(resumeId);
+    if (resume) {
+      await ctx.db.insert("resume_digests", buildResumeDigest(resume, Date.now()) as any);
+    }
+    return resumeId;
   });
 }
 

--- a/packages/convex/__tests__/resume-digest-callsite-inventory.test.ts
+++ b/packages/convex/__tests__/resume-digest-callsite-inventory.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Inventory gate: fails while any production consumer of the cold
+ * resumes.search_body search index remains in resumes_search.ts.
+ *
+ * This is the Phase 1A gate from the digest-first-everywhere refactor.
+ * It must pass before the cold search index can be removed from schema.ts.
+ */
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function collectColdResumeSearchConsumers(source: string): string[] {
+    const matches: string[] = [];
+    const pattern = /query\("resumes"\)[\s\S]{0,240}\.withSearchIndex\("search_body"/g;
+    for (const match of source.matchAll(pattern)) {
+        const before = source.slice(0, match.index ?? 0);
+        const line = before.split("\n").length;
+        matches.push(`packages/convex/convex/resumes_search.ts:${line}`);
+    }
+    return matches;
+}
+
+describe("digest-first resume search call-site inventory", () => {
+    it("has no production consumers of the cold resumes.search_body index", () => {
+        const source = readFileSync(
+            new URL("../convex/resumes_search.ts", import.meta.url),
+            "utf8",
+        );
+
+        expect(collectColdResumeSearchConsumers(source)).toEqual([]);
+    });
+});

--- a/packages/convex/__tests__/resumes-convex-test.test.ts
+++ b/packages/convex/__tests__/resumes-convex-test.test.ts
@@ -13,6 +13,7 @@
 import { createTest } from "./test-helpers.js";
 import { describe, expect, it } from "vitest";
 import { api } from "../convex/_generated/api.js";
+import { buildResumeDigest } from "../convex/lib/resume_digests.js";
 
 // Explicitly provide module glob so convex-test can discover Convex functions.
 // Vite transforms import.meta.glob at compile time — works regardless of runtime.
@@ -29,6 +30,19 @@ function seedResume(overrides: Record<string, unknown> = {}) {
     searchText: "test resume",
     ...overrides,
   };
+}
+
+// Insert resume + digest in one step (mirrors production behavior).
+async function insertResumeWithDigest(
+  ctx: { db: any },
+  overrides: Record<string, unknown> = {},
+) {
+  const resumeId = await ctx.db.insert("resumes", seedResume(overrides));
+  const resume = await ctx.db.get(resumeId);
+  if (resume) {
+    await ctx.db.insert("resume_digests", buildResumeDigest(resume, Date.now()) as any);
+  }
+  return resumeId;
 }
 
 describe("resumes.listWithIngestData (convex-test)", () => {
@@ -109,14 +123,16 @@ describe("resumes.search (convex-test)", () => {
     const t = createTest();
 
     await t.run(async (ctx) => {
-      await ctx.db.insert("resumes", seedResume({
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-cnc",
         searchText: "cnc operator with 5 years experience",
-      }));
-      await ctx.db.insert("resumes", seedResume({
+        content: { name: "CNC Operator" },
+      });
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-java",
         searchText: "java developer spring boot",
-      }));
+        content: { name: "Java Developer" },
+      });
     });
 
     const results = await t.query(api.resumes_search.search, {
@@ -134,15 +150,15 @@ describe("resumes.search (convex-test)", () => {
     const t = createTest();
 
     await t.run(async (ctx) => {
-      await ctx.db.insert("resumes", seedResume({
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-active",
         searchText: "cnc operator",
-      }));
-      await ctx.db.insert("resumes", seedResume({
+      });
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-archived",
         searchText: "cnc machinist",
         isArchived: true,
-      }));
+      });
     });
 
     const results = await t.query(api.resumes_search.search, {
@@ -159,14 +175,14 @@ describe("resumes.search (convex-test)", () => {
     const t = createTest();
 
     await t.run(async (ctx) => {
-      await ctx.db.insert("resumes", seedResume({
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-both",
         searchText: "cnc operator sales experience",
-      }));
-      await ctx.db.insert("resumes", seedResume({
+      });
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-cnc-only",
         searchText: "cnc operator manufacturing",
-      }));
+      });
     });
 
     const results = await t.query(api.resumes_search.search, {

--- a/packages/convex/__tests__/resumes-paginated-default-convex-test.test.ts
+++ b/packages/convex/__tests__/resumes-paginated-default-convex-test.test.ts
@@ -8,9 +8,10 @@
 import { createTest } from "./test-helpers.js";
 import { describe, expect, it } from "vitest";
 import { api } from "../convex/_generated/api.js";
+import { buildResumeDigest } from "../convex/lib/resume_digests.js";
 
 
-// Helper: insert a minimal resume document
+// Helper: insert a minimal resume document + mirror production digest upsert
 let _counter = 0;
 async function insertResume(
   t: ReturnType<typeof createTest>,
@@ -18,7 +19,7 @@ async function insertResume(
 ) {
   _counter += 1;
   return t.run(async (ctx) => {
-    return ctx.db.insert("resumes", {
+    const resumeId = await ctx.db.insert("resumes", {
       externalId: `ext-${_counter}`,
       content: { name: `User ${_counter}` },
       hash: `hash-${_counter}`,
@@ -28,6 +29,11 @@ async function insertResume(
       sourceKey: "test",
       ...overrides,
     });
+    const resume = await ctx.db.get(resumeId);
+    if (resume) {
+      await ctx.db.insert("resume_digests", buildResumeDigest(resume, Date.now()) as any);
+    }
+    return resumeId;
   });
 }
 

--- a/packages/convex/__tests__/resumes-search-convex-test.test.ts
+++ b/packages/convex/__tests__/resumes-search-convex-test.test.ts
@@ -966,3 +966,161 @@ describe("resumes_search: searchWithTagExpansionAndMode", () => {
         expect(result.expansion.expanded).toContain("cnc");
     });
 });
+
+// ---------------------------------------------------------------------------
+// digest-first parity gates (Phase 1A)
+// ---------------------------------------------------------------------------
+
+async function seedSearchParityRows(t: ReturnType<typeof convexTest>) {
+    await seedResume(t, {
+        externalId: "parity-cnc-sales",
+        identityKey: "profileUrl:example.com/candidates/parity-cnc-sales",
+        searchText: "cnc sales machine tools shanghai",
+        content: {
+            name: "CNC Sales",
+            location: "Shanghai, China",
+            education: "Bachelor",
+            expectedSalary: "20000",
+            experience: "6 years",
+            workHistory: [{ companyName: "Machine Tools Co", jobTitle: "Sales Manager" }],
+        },
+        source: "ehire.51job.com",
+        sourceKey: "51job",
+        primaryRuleScore: 91,
+        ingestData: {
+            ...MINIMAL_INGEST_DATA,
+            roleSignals: [{
+                type: "sales",
+                matchedSignals: ["Sales Manager"],
+                signalCount: 1,
+                occurrences: 1,
+                years: 5,
+                verifyIn: "workHistory",
+            }],
+            verifiedRoleYears: { sales: 5 },
+        },
+    });
+    await seedResume(t, {
+        externalId: "parity-cnc-engineer",
+        identityKey: "profileUrl:example.com/candidates/parity-cnc-engineer",
+        searchText: "cnc machining engineer guangzhou",
+        content: {
+            name: "CNC Engineer",
+            location: "Guangzhou, China",
+            education: "College",
+            expectedSalary: "15000",
+            experience: "4 years",
+            workHistory: [{ companyName: "Factory", jobTitle: "CNC Engineer" }],
+        },
+        source: "hr.job5156.com",
+        sourceKey: "job5156",
+        primaryRuleScore: 73,
+        ingestData: {
+            ...MINIMAL_INGEST_DATA,
+            roleSignals: [{
+                type: "manufacturing",
+                matchedSignals: ["CNC Engineer"],
+                signalCount: 1,
+                occurrences: 1,
+                years: 4,
+                verifyIn: "workHistory",
+            }],
+            verifiedRoleYears: { manufacturing: 4 },
+        },
+    });
+    await seedResume(t, {
+        externalId: "parity-java",
+        identityKey: "profileUrl:example.com/candidates/parity-java",
+        searchText: "java developer spring",
+        content: { name: "Java Developer", location: "Kuala Lumpur, Malaysia" },
+        source: "my.seek.com",
+        sourceKey: "seek",
+        primaryRuleScore: 55,
+    });
+}
+
+describe("resumes_search digest parity gates", () => {
+    const cncGroup = { original: "cnc", variants: ["cnc"] };
+    const salesGroup = { original: "sales", variants: ["sales", "销售"] };
+
+    it("returns the same matching externalIds across keyword search entrypoints", async () => {
+        const t = convexTest(schema, modules);
+        await seedSearchParityRows(t);
+
+        const simple = await t.query(api.resumes_search.search, {
+            query: "cnc",
+            limit: 20,
+        });
+        const ingest = await t.query(api.resumes_search.searchWithIngestData, {
+            query: "cnc",
+            limit: 20,
+        });
+        const tagged = await t.query(api.resumes_search.searchWithTagExpansion, {
+            query: "cnc",
+            keywordGroups: [cncGroup],
+            limit: 20,
+        });
+        const page = await t.query(api.resumes_search.searchWithTagExpansionPage, {
+            query: "cnc",
+            keywordGroups: [cncGroup],
+            limit: 20,
+        });
+        const paginated = await t.query(api.resumes_search.searchWithTagExpansionPaginated, {
+            query: "cnc",
+            keywordGroups: [cncGroup],
+            paginationOpts: { cursor: null, numItems: 20 },
+        });
+        const scan = await t.query(api.resumes_search.searchWithTagExpansionScanPage, {
+            query: "cnc",
+            keywordGroups: [cncGroup],
+            paginationOpts: { cursor: null, numItems: 20 },
+        });
+
+        expect(simple.map((row) => row.externalId).sort()).toEqual([
+            "parity-cnc-engineer",
+            "parity-cnc-sales",
+        ]);
+        expect(ingest.map((row) => row.externalId).sort()).toEqual([
+            "parity-cnc-engineer",
+            "parity-cnc-sales",
+        ]);
+        expect(tagged.results.map((entry) => entry.resume.externalId).sort()).toEqual([
+            "parity-cnc-engineer",
+            "parity-cnc-sales",
+        ]);
+        expect(page.results.map((entry) => entry.resume.externalId).sort()).toEqual([
+            "parity-cnc-engineer",
+            "parity-cnc-sales",
+        ]);
+        expect(paginated.page.map((entry) => entry.resume.externalId).sort()).toEqual([
+            "parity-cnc-engineer",
+            "parity-cnc-sales",
+        ]);
+        expect(scan.page.map((entry) => entry.resume.externalId).sort()).toEqual([
+            "parity-cnc-engineer",
+            "parity-cnc-sales",
+        ]);
+    });
+
+    it("keeps digest-side filters equivalent for the CNC sales cohort", async () => {
+        const t = convexTest(schema, modules);
+        await seedSearchParityRows(t);
+
+        const result = await t.query(api.resumes_search.searchWithTagExpansionScanPage, {
+            query: "cnc sales",
+            keywordGroups: [cncGroup, salesGroup],
+            mode: "AND",
+            locations: ["China"],
+            minRoleYears: 3,
+            roleFilterType: "sales",
+            minAge: 20,
+            maxAge: 60,
+            sources: ["51job"],
+            paginationOpts: { cursor: null, numItems: 20 },
+        });
+
+        expect(result.page.map((entry) => entry.resume.externalId)).toEqual([
+            "parity-cnc-sales",
+        ]);
+    });
+});

--- a/packages/convex/__tests__/test-helpers.ts
+++ b/packages/convex/__tests__/test-helpers.ts
@@ -3,6 +3,7 @@
  */
 import { convexTest } from "convex-test";
 import schema from "../convex/schema.js";
+import { buildResumeDigest } from "../convex/lib/resume_digests.js";
 
 const modules = (import.meta as any).glob("../**/*.ts", { eager: false });
 
@@ -15,11 +16,13 @@ export function createTest() {
 
 /**
  * Insert a minimal resume document into the database for testing.
+ * Also upserts a resume_digests row to mirror production behavior
+ * (every resume insert triggers a digest upsert via internal mutation).
  * Returns the resume ID.
  */
 export function seedResume(t: ReturnType<typeof convexTest>, overrides: Record<string, unknown> = {}) {
     return t.run(async (ctx) => {
-        return ctx.db.insert("resumes", {
+        const resumeId = await ctx.db.insert("resumes", {
             externalId: "test-resume-1",
             identityKey: "profileUrl:example.com/candidates/1",
             content: { name: "Test Candidate" },
@@ -30,6 +33,12 @@ export function seedResume(t: ReturnType<typeof convexTest>, overrides: Record<s
             crawledAt: Date.now(),
             ...overrides,
         });
+        const resume = await ctx.db.get(resumeId);
+        if (resume) {
+            const digest = buildResumeDigest(resume, Date.now());
+            await ctx.db.insert("resume_digests", digest as any);
+        }
+        return resumeId;
     });
 }
 

--- a/packages/convex/convex/resumes_search.ts
+++ b/packages/convex/convex/resumes_search.ts
@@ -52,6 +52,16 @@ import {
 // Private helpers
 // ---------------------------------------------------------------------------
 
+async function getResumeDocsByDigestRows(
+    ctx: QueryCtx,
+    digests: Doc<"resume_digests">[],
+): Promise<Doc<"resumes">[]> {
+    const docs = await Promise.all(digests.map((digest) => ctx.db.get(digest.resumeId)));
+    // Guard against stale digests: the digest search filters .eq("isArchived", undefined)
+    // but the digest row may lag a recent resume archive. Re-check the source doc.
+    return docs.filter((doc): doc is Doc<"resumes"> => doc !== null && doc.isArchived !== true);
+}
+
 function compareResumes(
     left: Doc<"resumes">,
     right: Doc<"resumes">,
@@ -174,12 +184,13 @@ async function runSearchWithTagExpansionPageQuery(
         jobDescriptionId,
     });
 
-    const matches = searchQuery
+    const digestMatches = searchQuery
         ? await ctx.db
-            .query("resumes")
+            .query("resume_digests")
             .withSearchIndex("search_body", (q) => q.search("searchText", searchQuery).eq("isArchived", undefined))
             .take(takeLimit)
         : [];
+    const matches = await getResumeDocsByDigestRows(ctx, digestMatches);
 
     const filteredDocs = matches.filter((doc) => {
         const provenance = resolveSearchWithTagExpansionMatch(
@@ -263,9 +274,9 @@ async function runSearchWithTagExpansionScanPageQuery(
         ? Math.min(requestedPageSize * FILTERED_PAGINATE_OVERFETCH_MULTIPLIER, MAX_SAFE_SEARCH_PAGINATE_SCAN)
         : Math.min(requestedPageSize, MAX_SAFE_SEARCH_PAGINATE_SCAN_UNFILTERED);
 
-    const searchPage = searchQuery
+    const digestPage = searchQuery
         ? await ctx.db
-            .query("resumes")
+            .query("resume_digests")
             .withSearchIndex("search_body", (q) => q.search("searchText", searchQuery).eq("isArchived", undefined))
             .paginate({
                 ...args.paginationOpts,
@@ -274,10 +285,11 @@ async function runSearchWithTagExpansionScanPageQuery(
                 maximumRowsRead: PAGINATE_MAX_ROWS_READ,
             })
         : {
-            page: [] as Doc<"resumes">[],
+            page: [] as Doc<"resume_digests">[],
             continueCursor: "",
             isDone: true,
         };
+    const fullDocs = await getResumeDocsByDigestRows(ctx, digestPage.page);
 
     return {
         expansion: {
@@ -286,7 +298,7 @@ async function runSearchWithTagExpansionScanPageQuery(
             groups: keywordGroups,
             mode,
         },
-        page: searchPage.page.flatMap((doc) => {
+        page: fullDocs.flatMap((doc) => {
             const provenance = resolveSearchWithTagExpansionMatch(
                 doc,
                 keywordGroups,
@@ -302,8 +314,8 @@ async function runSearchWithTagExpansionScanPageQuery(
                 provenance,
             }];
         }),
-        continueCursor: searchPage.continueCursor,
-        isDone: searchPage.isDone,
+        continueCursor: digestPage.continueCursor,
+        isDone: digestPage.isDone,
     };
 }
 
@@ -321,10 +333,11 @@ export const search = query({
         const tokens = splitQueryTokens(args.query);
         const fetchLimit = tokens.length > 1 ? Math.max(limit * 5, 500) : limit;
 
-        const matches = await ctx.db
-            .query("resumes")
+        const digestMatches = await ctx.db
+            .query("resume_digests")
             .withSearchIndex("search_body", (q) => q.search("searchText", args.query).eq("isArchived", undefined))
             .take(fetchLimit);
+        const matches = await getResumeDocsByDigestRows(ctx, digestMatches);
 
         // Convex full-text search uses OR. Post-filter to enforce AND.
         const filtered = tokens.length > 1
@@ -348,10 +361,11 @@ export const searchWithIngestData = query({
         // Over-fetch to compensate for AND post-filtering on OR results
         const fetchLimit = tokens.length > 1 ? Math.max(limit * 5, 500) : Math.max(limit, 200);
 
-        const matches = await ctx.db
-            .query("resumes")
+        const digestMatches = await ctx.db
+            .query("resume_digests")
             .withSearchIndex("search_body", (q) => q.search("searchText", args.query).eq("isArchived", undefined))
             .take(fetchLimit);
+        const matches = await getResumeDocsByDigestRows(ctx, digestMatches);
 
         // Convex full-text search uses OR. Post-filter to enforce AND.
         const filtered = tokens.length > 1
@@ -407,12 +421,13 @@ export const searchWithTagExpansion = query({
         const fetchLimit = overfetchLimit;
         const searchQuery = buildTagExpansionSearchQuery(keywordGroups, mode);
 
-        const matches = searchQuery
+        const digestMatches = searchQuery
             ? await ctx.db
-                .query("resumes")
+                .query("resume_digests")
                 .withSearchIndex("search_body", (q) => q.search("searchText", searchQuery).eq("isArchived", undefined))
                 .take(fetchLimit)
             : [];
+        const matches = await getResumeDocsByDigestRows(ctx, digestMatches);
 
         const filteredDocs = matches.filter((doc) => {
             const normalizedSearchText = (doc.searchText || "").toLowerCase();
@@ -1050,7 +1065,7 @@ export const collectSearchIndexDocIds = internalQuery({
     },
     handler: async (ctx, args) => {
         const page = await ctx.db
-            .query("resumes")
+            .query("resume_digests")
             .withSearchIndex("search_body", (q) => q.search("searchText", args.searchQuery).eq("isArchived", undefined))
             .paginate({
                 cursor: args.cursor ?? null,
@@ -1059,7 +1074,7 @@ export const collectSearchIndexDocIds = internalQuery({
                 maximumRowsRead: PAGINATE_MAX_ROWS_READ,
             });
         return {
-            ids: page.page.map((doc) => String(doc._id)),
+            ids: page.page.map((digest) => String(digest.resumeId)),
             isDone: page.isDone,
             cursor: page.isDone ? null : page.continueCursor,
         };


### PR DESCRIPTION
## Summary

- Migrate all 6 production cold `resumes.search_body` consumers to `resume_digests.search_body` with full-doc hydration via `getResumeDocsByDigestRows`
- Add cold search call-site inventory test that fails while any production `query("resumes").withSearchIndex("search_body")` remains — this is the Phase 1A gate
- Add digest search parity tests across keyword-search entrypoints
- Enhance test `seedResume` and local `insertResume` helpers to auto-create `resume_digests` rows (mirrors production where every resume insert triggers a digest upsert)

## What changed

**`packages/convex/convex/resumes_search.ts`**:
- New `getResumeDocsByDigestRows(ctx, digests)` helper: hydrates digest rows to full `Doc<"resumes">` with stale-digest guard
- `search`, `searchWithIngestData`: digest search → hydrate → token post-filter
- `searchWithTagExpansion`, `runSearchWithTagExpansionPageQuery`: digest search → hydrate → tag-expansion match
- `runSearchWithTagExpansionScanPageQuery`: digest paginate → hydrate page → tag-expansion match
- `collectSearchIndexDocIds`: digest search, returns `digest.resumeId` (used by AND-mode anchor scan)

**Tests**:
- New `resume-digest-callsite-inventory.test.ts`: inventory gate (fails if cold consumers exist)
- `resumes-search-convex-test.test.ts`: parity tests for keyword-search entrypoints
- `test-helpers.ts`, 3 local `insertResume` helpers: auto-create digests

## Test plan

- [x] `bunx vitest run packages/convex/__tests__/` — 1803 pass, 1 pre-existing audit failure (`CONVEX_WRITE_SECRET` env var, fails on main too)
- [x] `make check` — all passed (typecheck + lint + governance + api-types)
- [x] Inventory test passes (0 cold consumers)
- [x] Parity tests pass (same results across all keyword-search entrypoints)
- [ ] Browser verification (`make dev` + playwright-cli) — deferred to post-merge; this change is Convex-only with no UI-facing behavior change
- [ ] Cold `resumes.search_body` schema index removal — Phase 1B or later, NOT in this PR

## Context

This is Phase 1A of the digest-first-everywhere refactor. Work item: `projects/trends/work/2026-06-14-resume-query-digest-first-everywhere-refactor` in the vault. Phase 1B (list/count discovery) and Phase 2 (status propagation) are separate PR-sized slices.