### PR TITLE
feat: backfill resume_digest_statuses overlay in validateDataConsistency

### DIFF
--- a/packages/convex/__tests__/migrations-convex-test.test.ts
+++ b/packages/convex/__tests__/migrations-convex-test.test.ts
@@ -1689,6 +1689,46 @@ describe("migration: validateDataConsistency", () => {
     expect(result.backfillVerifiedRoleYears.scanned).toBe(0);
     expect(result.backfillVerifiedRoleYears.updated).toBe(0);
   });
+
+  it("backfills resume_digest_statuses overlay from candidate_status", async () => {
+    const t = createTest();
+
+    const resumeId = await insertResume(t, {
+      identityKey: "ik-status-backfill",
+      content: { name: "Status Backfill Candidate" },
+      searchText: "cnc status backfill",
+      ingestData: {
+        industryTags: ["manufacturing"],
+        synonymHits: ["cnc"],
+        ruleScores: {},
+        experienceLevel: "senior",
+        computedAt: Date.now(),
+        skillsVersion: 2,
+      },
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("candidate_status", {
+        workspaceSlug: "backfill-ws",
+        identityKey: "ik-status-backfill",
+        status: "shortlisted",
+        updatedAt: Date.now(),
+      });
+    });
+
+    const result = await t.action(api.migrations.validateDataConsistency, {});
+
+    expect(result.backfillResumeDigests.processed).toBeGreaterThanOrEqual(1);
+    expect(result.backfillResumeDigestStatuses.processed).toBe(1);
+
+    const statusRows = await t.run(async (ctx) =>
+      ctx.db.query("resume_digest_statuses").collect()
+    );
+    expect(statusRows).toHaveLength(1);
+    expect(statusRows[0].identityKey).toBe("ik-status-backfill");
+    expect(statusRows[0].workspaceSlug).toBe("backfill-ws");
+    expect(statusRows[0].status).toBe("shortlisted");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -1533,10 +1533,27 @@ export const validateDataConsistency = action({
             digestCursor = result.cursor;
         }
 
+        // Step 4: Backfill resume_digest_statuses overlay from candidate_status.
+        // Restores from pre-Phase-2 backups have candidate_status but no overlay.
+        // This step runs after Step 3 (digest rebuild) so resume_digests.by_identityKey
+        // lookups resolve correctly.
+        let statusCursor: string | null = null;
+        let statusProcessed = 0;
+        for (let i = 0; i < 10000; i++) {
+            const result: { processed: number; isDone: boolean; cursor: string | null } = await ctx.runMutation(api.resumes_search.backfillResumeDigestStatuses, {
+                cursor: statusCursor ?? undefined,
+                limit: batchSize,
+            });
+            statusProcessed += result.processed;
+            if (result.isDone) break;
+            statusCursor = result.cursor;
+        }
+
         return {
             reindexSearchText: { scanned: reindexScanned, updated: reindexUpdated },
             backfillVerifiedRoleYears: { scanned: vryScanned, updated: vryUpdated },
             backfillResumeDigests: { processed: digestProcessed },
+            backfillResumeDigestStatuses: { processed: statusProcessed },
         };
     },
 });

--- a/packages/convex/convex/resumes_search.ts
+++ b/packages/convex/convex/resumes_search.ts
@@ -971,7 +971,67 @@ export const backfillResumeDigests = mutation({
     },
 });
 
-// Keep getResumes for backward compatibility
+// Idempotent backfill: paginate through all candidate_status rows and
+// upsert resume_digest_statuses overlay rows. Safe to re-run — existing
+// overlay rows are updated in place. Required after a restore where the
+// overlay table may not exist in the backup (pre-Phase-2 backups).
+export const backfillResumeDigestStatuses = mutation({
+    args: {
+        cursor: v.optional(v.string()),
+        limit: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const numItems = Math.min(args.limit ?? 100, 200);
+        const page = await ctx.db
+            .query("candidate_status")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems,
+            });
+
+        let processed = 0;
+        for (const status of page.page) {
+            // Look up the resume via the digest overlay's by_identityKey index.
+            const digest = await ctx.db
+                .query("resume_digests")
+                .withIndex("by_identityKey", (q) => q.eq("identityKey", status.identityKey))
+                .first();
+            if (!digest) {
+                continue;
+            }
+
+            const existing = await ctx.db
+                .query("resume_digest_statuses")
+                .withIndex("by_workspace_identity", (q) =>
+                    q.eq("workspaceSlug", status.workspaceSlug).eq("identityKey", status.identityKey)
+                )
+                .unique();
+
+            if (existing) {
+                await ctx.db.patch(existing._id, {
+                    status: status.status,
+                    updatedAt: status.updatedAt,
+                });
+            } else {
+                await ctx.db.insert("resume_digest_statuses", {
+                    resumeId: digest.resumeId,
+                    identityKey: status.identityKey,
+                    workspaceSlug: status.workspaceSlug,
+                    status: status.status,
+                    updatedAt: status.updatedAt,
+                });
+            }
+            processed += 1;
+        }
+
+        return {
+            processed,
+            isDone: page.isDone,
+            cursor: page.isDone ? null : page.continueCursor,
+        };
+    },
+});
 // These are used by the API resume list for AND-mode search
 // getResumes added to resolve production "function not found" errors
 export const getResumes = query({


### PR DESCRIPTION
## Summary

- Add Step 4 to `validateDataConsistency`: backfill `resume_digest_statuses` overlay from `candidate_status`
- New mutation `backfillResumeDigestStatuses` — idempotent, updates existing overlay rows in place
- Required after a restore from pre-Phase-2 backup where the overlay table doesn't exist

## What changed

**`packages/convex/convex/resumes_search.ts`**: New `backfillResumeDigestStatuses` mutation. Paginates through `candidate_status`, looks up `resumeId` via `resume_digests.by_identityKey`, upserts overlay row keyed by `workspaceSlug + identityKey`.

**`packages/convex/convex/migrations.ts`**: `validateDataConsistency` now has Step 4 after the digest rebuild (Step 3). Returns `backfillResumeDigestStatuses: { processed }` in the result.

**Test**: Validates overlay backfill from a `candidate_status` row with `shortlisted` status → lands in `resume_digest_statuses` with correct `workspaceSlug`, `identityKey`, `status`.

## Test plan

- [x] `bunx vitest run packages/convex/__tests__/` — 1813 pass, 0 failures
- [x] `make check` — all passed
- [x] Migration test: overlay populated from candidate_status after validateDataConsistency

## Context

Migration safety follow-up to Phase 2 (#1266). Without this backfill, a production restore from a pre-Phase-2 backup would have empty overlay until individual status mutations repopulate it. Now `validateDataConsistency` (run after every restore) populates it automatically.