### PR TITLE
refactor: remove cold resumes.search_body index (R3)

### DIFF
--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -116,11 +116,7 @@ export default defineSchema({
         .index("by_crawledAt", ["crawledAt"])
         .index("by_primaryRuleScore", ["primaryRuleScore"])
         .index("by_sourceKey", ["sourceKey"])
-        .index("by_needsEmbedding", ["needsEmbedding"])
-        .searchIndex("search_body", {
-            searchField: "searchText",
-            filterFields: ["isArchived"],
-        }),
+        .index("by_needsEmbedding", ["needsEmbedding"]),
 
     // Optional: Search Profiles (if we want to store user configs)
     search_profiles: defineTable({


### PR DESCRIPTION
## Summary

Removes the cold `resumes.search_body` search index from schema — all 6 production consumers were migrated to `resume_digests.search_body` in Phase 1A (#1264). Completes spec requirement R3.

## What changed

**`packages/convex/convex/schema.ts`**: Removed `.searchIndex("search_body", ...)` from the `resumes` table definition.

## Safety

- The inventory test (`resume-digest-callsite-inventory.test.ts`) confirms zero remaining cold `query("resumes").withSearchIndex("search_body")` consumers
- `resumes.searchText` field is retained — still used by `scanResumePageSlim` and `getResumeDocsByIds` for filter/display
- `resume_digests.search_body` index is unaffected (it's on a separate table)

## Test plan

- [x] `bunx vitest run packages/convex/__tests__/` — 1813 pass, 0 failures
- [x] `make check` — all passed
- [x] Inventory test passes (0 cold consumers)