### PR TITLE
feat: add resume_digest_statuses overlay for workspace-scoped status propagation (Phase 2)

### DIFF
--- a/packages/convex/__tests__/audit-convex-test.test.ts
+++ b/packages/convex/__tests__/audit-convex-test.test.ts
@@ -4,7 +4,7 @@
  * Uses edge-runtime environment (configured via environmentMatchGlobs in root vitest.config.ts).
  */
 import { createTest } from "./test-helpers.js";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { api } from "../convex/_generated/api.js";
 import { internal } from "../convex/_generated/api.js";
 import {
@@ -1271,6 +1271,20 @@ describe("audit log retention (EU AI Act / GDPR)", () => {
   });
 
   describe("submitAppeal", () => {
+    const originalWriteSecret = process.env.CONVEX_WRITE_SECRET;
+
+    beforeEach(() => {
+      process.env.CONVEX_WRITE_SECRET = "test-secret";
+    });
+
+    afterEach(() => {
+      if (originalWriteSecret === undefined) {
+        delete process.env.CONVEX_WRITE_SECRET;
+        return;
+      }
+      process.env.CONVEX_WRITE_SECRET = originalWriteSecret;
+    });
+
     it("creates candidate_status with appeal_submitted and sets audit log to appealed", async () => {
       const t = createTest();
 
@@ -1327,6 +1341,7 @@ describe("audit log retention (EU AI Act / GDPR)", () => {
         identityKey: "candidate-2",
         status: "interviewed_reject",
         notes: "Not suitable",
+        writeSecret: "test-secret",
       });
 
       const resumeId = await t.run(async (ctx) => {
@@ -1390,6 +1405,46 @@ describe("audit log retention (EU AI Act / GDPR)", () => {
 
       expect(result.success).toBe(true);
       expect(result.status).toBe("appeal_submitted");
+    });
+
+    it("propagates appeal_submitted into resume_digest_statuses overlay", async () => {
+      const t = createTest();
+
+      const resumeId = await t.run(async (ctx) => {
+        const id = await ctx.db.insert("resumes", {
+          externalId: "appeal-digest-r1",
+          content: { name: "Appeal Digest" },
+          hash: "appeal-digest1",
+          source: "test",
+          tags: [],
+          crawledAt: Date.now(),
+        });
+        await ctx.db.insert("resume_digests", {
+          resumeId: id,
+          identityKey: "appeal-digest-identity",
+          externalId: "appeal-digest-r1",
+          source: "test",
+          sourceKey: "test",
+          searchText: "appeal digest candidate",
+          updatedAt: Date.now(),
+        });
+        return id;
+      });
+
+      await t.mutation(api.audit.submitAppeal, {
+        resumeId,
+        identityKey: "appeal-digest-identity",
+        workspaceSlug: "appeal-ws",
+        reason: "Score should be higher",
+      });
+
+      const rows = await t.run(async (ctx) =>
+        ctx.db.query("resume_digest_statuses").collect()
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].identityKey).toBe("appeal-digest-identity");
+      expect(rows[0].workspaceSlug).toBe("appeal-ws");
+      expect(rows[0].status).toBe("appeal_submitted");
     });
   });
 });

--- a/packages/convex/__tests__/candidate-status-convex-test.test.ts
+++ b/packages/convex/__tests__/candidate-status-convex-test.test.ts
@@ -229,4 +229,95 @@ describe("candidate_status: list + listForBackup", () => {
     // Should not include internal fields like _id, _creationTime
     expect(row).not.toHaveProperty("_id");
   });
+
+  // -------------------------------------------------------------------------
+  // Phase 2: digest status propagation
+  // -------------------------------------------------------------------------
+
+  it("propagates status changes into resume_digest_statuses overlay", async () => {
+    const t = createTest();
+    await t.run(async (ctx) => {
+      const resumeId = await ctx.db.insert("resumes", {
+        externalId: "status-digest-resume",
+        identityKey: "status-digest-identity",
+        content: { name: "Status Digest Candidate" },
+        hash: "status-digest-hash",
+        tags: [],
+        crawledAt: Date.now(),
+        source: "test",
+        sourceKey: "test",
+      });
+      await ctx.db.insert("resume_digests", {
+        resumeId,
+        identityKey: "status-digest-identity",
+        externalId: "status-digest-resume",
+        source: "test",
+        sourceKey: "test",
+        searchText: "status digest candidate",
+        updatedAt: Date.now(),
+      });
+    });
+
+    await t.mutation(api.candidate_status.upsert, {
+      workspaceSlug: "status-digest-ws",
+      identityKey: "status-digest-identity",
+      status: "contacted",
+      writeSecret: WRITE_SECRET,
+    });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("resume_digest_statuses").collect()
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].identityKey).toBe("status-digest-identity");
+    expect(rows[0].workspaceSlug).toBe("status-digest-ws");
+    expect(rows[0].status).toBe("contacted");
+  });
+
+  it("preserves independent workspace statuses in the digest overlay", async () => {
+    const t = createTest();
+    await t.run(async (ctx) => {
+      const resumeId = await ctx.db.insert("resumes", {
+        externalId: "multi-ws-resume",
+        identityKey: "multi-ws-identity",
+        content: { name: "Multi WS Candidate" },
+        hash: "multi-ws-hash",
+        tags: [],
+        crawledAt: Date.now(),
+        source: "test",
+        sourceKey: "test",
+      });
+      await ctx.db.insert("resume_digests", {
+        resumeId,
+        identityKey: "multi-ws-identity",
+        externalId: "multi-ws-resume",
+        source: "test",
+        sourceKey: "test",
+        searchText: "multi ws candidate",
+        updatedAt: Date.now(),
+      });
+    });
+
+    await t.mutation(api.candidate_status.upsert, {
+      workspaceSlug: "ws-a",
+      identityKey: "multi-ws-identity",
+      status: "shortlisted",
+      writeSecret: WRITE_SECRET,
+    });
+    await t.mutation(api.candidate_status.upsert, {
+      workspaceSlug: "ws-b",
+      identityKey: "multi-ws-identity",
+      status: "rejected",
+      writeSecret: WRITE_SECRET,
+    });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("resume_digest_statuses").collect()
+    );
+    expect(rows).toHaveLength(2);
+    const wsA = rows.find((r) => r.workspaceSlug === "ws-a");
+    const wsB = rows.find((r) => r.workspaceSlug === "ws-b");
+    expect(wsA?.status).toBe("shortlisted");
+    expect(wsB?.status).toBe("rejected");
+  });
 });

--- a/packages/convex/convex/audit.ts
+++ b/packages/convex/convex/audit.ts
@@ -3,6 +3,7 @@ import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import { fnvHash, ageToBracket } from "./lib/bias_metrics.js";
+import { upsertDigestStatusForIdentity } from "./candidate_status.js";
 
 // ---------------------------------------------------------------------------
 // Internal mutation: logAnalysisDecision
@@ -173,6 +174,13 @@ export const submitAppeal = mutation({
                 history: [],
             });
         }
+
+        await upsertDigestStatusForIdentity(ctx, {
+            workspaceSlug: args.workspaceSlug,
+            identityKey: args.identityKey,
+            status: "appeal_submitted",
+            updatedAt: now,
+        });
 
         // Set audit log outcome to "appealed"
         const auditLog = await ctx.db

--- a/packages/convex/convex/candidate_status.ts
+++ b/packages/convex/convex/candidate_status.ts
@@ -1,8 +1,60 @@
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server";
+import { mutation, query, type MutationCtx } from "./_generated/server";
 
 import { DEFAULT_WORKSPACE_SLUG } from "./sessions";
 const DEFAULT_STATUS = "new";
+
+type CandidateStatus =
+    | "new" | "shortlisted" | "rejected" | "contacted"
+    | "interviewing" | "interviewed_pass" | "interviewed_reject"
+    | "appeal_submitted" | "human_review" | "upheld" | "reversed"
+    | "offer" | "hired" | "withdrawn";
+
+/**
+ * Propagate a status change into the hot resume_digest_statuses overlay.
+ * Called from candidate_status.upsert and audit.submitAppeal after writing
+ * candidate_status. Looks up the resume via resume_digests.by_identityKey,
+ * then upserts the workspace-scoped status overlay row.
+ */
+export async function upsertDigestStatusForIdentity(
+    ctx: MutationCtx,
+    args: {
+        workspaceSlug: string;
+        identityKey: string;
+        status: CandidateStatus;
+        updatedAt: number;
+    },
+): Promise<void> {
+    const digest = await ctx.db
+        .query("resume_digests")
+        .withIndex("by_identityKey", (q) => q.eq("identityKey", args.identityKey))
+        .first();
+    if (!digest) {
+        return;
+    }
+
+    const existing = await ctx.db
+        .query("resume_digest_statuses")
+        .withIndex("by_workspace_identity", (q) =>
+            q.eq("workspaceSlug", args.workspaceSlug).eq("identityKey", args.identityKey)
+        )
+        .unique();
+
+    if (existing) {
+        await ctx.db.patch(existing._id, {
+            status: args.status,
+            updatedAt: args.updatedAt,
+        });
+    } else {
+        await ctx.db.insert("resume_digest_statuses", {
+            resumeId: digest.resumeId,
+            identityKey: args.identityKey,
+            workspaceSlug: args.workspaceSlug,
+            status: args.status,
+            updatedAt: args.updatedAt,
+        });
+    }
+}
 
 function normalizeWorkspaceSlug(input: string | undefined): string {
     const normalized = input?.trim();
@@ -134,17 +186,34 @@ export const upsert = mutation({
                 history: nextHistory,
             });
 
+            await upsertDigestStatusForIdentity(ctx, {
+                workspaceSlug,
+                identityKey,
+                status: args.status,
+                updatedAt: now,
+            });
+
             return existing._id;
         }
 
-        return await ctx.db.insert("candidate_status", {
+        const statusValue = args.status ?? DEFAULT_STATUS;
+        const newId = await ctx.db.insert("candidate_status", {
             workspaceSlug,
             identityKey,
-            status: args.status ?? DEFAULT_STATUS,
+            status: statusValue as any,
             notes: args.notes,
             updatedBy: args.updatedBy,
             updatedAt: now,
             history: [],
         });
+
+        await upsertDigestStatusForIdentity(ctx, {
+            workspaceSlug,
+            identityKey,
+            status: statusValue as CandidateStatus,
+            updatedAt: now,
+        });
+
+        return newId;
     },
 });

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -509,6 +509,35 @@ export default defineSchema({
             filterFields: ["isArchived", "sourceKey"],
         }),
 
+    // Hot status overlay — workspace-scoped candidate status for server-side
+    // filtering. Separate from resume_digests (which is resume-scoped) to
+    // preserve independent workspace statuses for the same identity.
+    resume_digest_statuses: defineTable({
+        resumeId: v.id("resumes"),
+        identityKey: v.string(),
+        workspaceSlug: v.string(),
+        status: v.union(
+            v.literal("new"),
+            v.literal("shortlisted"),
+            v.literal("rejected"),
+            v.literal("contacted"),
+            v.literal("interviewing"),
+            v.literal("interviewed_pass"),
+            v.literal("interviewed_reject"),
+            v.literal("appeal_submitted"),
+            v.literal("human_review"),
+            v.literal("upheld"),
+            v.literal("reversed"),
+            v.literal("offer"),
+            v.literal("hired"),
+            v.literal("withdrawn")
+        ),
+        updatedAt: v.number(),
+    })
+        .index("by_workspace_status", ["workspaceSlug", "status"])
+        .index("by_workspace_identity", ["workspaceSlug", "identityKey"])
+        .index("by_resume", ["resumeId"]),
+
     // Analysis Audit Log — EU AI Act compliance (Annex III §4a high-risk)
     analysis_audit_log: defineTable({
         resumeId: v.id("resumes"),


### PR DESCRIPTION
## Summary

- Add `resume_digest_statuses` hot overlay table for workspace-scoped candidate status, enabling future server-side status filtering
- Propagate status changes from `candidate_status.upsert` and `audit.submitAppeal` into the overlay via `upsertDigestStatusForIdentity` helper
- **Design: Option A** (separate overlay table) — `resume_digests` is resume-scoped, but candidate status is workspace-scoped. A single scalar on digests would collapse independent workspace statuses
- **Bug fix**: pre-existing `audit-convex-test` failure (missing `CONVEX_WRITE_SECRET` env setup + missing `writeSecret` arg) — now all 1807 convex tests pass

## What changed

**`packages/convex/convex/schema.ts`**:
- New `resume_digest_statuses` table with `by_workspace_status`, `by_workspace_identity`, `by_resume` indexes

**`packages/convex/convex/candidate_status.ts`**:
- New `upsertDigestStatusForIdentity(ctx, args)` helper — looks up resumeId via `resume_digests.by_identityKey`, upserts overlay row
- `upsert` mutation calls helper after both insert and patch paths

**`packages/convex/convex/audit.ts`**:
- `submitAppeal` calls helper with `status: "appeal_submitted"` after candidate_status write

**Tests**:
- Status propagation test (contacted → overlay)
- Multi-workspace independence guard (ws-a=shortlisted, ws-b=rejected)
- Appeal propagation test (appeal_submitted → overlay)
- Fixed pre-existing audit env var bug

## Test plan

- [x] `bunx vitest run packages/convex/__tests__/` — 1807 pass, 0 failures (was 1804+1 pre-existing)
- [x] `make check` — all passed
- [x] Multi-workspace guard: independent statuses preserved
- [x] Appeal propagation: appeal_submitted lands in overlay
- [ ] Server-side status filtering in queries — deferred to follow-up (depends on Phase 1B merging)

## Context

Phase 2 of the digest-first-everywhere refactor. Phase 1A (#1264, merged) migrated keyword search. Phase 1B (#1265, pending CI) migrated list/count. This PR adds the status overlay infrastructure. Server-side status filtering (Task 9 Step 4) is a follow-up that depends on Phase 1B's digest filter path.