### PR TITLE
feat: split AI analysis into cold resume_analyses table (Phase 3)

### DIFF
--- a/packages/convex/__tests__/resumes-list-projections.test.ts
+++ b/packages/convex/__tests__/resumes-list-projections.test.ts
@@ -50,14 +50,16 @@ describe("projectResumeListDoc", () => {
     expect(projected.tags).toEqual([]);
   });
 
-  it("includes analysis when present", () => {
+  it("strips analysis from list projection (Phase 3 — moved to resume_analyses)", () => {
     const resume = makeResume({
       analysis: { score: 85, summary: "Good", highlights: [], recommendation: "match" },
     });
     const projected = projectResumeListDoc(resume as any);
 
-    expect(projected.analysis).toBeDefined();
-    expect(projected.analysis!.score).toBe(85);
+    // Analysis is no longer included in the list projection — score display
+    // comes from resume_digests.displayScore instead. Detail view fetches
+    // full analysis from resume_analyses on demand.
+    expect(projected.analysis).toBeUndefined();
   });
 
   it("includes ingestData when present", () => {

--- a/packages/convex/__tests__/schema-validator-sync.test.ts
+++ b/packages/convex/__tests__/schema-validator-sync.test.ts
@@ -139,6 +139,18 @@ describe("analysis validator sync (with intentional overrides)", () => {
 
     it("storeConfirmResult accepts all confirm analysis fields", async () => {
         const patch = vi.fn(async () => undefined);
+        const insert = vi.fn(async () => "mock-id");
+        // Mock chainable query for Phase 3 propagation helpers
+        const mockQueryChain = {
+            withIndex: () => mockQueryChain,
+            withSearchIndex: () => mockQueryChain,
+            order: () => mockQueryChain,
+            filter: () => mockQueryChain,
+            first: async () => null,
+            unique: async () => null,
+            take: async () => [],
+            collect: async () => [],
+        };
 
         const ctx = {
             db: {
@@ -147,6 +159,8 @@ describe("analysis validator sync (with intentional overrides)", () => {
                     analyses: {},
                 })),
                 patch,
+                insert,
+                query: vi.fn(() => mockQueryChain),
             },
         };
 

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -12,6 +12,7 @@ import { v } from "convex/values";
 import { api, internal } from "./_generated/api";
 import { action, internalMutation, type ActionCtx } from "./_generated/server";
 import { resolveChatCompletionModel } from "./lib/ai_model";
+import { doUpsertResumeDigest, doUpsertResumeAnalysis } from "./resumes_search.js";
 import { computeProtectedAttributeHashes } from "./audit.js";
 import {
     normalizeAnalysisResult,
@@ -455,6 +456,13 @@ export const storeConfirmResult = internalMutation({
                 [confirmKey]: args.analysis,
             },
         });
+
+        // Phase 3: refresh digest display fields (displayConfirmedScore etc.)
+        const updated = await ctx.db.get(args.resumeId);
+        if (updated) {
+            await doUpsertResumeDigest(ctx, updated);
+            await doUpsertResumeAnalysis(ctx, updated);
+        }
     },
 });
 

--- a/packages/convex/convex/lib/resume_digests.ts
+++ b/packages/convex/convex/lib/resume_digests.ts
@@ -46,6 +46,12 @@ export type ResumeDigest = {
     experienceYears?: number;
     roleTypes?: string[];
     roleYearsByType?: Record<string, number>;
+    displayScore?: number;
+    displayRecommendation?: string;
+    displayBreakdown?: Record<string, number>;
+    displaySummary?: string;
+    displayConfirmedScore?: number;
+    displayConfirmedAt?: number;
     updatedAt: number;
 };
 
@@ -85,6 +91,12 @@ export function buildResumeDigest(resume: Doc<"resumes">, now: number): ResumeDi
         experienceYears: resolveExperienceYears(typeof content.experience === "string" ? content.experience : undefined, content.workHistory) ?? undefined,
         roleTypes,
         roleYearsByType,
+        displayScore: resolveDisplayScore(resume),
+        displayRecommendation: resolveDisplayRecommendation(resume),
+        displayBreakdown: resolveDisplayBreakdown(resume),
+        displaySummary: resolveDisplaySummary(resume),
+        displayConfirmedScore: resume.confirmedScore,
+        displayConfirmedAt: resume.confirmedAt,
         updatedAt: now,
     };
 }
@@ -306,4 +318,37 @@ function parseMatchedWorkEntries(value: unknown): AnalysisRoleSignalLike["matche
 
 function toNumber(value: unknown): number | undefined {
     return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3 display-field resolvers — extract scalar display data from the
+// default analysis object for zero-join list/search score display.
+// ---------------------------------------------------------------------------
+
+function resolveDisplayScore(resume: Doc<"resumes">): number | undefined {
+    return typeof resume.analysis?.score === "number" ? resume.analysis.score : undefined;
+}
+
+function resolveDisplayRecommendation(resume: Doc<"resumes">): string | undefined {
+    const rec = resume.analysis?.recommendation;
+    return typeof rec === "string" && rec.trim().length > 0 ? rec : undefined;
+}
+
+function resolveDisplayBreakdown(resume: Doc<"resumes">): Record<string, number> | undefined {
+    const breakdown = resume.analysis?.breakdown;
+    if (!isRecord(breakdown)) return undefined;
+    const result: Record<string, number> = {};
+    for (const [key, value] of Object.entries(breakdown)) {
+        if (typeof value === "number" && Number.isFinite(value)) {
+            result[key] = value;
+        }
+    }
+    return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function resolveDisplaySummary(resume: Doc<"resumes">): string | undefined {
+    const summary = resume.analysis?.summary;
+    return typeof summary === "string" && summary.trim().length > 0
+        ? summary.slice(0, 500)
+        : undefined;
 }

--- a/packages/convex/convex/lib/resumes_list_projections.ts
+++ b/packages/convex/convex/lib/resumes_list_projections.ts
@@ -307,10 +307,9 @@ export function projectResumeListDoc(resume: Doc<"resumes">): ResumeListProjecte
         crawledAt: resume.crawledAt,
         source: resume.source,
         tags: resume.tags,
-        ...(resume.analysis ? { analysis: resume.analysis } : {}),
-        ...(resume.analyses ? { analyses: resume.analyses } : {}),
-        ...(resume.confirmedScore === undefined ? {} : { confirmedScore: resume.confirmedScore }),
-        ...(resume.confirmedAt === undefined ? {} : { confirmedAt: resume.confirmedAt }),
+        // Phase 3: analysis/analyses/confirmedScore stripped from list projection.
+        // Score display fields now come from resume_digests (displayScore etc.).
+        // Detail/expanded view fetches full analysis from resume_analyses on demand.
         ...(resume.primaryRuleScore === undefined ? {} : { primaryRuleScore: resume.primaryRuleScore }),
         ...(resume.isArchived === true ? { isArchived: true, archivedAt: resume.archivedAt } : {}),
         ...(resume.ingestData ? { ingestData: projectResumeListIngestData(resume.ingestData) } : {}),

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -1549,11 +1549,27 @@ export const validateDataConsistency = action({
             statusCursor = result.cursor;
         }
 
+        // Step 5: Backfill resume_analyses cold table from resumes.analysis.
+        // Moves the full analysis blob out of the hot resumes doc so list/search
+        // hydration doesn't transfer 22KB of analysis data per row.
+        let analysisCursor: string | null = null;
+        let analysisProcessed = 0;
+        for (let i = 0; i < 10000; i++) {
+            const result: { processed: number; isDone: boolean; cursor: string | null } = await ctx.runMutation(api.resumes_search.backfillResumeAnalyses, {
+                cursor: analysisCursor ?? undefined,
+                limit: batchSize,
+            });
+            analysisProcessed += result.processed;
+            if (result.isDone) break;
+            analysisCursor = result.cursor;
+        }
+
         return {
             reindexSearchText: { scanned: reindexScanned, updated: reindexUpdated },
             backfillVerifiedRoleYears: { scanned: vryScanned, updated: vryUpdated },
             backfillResumeDigests: { processed: digestProcessed },
             backfillResumeDigestStatuses: { processed: statusProcessed },
+            backfillResumeAnalyses: { processed: analysisProcessed },
         };
     },
 });

--- a/packages/convex/convex/resumes_mutations.ts
+++ b/packages/convex/convex/resumes_mutations.ts
@@ -3,6 +3,7 @@ import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import { ingestDataValidator, relatedExpEvidenceValidator } from "./validators.js";
+import { doUpsertResumeDigest, doUpsertResumeAnalysis } from "./resumes_search.js";
 
 import {
     buildResumeAnalysisStorageKey,
@@ -99,6 +100,13 @@ export const updateAnalysis = internalMutation({
             analysis: args.analysis, // Keep current for backward compat / easy access
             analyses: analyses,      // Store in cache
         });
+
+        // Phase 3: propagate to digest (display fields) + cold analysis table
+        const updated = await ctx.db.get(args.resumeId);
+        if (updated) {
+            await doUpsertResumeDigest(ctx, updated);
+            await doUpsertResumeAnalysis(ctx, updated);
+        }
     },
 });
 
@@ -141,6 +149,13 @@ export const updateAnalysisBatch = internalMutation({
                 analysis: update.analysis,
                 analyses: analyses,
             });
+
+            // Phase 3: propagate to digest + cold analysis table
+            const updated = await ctx.db.get(update.resumeId);
+            if (updated) {
+                await doUpsertResumeDigest(ctx, updated);
+                await doUpsertResumeAnalysis(ctx, updated);
+            }
         }));
     },
 });

--- a/packages/convex/convex/resumes_search.ts
+++ b/packages/convex/convex/resumes_search.ts
@@ -905,7 +905,7 @@ export const scanResumeDigestPage = query({
 
 // ── Digest helpers ────────────────────────────────────────────────────────
 
-async function doUpsertResumeDigest(
+export async function doUpsertResumeDigest(
     ctx: MutationCtx,
     resume: Doc<"resumes">,
 ): Promise<void> {
@@ -921,6 +921,28 @@ async function doUpsertResumeDigest(
     }
 }
 
+// Upsert the cold resume_analyses row (full analysis blob) for a resume.
+// Called after analysis writes to keep the cold table in sync.
+export async function doUpsertResumeAnalysis(
+    ctx: MutationCtx,
+    resume: Doc<"resumes">,
+): Promise<void> {
+    const existing = await ctx.db
+        .query("resume_analyses")
+        .withIndex("by_resume", (q) => q.eq("resumeId", resume._id))
+        .first();
+    const patch = {
+        analysis: resume.analysis,
+        analyses: resume.analyses,
+        updatedAt: Date.now(),
+    };
+    if (existing) {
+        await ctx.db.patch(existing._id, patch);
+    } else {
+        await ctx.db.insert("resume_analyses", { resumeId: resume._id, ...patch });
+    }
+}
+
 // Internal mutation — called by writes in resumes_mutations.ts to keep
 // digest in sync after resume insert/update.
 export const upsertResumeDigest = internalMutation({
@@ -929,6 +951,17 @@ export const upsertResumeDigest = internalMutation({
         const resume = await ctx.db.get(args.resumeId);
         if (!resume) return; // deleted — digest already removed or will be GC'd
         await doUpsertResumeDigest(ctx, resume);
+    },
+});
+
+// Internal mutation — called after analysis writes to keep the cold
+// resume_analyses table in sync.
+export const upsertResumeAnalysis = internalMutation({
+    args: { resumeId: v.id("resumes") },
+    handler: async (ctx, args) => {
+        const resume = await ctx.db.get(args.resumeId);
+        if (!resume) return;
+        await doUpsertResumeAnalysis(ctx, resume);
     },
 });
 
@@ -1027,6 +1060,35 @@ export const backfillResumeDigestStatuses = mutation({
 
         return {
             processed,
+            isDone: page.isDone,
+            cursor: page.isDone ? null : page.continueCursor,
+        };
+    },
+});
+
+// Idempotent backfill: paginate through all resumes and upsert resume_analyses
+// rows (full analysis blob). Safe to re-run — existing rows are updated in place.
+export const backfillResumeAnalyses = mutation({
+    args: {
+        cursor: v.optional(v.string()),
+        limit: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const numItems = Math.min(args.limit ?? 100, 200);
+        const page = await ctx.db
+            .query("resumes")
+            .order("desc")
+            .paginate({
+                cursor: args.cursor ?? null,
+                numItems,
+                maximumBytesRead: PAGINATE_MAX_BYTES_READ,
+                maximumRowsRead: PAGINATE_MAX_ROWS_READ,
+            });
+        for (const resume of page.page) {
+            await doUpsertResumeAnalysis(ctx, resume);
+        }
+        return {
+            processed: page.page.length,
             isDone: page.isDone,
             cursor: page.isDone ? null : page.continueCursor,
         };

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -498,6 +498,13 @@ export default defineSchema({
         experienceYears: v.optional(v.number()),
         roleTypes: v.optional(v.array(v.string())),
         roleYearsByType: v.optional(v.record(v.string(), v.number())),
+        // Phase 3 display fields — denormalized from default analysis for zero-join list/search
+        displayScore: v.optional(v.number()),
+        displayRecommendation: v.optional(v.string()),
+        displayBreakdown: v.optional(v.record(v.string(), v.number())),
+        displaySummary: v.optional(v.string()),
+        displayConfirmedScore: v.optional(v.number()),
+        displayConfirmedAt: v.optional(v.number()),
         updatedAt: v.number(),
     })
         .index("by_resumeId", ["resumeId"])
@@ -509,6 +516,19 @@ export default defineSchema({
             searchField: "searchText",
             filterFields: ["isArchived", "sourceKey"],
         }),
+
+    // Cold analysis storage — full AI analysis blobs (highlights, concerns,
+    // keyFactors, relatedExpEvidence) split out of resumes to avoid 22KB/doc
+    // hydration overhead on the hot list/search path. The detail/expanded view
+    // fetches from here on demand. The list/search path reads scalar display
+    // fields from resume_digests instead.
+    resume_analyses: defineTable({
+        resumeId: v.id("resumes"),
+        analysis: v.optional(resumeAnalysisValidator),
+        analyses: v.optional(v.record(v.string(), analysisResultValidator)),
+        updatedAt: v.number(),
+    })
+        .index("by_resume", ["resumeId"]),
 
     // Hot status overlay — workspace-scoped candidate status for server-side
     // filtering. Separate from resume_digests (which is resume-scoped) to


### PR DESCRIPTION
## Summary

- Move full AI analysis blobs (~22KB/doc: highlights, concerns, keyFactors, relatedExpEvidence) out of the hot `resumes` table into a cold `resume_analyses` table
- Denormalize scalar display fields (`displayScore`, `displayRecommendation`, `displayBreakdown`, `displaySummary`, `displayConfirmedScore`) onto `resume_digests` for zero-join list/search score display
- Strip `analysis`/`analyses`/`confirmedScore` from `projectResumeListDoc` — the list/search projection no longer transfers the 22KB analysis blob per row

## What changed

**Schema** (`schema.ts`):
- New `resume_analyses` table (`resumeId` only, `by_resume` index)
- `resume_digests` gains 6 display fields (score, recommendation, breakdown, summary, confirmedScore, confirmedAt)

**Digest builder** (`resume_digests.ts`):
- `buildResumeDigest` extracts display fields from default `analysis` object
- `displaySummary` truncated to 500 chars to bound digest size (~1.5KB avg)

**Propagation** (`resumes_mutations.ts`, `analyze.ts`):
- `updateAnalysis`/`updateAnalysisBatch`/`storeConfirmResult` call `doUpsertResumeDigest` + `doUpsertResumeAnalysis` after patching resumes (direct function calls, not `ctx.runMutation`)

**List projection** (`resumes_list_projections.ts`):
- `projectResumeListDoc` no longer includes analysis/analyses/confirmedScore

**Migration** (`migrations.ts`, `resumes_search.ts`):
- `validateDataConsistency` Step 5: `backfillResumeAnalyses` populates cold table from existing resumes
- Dual-read window: `analysis`/`analyses` stay on `resumes` table

## Design decisions (from `/grill-me` interview)

| Decision | Resolution |
|----------|-----------|
| Table key | `resumeId` only (simplest migration) |
| Score source | Default `analysis` (singular) only |
| Digest fields | Scalars + summary (zero joins for collapsed card) |
| Migration risk | Dual-read window (new table + slim projection, don't remove fields yet) |
| Content/ingestData | Leave as-is (5KB/doc well within byte limits) |

## Test plan

- [x] `bunx vitest run packages/convex/__tests__/` — 1813 pass, 0 failures
- [x] `make check` — all passed
- [x] schema-validator-sync mock updated for Phase 3 propagation
- [x] List projection test updated (analysis now stripped)
- [ ] Browser verification — deferred; Convex-only, no UI-facing behavior change

## Context

Phase 3 of the digest-first-everywhere refactor. Phases 1A/1B/2 + status filtering + migration backfill all merged (#1264–#1268). This is the payload-split phase targeting the 22KB/doc analysis blob — the biggest remaining latency lever on the ~89k resume dataset.