### PR TITLE
perf: use resume_digest_statuses overlay for countResumesByStatus

### DIFF
--- a/packages/convex/__tests__/count-resumes-by-status-convex-test.test.ts
+++ b/packages/convex/__tests__/count-resumes-by-status-convex-test.test.ts
@@ -357,4 +357,54 @@ describe("countResumesByStatus", () => {
     expect(result.new).toBe(12);
     expect(result.overflow).toBe(false);
   });
+
+  it("uses the resume_digest_statuses overlay for workspace status counts", async () => {
+    const source = "test-count-overlay";
+    const ws = "test-count-overlay-ws";
+    await test.run(async (ctx) => {
+      for (let i = 0; i < 3; i += 1) {
+        const resumeId = await ctx.db.insert("resumes", {
+          externalId: `ext-overlay-${i}`,
+          identityKey: `ik-overlay-${i}`,
+          content: { name: `Overlay ${i}`, location: "Shanghai, China" },
+          searchText: `cnc overlay ${i}`,
+          hash: `hash-overlay-${i}`,
+          tags: [],
+          crawledAt: Date.now(),
+          source,
+          sourceKey: source,
+        });
+        const resume = await ctx.db.get(resumeId);
+        if (resume) {
+          await ctx.db.insert("resume_digests", buildResumeDigest(resume, Date.now()) as any);
+        }
+      }
+      // Populate overlay directly — one shortlisted, one rejected, one stays "new"
+      await ctx.db.insert("resume_digest_statuses", {
+        resumeId: await ctx.db.query("resume_digests").withIndex("by_identityKey", (q) => q.eq("identityKey", "ik-overlay-0")).first().then((d: any) => d?.resumeId),
+        identityKey: "ik-overlay-0",
+        workspaceSlug: ws,
+        status: "shortlisted",
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("resume_digest_statuses", {
+        resumeId: await ctx.db.query("resume_digests").withIndex("by_identityKey", (q) => q.eq("identityKey", "ik-overlay-1")).first().then((d: any) => d?.resumeId),
+        identityKey: "ik-overlay-1",
+        workspaceSlug: ws,
+        status: "rejected",
+        updatedAt: Date.now(),
+      });
+    });
+
+    const result = await test.query(api.resumes.countResumesByStatus, {
+      workspaceSlug: ws,
+      sources: [source],
+    });
+
+    expect(result.total).toBe(3);
+    expect(result.new).toBe(1);
+    expect(result.shortlisted).toBe(1);
+    expect(result.rejected).toBe(1);
+    expect(result.overflow).toBe(false);
+  });
 });

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -709,17 +709,32 @@ export const countResumesByStatus = query({
   handler: async (ctx, args) => {
     const { workspaceSlug, showBlocked, ...rawFilters } = args;
 
-    // 1. Load candidate_status for workspace
-    const statuses = await ctx.db
-      .query("candidate_status")
+    // 1. Load workspace status overlay (resume_digest_statuses) first —
+    //    it's workspace-scoped and populated by propagation hooks.
+    //    Fall back to candidate_status for identities not yet in the overlay
+    //    (e.g., after a restore that hasn't backfilled the overlay).
+    const overlayStatuses = await ctx.db
+      .query("resume_digest_statuses")
       .withIndex("by_workspace_status", (q) =>
         q.eq("workspaceSlug", workspaceSlug)
       )
       .collect();
 
     const statusByIdentity = new Map<string, string>();
-    for (const s of statuses) {
+    for (const s of overlayStatuses) {
       statusByIdentity.set(s.identityKey, s.status);
+    }
+
+    const candidateStatuses = await ctx.db
+      .query("candidate_status")
+      .withIndex("by_workspace_status", (q) =>
+        q.eq("workspaceSlug", workspaceSlug)
+      )
+      .collect();
+    for (const s of candidateStatuses) {
+      if (!statusByIdentity.has(s.identityKey)) {
+        statusByIdentity.set(s.identityKey, s.status);
+      }
     }
 
     const blockedIdentities = new Set<string>();


### PR DESCRIPTION
## Summary

- `countResumesByStatus` now reads workspace status from the `resume_digest_statuses` overlay first, falling back to `candidate_status` for identities not yet in the overlay
- Eliminates the full `candidate_status` collect when the overlay is fully populated
- Preserves correctness during the overlay backfill window (post-restore identities still get status from `candidate_status`)

## What changed

**`packages/convex/convex/resumes.ts`**: `countResumesByStatus` handler now queries `resume_digest_statuses.by_workspace_status` first, then fills gaps from `candidate_status.by_workspace_status`.

## Test plan

- [x] `bunx vitest run packages/convex/__tests__/` — 1812 pass, 0 failures
- [x] `make check` — all passed
- [x] New overlay test: 3 resumes with overlay-only statuses (no candidate_status rows) → correct counts

## Context

Server-side status filtering follow-up to Phase 2 (#1266, merged). The overlay table was added in Phase 2; this PR makes `countResumesByStatus` use it as the primary status source. List/search status filtering is a separate follow-up.