### PR TITLE
refactor: migrate resume list/count discovery to digest-first architecture (Phase 1B)

### DIFF
--- a/packages/convex/__tests__/count-resumes-by-status-convex-test.test.ts
+++ b/packages/convex/__tests__/count-resumes-by-status-convex-test.test.ts
@@ -1,6 +1,24 @@
 import { describe, it, expect } from "vitest";
 import { createTest } from "./test-helpers.js";
 import { api } from "../convex/_generated/api.js";
+import { buildResumeDigest } from "../convex/lib/resume_digests.js";
+
+// Insert a resume + mirror production digest upsert.
+async function insertResumeWithDigest(
+  ctx: { db: any },
+  overrides: Record<string, unknown>,
+) {
+  const resumeId = await ctx.db.insert("resumes", {
+    tags: [],
+    crawledAt: Date.now(),
+    ...overrides,
+  });
+  const resume = await ctx.db.get(resumeId);
+  if (resume) {
+    await ctx.db.insert("resume_digests", buildResumeDigest(resume, Date.now()) as any);
+  }
+  return resumeId;
+}
 
 describe("countResumesByStatus", () => {
   const test = createTest();
@@ -20,33 +38,27 @@ describe("countResumesByStatus", () => {
     const source = "test-count-basic";
     const ws = "test-count-basic-ws";
     await test.run(async (ctx) => {
-      await ctx.db.insert("resumes", {
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-basic-1",
         identityKey: "ik-basic-new",
         content: { name: "User 1" },
         hash: "hash-b1",
-        tags: [],
-        crawledAt: Date.now(),
         source,
         sourceKey: source,
       });
-      await ctx.db.insert("resumes", {
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-basic-2",
         identityKey: "ik-basic-short",
         content: { name: "User 2" },
         hash: "hash-b2",
-        tags: [],
-        crawledAt: Date.now(),
         source,
         sourceKey: source,
       });
-      await ctx.db.insert("resumes", {
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-basic-3",
         identityKey: "ik-basic-rej",
         content: { name: "User 3" },
         hash: "hash-b3",
-        tags: [],
-        crawledAt: Date.now(),
         source,
         sourceKey: source,
       });
@@ -80,23 +92,19 @@ describe("countResumesByStatus", () => {
     const source = "test-count-location";
     const ws = "test-count-location-ws";
     await test.run(async (ctx) => {
-      await ctx.db.insert("resumes", {
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-loc-cn",
         identityKey: "ik-loc-cn",
         content: { name: "User CN", location: "Shanghai, China" },
         hash: "hash-loc-cn",
-        tags: [],
-        crawledAt: Date.now(),
         source,
         sourceKey: source,
       });
-      await ctx.db.insert("resumes", {
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-loc-my",
         identityKey: "ik-loc-my",
         content: { name: "User MY", location: "Kuala Lumpur, Malaysia" },
         hash: "hash-loc-my",
-        tags: [],
-        crawledAt: Date.now(),
         source,
         sourceKey: source,
       });
@@ -115,23 +123,19 @@ describe("countResumesByStatus", () => {
   it("respects source filter", async () => {
     const ws = "test-count-source-ws";
     await test.run(async (ctx) => {
-      await ctx.db.insert("resumes", {
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-src-51",
         identityKey: "ik-src-51",
         content: { name: "User 51" },
         hash: "hash-src-51",
-        tags: [],
-        crawledAt: Date.now(),
         source: "ehire.51job.com",
         sourceKey: "51job",
       });
-      await ctx.db.insert("resumes", {
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-src-5156",
         identityKey: "ik-src-5156",
         content: { name: "User 5156" },
         hash: "hash-src-5156",
-        tags: [],
-        crawledAt: Date.now(),
         source: "hr.job5156.com",
         sourceKey: "job5156",
       });
@@ -150,13 +154,11 @@ describe("countResumesByStatus", () => {
     const source = "test-count-default-new";
     const ws = "test-count-default-new-ws";
     await test.run(async (ctx) => {
-      await ctx.db.insert("resumes", {
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-def-no-status",
         identityKey: "ik-def-no-status",
         content: { name: "No Status" },
         hash: "hash-def-ns",
-        tags: [],
-        crawledAt: Date.now(),
         source,
         sourceKey: source,
       });
@@ -176,23 +178,19 @@ describe("countResumesByStatus", () => {
     const source = "test-count-interviewed-pass";
     const ws = "test-count-interviewed-pass-ws";
     await test.run(async (ctx) => {
-      await ctx.db.insert("resumes", {
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-zs-new",
         identityKey: "ik-zs-new",
         content: { name: "New Candidate" },
         hash: "hash-zs-new",
-        tags: [],
-        crawledAt: Date.now(),
         source,
         sourceKey: source,
       });
-      await ctx.db.insert("resumes", {
+      await insertResumeWithDigest(ctx, {
         externalId: "k172rcvmvqj4hhn98r74r3brps82v28b",
         identityKey: "ik-zs-interviewed",
         content: { name: "周先生" },
         hash: "hash-zs-interviewed",
-        tags: [],
-        crawledAt: Date.now(),
         source,
         sourceKey: source,
       });
@@ -222,24 +220,20 @@ describe("countResumesByStatus", () => {
     const source = "test-count-archived";
     const ws = "test-count-archived-ws";
     await test.run(async (ctx) => {
-      await ctx.db.insert("resumes", {
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-arch-yes",
         identityKey: "ik-arch-yes",
         content: { name: "Archived" },
         hash: "hash-arch-yes",
-        tags: [],
-        crawledAt: Date.now(),
         source,
         sourceKey: source,
         isArchived: true,
       });
-      await ctx.db.insert("resumes", {
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-arch-no",
         identityKey: "ik-arch-no",
         content: { name: "Active" },
         hash: "hash-arch-no",
-        tags: [],
-        crawledAt: Date.now(),
         source,
         sourceKey: source,
       });
@@ -258,23 +252,19 @@ describe("countResumesByStatus", () => {
     const source = "test-count-blocked-default";
     const ws = "test-count-blocked-default-ws";
     await test.run(async (ctx) => {
-      await ctx.db.insert("resumes", {
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-block-visible",
         identityKey: "ik-block-visible",
         content: { name: "Visible" },
         hash: "hash-block-visible",
-        tags: [],
-        crawledAt: Date.now(),
         source,
         sourceKey: source,
       });
-      await ctx.db.insert("resumes", {
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-block-hidden",
         identityKey: "ik-block-hidden",
         content: { name: "Hidden" },
         hash: "hash-block-hidden",
-        tags: [],
-        crawledAt: Date.now(),
         source,
         sourceKey: source,
       });
@@ -299,23 +289,19 @@ describe("countResumesByStatus", () => {
     const source = "test-count-blocked-visible";
     const ws = "test-count-blocked-visible-ws";
     await test.run(async (ctx) => {
-      await ctx.db.insert("resumes", {
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-show-block-visible",
         identityKey: "ik-show-block-visible",
         content: { name: "Visible" },
         hash: "hash-show-block-visible",
-        tags: [],
-        crawledAt: Date.now(),
         source,
         sourceKey: source,
       });
-      await ctx.db.insert("resumes", {
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-show-block-hidden",
         identityKey: "ik-show-block-hidden",
         content: { name: "Hidden" },
         hash: "hash-show-block-hidden",
-        tags: [],
-        crawledAt: Date.now(),
         source,
         sourceKey: source,
       });
@@ -335,5 +321,40 @@ describe("countResumesByStatus", () => {
 
     expect(result.new).toBe(2);
     expect(result.total).toBe(2);
+  });
+
+  it("counts from digest rows without returning overflow for broad source-filtered cohorts", async () => {
+    const source = "test-count-digest-wide";
+    const ws = "test-count-digest-wide-ws";
+    await test.run(async (ctx) => {
+      for (let i = 0; i < 12; i += 1) {
+        const resumeId = await ctx.db.insert("resumes", {
+          externalId: `ext-digest-wide-${i}`,
+          identityKey: `ik-digest-wide-${i}`,
+          content: { name: `Digest Wide ${i}`, location: "Shanghai, China" },
+          searchText: `cnc sales digest wide ${i}`,
+          hash: `hash-digest-wide-${i}`,
+          tags: [],
+          crawledAt: Date.now() + i,
+          source,
+          sourceKey: source,
+        });
+        const resume = await ctx.db.get(resumeId);
+        if (resume) {
+          const { buildResumeDigest } = await import("../convex/lib/resume_digests.js");
+          await ctx.db.insert("resume_digests", buildResumeDigest(resume, Date.now()) as any);
+        }
+      }
+    });
+
+    const result = await test.query(api.resumes.countResumesByStatus, {
+      workspaceSlug: ws,
+      sources: [source],
+      locations: ["China"],
+    });
+
+    expect(result.total).toBe(12);
+    expect(result.new).toBe(12);
+    expect(result.overflow).toBe(false);
   });
 });

--- a/packages/convex/__tests__/resumes-convex-test.test.ts
+++ b/packages/convex/__tests__/resumes-convex-test.test.ts
@@ -13,6 +13,7 @@
 import { createTest } from "./test-helpers.js";
 import { describe, expect, it } from "vitest";
 import { api } from "../convex/_generated/api.js";
+import { buildResumeDigest } from "../convex/lib/resume_digests.js";
 
 // Explicitly provide module glob so convex-test can discover Convex functions.
 // Vite transforms import.meta.glob at compile time — works regardless of runtime.
@@ -31,6 +32,19 @@ function seedResume(overrides: Record<string, unknown> = {}) {
   };
 }
 
+// Insert resume + digest in one step (mirrors production behavior).
+async function insertResumeWithDigest(
+  ctx: { db: any },
+  overrides: Record<string, unknown> = {},
+) {
+  const resumeId = await ctx.db.insert("resumes", seedResume(overrides));
+  const resume = await ctx.db.get(resumeId);
+  if (resume) {
+    await ctx.db.insert("resume_digests", buildResumeDigest(resume, Date.now()) as any);
+  }
+  return resumeId;
+}
+
 describe("resumes.listWithIngestData (convex-test)", () => {
   it("returns empty array when no resumes exist", async () => {
     const t = createTest();
@@ -42,16 +56,16 @@ describe("resumes.listWithIngestData (convex-test)", () => {
     const t = createTest();
 
     await t.run(async (ctx) => {
-      await ctx.db.insert("resumes", seedResume({
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-low",
         primaryRuleScore: 30,
         searchText: "cnc operator",
-      }));
-      await ctx.db.insert("resumes", seedResume({
+      });
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-high",
         primaryRuleScore: 80,
         searchText: "cnc programmer",
-      }));
+      });
     });
 
     const result = await t.query(api.resumes.listWithIngestData, { limit: 10 });
@@ -66,17 +80,17 @@ describe("resumes.listWithIngestData (convex-test)", () => {
     const t = createTest();
 
     await t.run(async (ctx) => {
-      await ctx.db.insert("resumes", seedResume({
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-active",
         primaryRuleScore: 50,
         searchText: "active resume",
-      }));
-      await ctx.db.insert("resumes", seedResume({
+      });
+      await insertResumeWithDigest(ctx, {
         externalId: "ext-archived",
         primaryRuleScore: 90,
         searchText: "archived resume",
         isArchived: true,
-      }));
+      });
     });
 
     const result = await t.query(api.resumes.listWithIngestData, { limit: 10 });
@@ -90,11 +104,11 @@ describe("resumes.listWithIngestData (convex-test)", () => {
 
     await t.run(async (ctx) => {
       for (let i = 0; i < 5; i++) {
-        await ctx.db.insert("resumes", seedResume({
+        await insertResumeWithDigest(ctx, {
           externalId: `ext-${i}`,
           primaryRuleScore: 50 + i,
           searchText: `resume ${i}`,
-        }));
+        });
       }
     });
 

--- a/packages/convex/__tests__/resumes-list-projections.test.ts
+++ b/packages/convex/__tests__/resumes-list-projections.test.ts
@@ -379,3 +379,27 @@ describe("sortResumeDocs", () => {
     expect(sorted[0]._id).toBe("r1");
   });
 });
+
+describe("buildResumeDigest list fields", () => {
+  it("projects list sort fields without copying cold full document payload", () => {
+    const resume = makeResume({
+      identityKey: "identity-list-1",
+      searchText: "cnc ".repeat(2000),
+      primaryRuleScore: 88,
+      crawledAt: 12345,
+      content: {
+        name: "List Candidate",
+        location: "Shanghai, China",
+        expectedSalary: "20000",
+      },
+    });
+
+    const digest = buildResumeDigest(resume as any, 999);
+
+    expect(digest.identityKey).toBe("identity-list-1");
+    expect(digest.primaryRuleScore).toBe(88);
+    expect(digest.crawledAt).toBe(12345);
+    expect(digest.searchText?.length ?? 0).toBeLessThan(1600);
+    expect(digest.updatedAt).toBe(999);
+  });
+});

--- a/packages/convex/__tests__/resumes-paginated-default-convex-test.test.ts
+++ b/packages/convex/__tests__/resumes-paginated-default-convex-test.test.ts
@@ -8,9 +8,10 @@
 import { createTest } from "./test-helpers.js";
 import { describe, expect, it } from "vitest";
 import { api } from "../convex/_generated/api.js";
+import { buildResumeDigest } from "../convex/lib/resume_digests.js";
 
 
-// Helper: insert a minimal resume document
+// Helper: insert a minimal resume document + mirror production digest upsert
 let _counter = 0;
 async function insertResume(
   t: ReturnType<typeof createTest>,
@@ -18,7 +19,7 @@ async function insertResume(
 ) {
   _counter += 1;
   return t.run(async (ctx) => {
-    return ctx.db.insert("resumes", {
+    const resumeId = await ctx.db.insert("resumes", {
       externalId: `ext-${_counter}`,
       content: { name: `User ${_counter}` },
       hash: `hash-${_counter}`,
@@ -28,6 +29,11 @@ async function insertResume(
       sourceKey: "test",
       ...overrides,
     });
+    const resume = await ctx.db.get(resumeId);
+    if (resume) {
+      await ctx.db.insert("resume_digests", buildResumeDigest(resume, Date.now()) as any);
+    }
+    return resumeId;
   });
 }
 
@@ -424,30 +430,18 @@ describe("resumes: listWithIngestDataPaginated", () => {
   it("matches resumes by source hostname when sourceKey is not set", async () => {
     const t = createTest();
 
-    // Insert directly without sourceKey to test hostname fallback
-    _counter += 1;
-    await t.run(async (ctx) => {
-      await ctx.db.insert("resumes", {
-        externalId: `ext-${_counter}`,
-        content: { name: "Job5156" },
-        hash: `hash-${_counter}`,
-        tags: [],
-        crawledAt: Date.now(),
-        source: "hr.job5156.com",
-        primaryRuleScore: 90,
-      });
+    // Insert without sourceKey to test hostname fallback
+    await insertResume(t, {
+      content: { name: "Job5156" },
+      source: "hr.job5156.com",
+      sourceKey: undefined as any,
+      primaryRuleScore: 90,
     });
-    _counter += 1;
-    await t.run(async (ctx) => {
-      await ctx.db.insert("resumes", {
-        externalId: `ext-${_counter}`,
-        content: { name: "Seek" },
-        hash: `hash-${_counter}`,
-        tags: [],
-        crawledAt: Date.now(),
-        source: "hk.employer.seek.com",
-        primaryRuleScore: 80,
-      });
+    await insertResume(t, {
+      content: { name: "Seek" },
+      source: "hk.employer.seek.com",
+      sourceKey: undefined as any,
+      primaryRuleScore: 80,
     });
 
     const result = await t.query(api.resumes.listWithIngestDataPaginated, {
@@ -717,5 +711,85 @@ describe("resumes: searchWithTagExpansionPaginated", () => {
     expect(result.page).toHaveLength(1);
     const name = ((result.page[0] as Record<string, unknown>).content as Record<string, unknown>)?.name;
     expect(name).toBe("DirectSales");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listWithIngestDataPaginated digest discovery parity (Phase 1B)
+// ---------------------------------------------------------------------------
+
+describe("listWithIngestDataPaginated digest discovery parity", () => {
+  it("keeps primaryRuleScore ordering when default list is backed by digests", async () => {
+    const t = createTest();
+    await insertResume(t, {
+      externalId: "list-low",
+      identityKey: "identity-list-low",
+      primaryRuleScore: 10,
+      searchText: "cnc low",
+    });
+    await insertResume(t, {
+      externalId: "list-high",
+      identityKey: "identity-list-high",
+      primaryRuleScore: 90,
+      searchText: "cnc high",
+    });
+
+    const result = await t.query(api.resumes.listWithIngestDataPaginated, {
+      paginationOpts: { cursor: null, numItems: 10 },
+    });
+
+    expect(result.page.map((row) => row.externalId).slice(0, 2)).toEqual([
+      "list-high",
+      "list-low",
+    ]);
+  });
+
+  it("applies digest-supported filters before full-doc hydration", async () => {
+    const t = createTest();
+    await insertResume(t, {
+      externalId: "list-sales-cn",
+      identityKey: "identity-list-sales-cn",
+      searchText: "cnc sales shanghai",
+      content: {
+        name: "Sales CN",
+        location: "Shanghai, China",
+        workHistory: [{ companyName: "Machine Co", jobTitle: "Sales Manager" }],
+      },
+      ingestData: {
+        industryTags: ["manufacturing"],
+        synonymHits: ["cnc"],
+        ruleScores: {},
+        experienceLevel: "senior",
+        computedAt: Date.now(),
+        skillsVersion: 2,
+        roleSignals: [{
+          type: "sales",
+          matchedSignals: ["Sales Manager"],
+          signalCount: 1,
+          occurrences: 1,
+          years: 5,
+          verifyIn: "workHistory",
+        }],
+        verifiedRoleYears: { sales: 5 },
+      },
+      sourceKey: "51job",
+    });
+    await insertResume(t, {
+      externalId: "list-engineer-cn",
+      identityKey: "identity-list-engineer-cn",
+      searchText: "cnc engineer shanghai",
+      content: { name: "Engineer CN", location: "Shanghai, China" },
+      sourceKey: "51job",
+    });
+
+    const result = await t.query(api.resumes.listWithIngestDataPaginated, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      locations: ["China"],
+      roleFilterType: "sales",
+      minRoleYears: 3,
+      sources: ["51job"],
+    });
+
+    expect(result.page.map((row) => row.externalId)).toEqual(["list-sales-cn"]);
   });
 });

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -20,6 +20,9 @@ import {
     sortResumeDocs,
     sortByIngestRuleScore,
 } from "./lib/resumes_list_projections.js";
+import {
+    matchesResumeDigestFilters,
+} from "./lib/resume_digests.js";
 import type {
     ResumeListPageArgs,
 } from "./lib/resumes_list_projections.js";
@@ -254,6 +257,15 @@ export type {
     ResumeUsageScanRow,
 } from "./resumes_mutations.js";
 
+async function getResumeDocsFromDigests(
+    ctx: QueryCtx,
+    digests: Doc<"resume_digests">[],
+): Promise<Doc<"resumes">[]> {
+    const docs = await Promise.all(digests.map((digest) => ctx.db.get(digest.resumeId)));
+    // Guard against stale digests: the digest row may lag a recent resume archive.
+    return docs.filter((doc): doc is Doc<"resumes"> => doc !== null && doc.isArchived !== true);
+}
+
 async function runListWithIngestDataPageQuery(
     ctx: QueryCtx,
     args: ResumeListPageArgs
@@ -264,12 +276,15 @@ async function runListWithIngestDataPageQuery(
     const { offset, pageLimit, scanLimit, overfetchLimit } = resolveListWithIngestPageWindow(args.limit, args.offset);
     const jobDescriptionId = args.jobDescriptionId?.trim() || undefined;
     const filters = normalizeResumeListFilters(args);
-    const candidates = await ctx.db
-        .query("resumes")
+    const digestCandidates = await ctx.db
+        .query("resume_digests")
         .withIndex("by_primaryRuleScore")
         .order("desc")
-        .filter((q) => q.neq(q.field("isArchived"), true))
         .take(overfetchLimit);
+    const digestFiltered = filters
+        ? digestCandidates.filter((digest) => matchesResumeDigestFilters(digest, filters))
+        : digestCandidates;
+    const candidates = await getResumeDocsFromDigests(ctx, digestFiltered);
     const sorted = sortResumeDocs(candidates, {
         jobDescriptionId,
         sortBy: args.sortBy,
@@ -425,12 +440,12 @@ export const listWithIngestData = query({
     handler: async (ctx, args) => {
         const { limit, overfetchLimit } = resolveListWithIngestWindow(args.limit);
         const jobDescriptionId = args.jobDescriptionId?.trim() || undefined;
-        const candidates = await ctx.db
-            .query("resumes")
+        const digestCandidates = await ctx.db
+            .query("resume_digests")
             .withIndex("by_primaryRuleScore")
             .order("desc")
-            .filter((q) => q.neq(q.field("isArchived"), true))
             .take(overfetchLimit);
+        const candidates = await getResumeDocsFromDigests(ctx, digestCandidates);
         return sortByIngestRuleScore(candidates, jobDescriptionId)
             .slice(0, limit)
             .map(projectResumeListDoc);
@@ -572,10 +587,9 @@ export const listWithIngestDataPaginated = query({
                     ? Math.min(requestedPageSize * FILTERED_PAGINATE_OVERFETCH_MULTIPLIER, MAX_SAFE_LIST_WITH_INGEST_LIMIT)
                     : requestedPageSize;
             const page = await ctx.db
-                .query("resumes")
+                .query("resume_digests")
                 .withIndex("by_primaryRuleScore")
                 .order("desc")
-                .filter((q) => q.neq(q.field("isArchived"), true))
                 .paginate({
                     ...args.paginationOpts,
                     numItems,
@@ -583,12 +597,16 @@ export const listWithIngestDataPaginated = query({
                     maximumRowsRead: PAGINATE_MAX_ROWS_READ,
                 });
 
-            const filtered = filters
-                ? page.page.filter((resume) => matchesResumeListFilters(resume, filters))
+            const digestFiltered = filters
+                ? page.page.filter((digest) => matchesResumeDigestFilters(digest, filters))
                 : page.page;
+            const fullDocs = await getResumeDocsFromDigests(ctx, digestFiltered);
+            const finalFiltered = filters
+                ? fullDocs.filter((resume) => matchesResumeListFilters(resume, filters))
+                : fullDocs;
             const ranked = jobDescriptionId
-                ? sortByIngestRuleScore(filtered, jobDescriptionId)
-                : filtered;
+                ? sortByIngestRuleScore(finalFiltered, jobDescriptionId)
+                : finalFiltered;
 
             return {
                 page: ranked.map(projectResumeListDoc),
@@ -723,40 +741,41 @@ export const countResumesByStatus = query({
       showArchived: false,
     });
 
-    // 3. Fetch non-archived resumes in a single paginated query.
-    // Convex only supports ONE .paginate() call per function (no loops).
+    // 3. Scan digest rows for candidate discovery.
+    // Digest rows are <1KB each, so we can scan far more than the cold
+    // resumes path (~27KB/doc) without hitting the byte limit.
     const MAX_MATCHES = 5000;
     const counts = createCandidateStatusCounts();
     let totalMatched = 0;
     let overflow = false;
 
     const page = await ctx.db
-      .query("resumes")
-      .filter((q) => q.neq(q.field("isArchived"), true))
+      .query("resume_digests")
       .paginate({
         cursor: null,
         numItems: MAX_MATCHES,
         maximumBytesRead: 10 * 1024 * 1024,
       });
 
-    for (const resume of page.page) {
+    for (const digest of page.page) {
       if (totalMatched >= MAX_MATCHES) {
         overflow = true;
         break;
       }
-      if (matchesResumeListFilters(resume, filters)) {
-        const identityKey = resume.identityKey ?? "";
-        if (identityKey && blockedIdentities.has(identityKey)) {
-          continue;
-        }
-        const status = statusByIdentity.get(identityKey) ?? "new";
-        const bucket = resolveCandidateStatus(status);
-        counts[bucket] += 1;
-        totalMatched += 1;
+      if (!matchesResumeDigestFilters(digest, filters)) {
+        continue;
       }
+      const identityKey = digest.identityKey ?? "";
+      if (identityKey && blockedIdentities.has(identityKey)) {
+        continue;
+      }
+      const status = statusByIdentity.get(identityKey) ?? "new";
+      const bucket = resolveCandidateStatus(status);
+      counts[bucket] += 1;
+      totalMatched += 1;
     }
 
-    // If the page isn't done, we hit the byte limit before reading all docs
+    // If the page isn't done, we hit the row limit before reading all digests
     if (!page.isDone) {
       overflow = true;
     }

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -504,6 +504,7 @@ export default defineSchema({
         .index("by_identityKey", ["identityKey"])
         .index("by_sourceKey", ["sourceKey"])
         .index("by_crawledAt", ["crawledAt"])
+        .index("by_primaryRuleScore", ["primaryRuleScore"])
         .searchIndex("search_body", {
             searchField: "searchText",
             filterFields: ["isArchived", "sourceKey"],


### PR DESCRIPTION
## Summary

- Move default list candidate discovery from cold `resumes.by_primaryRuleScore` to `resume_digests.by_primaryRuleScore` with full-doc hydration
- Move `countResumesByStatus` from cold `resumes` scan (27KB/doc) to `resume_digests` scan (<1KB/doc), eliminating byte-budget overflow risk
- Add `by_primaryRuleScore` index to `resume_digests` table
- Apply `matchesResumeDigestFilters` as phase-1 filter before hydration; keep `matchesResumeListFilters` as final full-doc guard until Phase 4 parity

## What changed

**`packages/convex/convex/schema.ts`**:
- Add `.index("by_primaryRuleScore", ["primaryRuleScore"])` to `resume_digests`

**`packages/convex/convex/resumes.ts`**:
- New `getResumeDocsFromDigests(ctx, digests)` helper with stale-digest guard
- `listWithIngestData`: digest index → hydrate → sort
- `listWithIngestDataPaginated` (no-sortBy branch): digest paginate → digest filter → hydrate → full-doc guard
- `runListWithIngestDataPageQuery`: same digest-first pattern
- `countResumesByStatus`: scan `resume_digests` instead of cold `resumes`

**Tests**:
- New list discovery parity tests (ordering + digest filter before hydration)
- New no-overflow count regression test (12-row broad cohort)
- New `buildResumeDigest` projection coverage test
- Enhanced 3 test files' insert helpers to auto-create digests (mirrors production)

## Test plan

- [x] `bunx vitest run packages/convex/__tests__/` — 1804 pass, 1 pre-existing audit failure (CONVEX_WRITE_SECRET env var, fails on main)
- [x] `make check` — all passed
- [x] List parity tests pass (same ordering + filter results as cold path)
- [x] Count no-overflow test passes (12 rows, `overflow: false`)
- [ ] Browser verification — deferred; Convex-only change, no UI-facing behavior change

## Context

Phase 1B of the digest-first-everywhere refactor. Phase 1A (keyword search) is PR #1264. These two PRs are independent and can merge in any order. Phase 2 (status/workspace propagation into digest) is the next slice.