### PR TITLE
refactor: remove redundant matchesResumeListFilters guards in list path (Phase 4)

### DIFF
--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -16,7 +16,6 @@ import {
     projectResumeListDoc,
     projectResumeDetailDoc,
     normalizeResumeListFilters,
-    matchesResumeListFilters,
     sortResumeDocs,
     sortByIngestRuleScore,
 } from "./lib/resumes_list_projections.js";
@@ -290,7 +289,6 @@ async function runListWithIngestDataPageQuery(
         sortBy: args.sortBy,
         sortOrder: args.sortOrder,
     })
-        .filter((resume) => matchesResumeListFilters(resume, filters))
         .slice(0, scanLimit);
 
     return {
@@ -601,12 +599,9 @@ export const listWithIngestDataPaginated = query({
                 ? page.page.filter((digest) => matchesResumeDigestFilters(digest, filters))
                 : page.page;
             const fullDocs = await getResumeDocsFromDigests(ctx, digestFiltered);
-            const finalFiltered = filters
-                ? fullDocs.filter((resume) => matchesResumeListFilters(resume, filters))
-                : fullDocs;
             const ranked = jobDescriptionId
-                ? sortByIngestRuleScore(finalFiltered, jobDescriptionId)
-                : finalFiltered;
+                ? sortByIngestRuleScore(fullDocs, jobDescriptionId)
+                : fullDocs;
 
             return {
                 page: ranked.map(projectResumeListDoc),


### PR DESCRIPTION
## Summary

Remove redundant post-hydration `matchesResumeListFilters` guards from the two list-path query functions in `resumes.ts`. The digest filter (`matchesResumeDigestFilters`) already ran before hydration on these paths, making the full-doc guard pure double-filtering overhead.

## What changed

**`packages/convex/convex/resumes.ts`**:
- `runListWithIngestDataPageQuery`: removed `.filter((resume) => matchesResumeListFilters(resume, filters))` — digest filter already ran
- `listWithIngestDataPaginated` (no-sortBy branch): removed `fullDocs.filter((resume) => matchesResumeListFilters(resume, filters))` — same pattern
- Removed unused `matchesResumeListFilters` import

The 3 guards in `resumes_search.ts` remain — they protect merge/tag-expansion logic where the digest filter doesn't cover all edge cases (AND-mode merge dedup, provenance dedup).

## Safety

- These 2 sites were the cleanest cases: digest filter + hydrate → redundant full-doc re-filter
- The search-path guards in `resumes_search.ts` involve merge logic that needs full-doc fields not on the digest
- `bffMatchesResumeFilters` and `ResumeService.filterResumes` (BFF paths) are untouched — they're separate code paths

## Test plan

- [x] `bunx vitest run packages/convex/__tests__/` — 1813 pass, 0 failures
- [x] `make check` — all passed

## Context

Phase 4 / R7 of the digest-first-everywhere refactor. All spec requirements R0-R7 are now complete:
- R1-R3: cold search migration + index removal
- R4-R5: status overlay + count optimization
- R6: analysis payload split (22KB/doc → cold table)
- R7: redundant filter retirement (this PR)