### PR TITLE
feat: complete Phase 3 read path + cleanup for resume_analyses (Phase 2-3/6)

### DIFF
--- a/packages/convex/__tests__/reingest-integration.test.ts
+++ b/packages/convex/__tests__/reingest-integration.test.ts
@@ -204,7 +204,18 @@ describe("Re-ingest pipeline integration", () => {
 
             const ctx = {
                 db: {
-                    query() {
+                    query(table: string) {
+                        if (table === "resume_analyses") {
+                            return {
+                                withIndex() {
+                                    return {
+                                        async unique() {
+                                            return null;
+                                        },
+                                    };
+                                },
+                            };
+                        }
                         return {
                             order(orderDirection: string) {
                                 expect(orderDirection).toBe("desc");

--- a/packages/convex/__tests__/resume-analyses-cleanup-paths.test.ts
+++ b/packages/convex/__tests__/resume-analyses-cleanup-paths.test.ts
@@ -1,20 +1,92 @@
 /**
- * Phase 0 scaffolding for resume_analyses cleanup path coverage.
+ * Phase 2+3 tests for resume_analyses cleanup paths.
  *
- * Stubs `it.skip()` placeholder tests for:
- * - deleteResumes / hardResetIngestData orphan cleanup
- * - clearAnalyses soft-clear semantics (status: archived)
- * - projectResumeDetailDoc async fetch via by_resume index
+ * projectResumeDetailDoc tests are unit-level (mocked ctx) — un-skipped
+ * in this file. clearAnalyses/deleteResumes tests are integration-level
+ * (convex-test) — stubs remain, to be un-skipped when fixture setup is
+ * streamlined.
  *
- * Tests will be un-skipped incrementally as Phases 2-3 of the
- * resume-analyses-phase3-completion-cleanup bundle land. See:
- *   projects/trends/work/2026-06-15-resume-analyses-phase3-completion-cleanup/plan.md
- *
- * TDD discipline: RED phase establishes the test skeleton before any
- * production code changes. Skipped tests are intentional — they document
- * the coverage matrix the bundle will fill in.
+ * See: projects/trends/work/2026-06-15-resume-analyses-phase3-completion-cleanup/plan.md
  */
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { projectResumeDetailDoc } from "../convex/lib/resumes_list_projections.js";
+import type { Doc } from "../convex/_generated/dataModel.js";
+
+// Helper: mock ctx.db.query chain for resume_analyses lookup.
+function mockCtxWithColdRow(coldRow: Record<string, unknown> | null) {
+    return {
+        db: {
+            query: () => ({
+                withIndex: () => ({
+                    unique: async () => coldRow,
+                }),
+            }),
+        },
+    } as any;
+}
+
+// Helper: minimal resume doc for projection tests.
+function makeResume(overrides: Partial<Doc<"resumes">> = {}): Doc<"resumes"> {
+    return {
+        _id: "r1" as any,
+        externalId: "ext-1",
+        content: { name: "Test" },
+        hash: "h1",
+        source: "test",
+        tags: [],
+        crawledAt: Date.now(),
+        ...overrides,
+    } as Doc<"resumes">;
+}
+
+describe("projectResumeDetailDoc (async fetch)", () => {
+    it("fetches analysis from resume_analyses via by_resume index (Phase 2)", async () => {
+        const resume = makeResume();
+        const coldRow = {
+            _id: "ra1" as any,
+            resumeId: resume._id,
+            analysis: { jobDescriptionId: "jd1", score: 85, recommendation: "strong" } as any,
+            analyses: undefined,
+            status: "active",
+            archivedAt: undefined,
+            updatedAt: Date.now(),
+        };
+        const projected = await projectResumeDetailDoc(mockCtxWithColdRow(coldRow), resume);
+
+        expect(projected.analysis).toBeDefined();
+        expect((projected.analysis as any).score).toBe(85);
+    });
+
+    it("returns undefined analysis when no resume_analyses row exists", async () => {
+        const resume = makeResume();
+        const projected = await projectResumeDetailDoc(mockCtxWithColdRow(null), resume);
+
+        expect(projected.analysis).toBeUndefined();
+        expect(projected.analyses).toBeUndefined();
+    });
+
+    it("filters out archived rows — only active rows reach the detail view", async () => {
+        const resume = makeResume();
+        const archivedRow = {
+            _id: "ra1" as any,
+            resumeId: resume._id,
+            analysis: { jobDescriptionId: "jd1", score: 85 } as any,
+            analyses: undefined,
+            status: "archived",
+            archivedAt: Date.now(),
+            updatedAt: Date.now(),
+        };
+        const projected = await projectResumeDetailDoc(mockCtxWithColdRow(archivedRow), resume);
+
+        // Archived row is invisible — analysis fields absent from projection.
+        expect(projected.analysis).toBeUndefined();
+        expect(projected.analyses).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Integration-level stubs (need convex-test fixture setup)
+// ---------------------------------------------------------------------------
 
 describe("deleteResumes cleanup", () => {
     it.skip("hard-deletes resume_analyses rows for deleted resumes");
@@ -25,10 +97,4 @@ describe("clearAnalyses soft-clear", () => {
     it.skip("flips cold row to status:archived with archivedAt when clearing all analyses");
     it.skip("keeps cold row active when surgical (jobDescriptionId) clear leaves keys in analyses map");
     it.skip("flips cold row to archived when surgical clear empties the analyses map AND clears current analysis");
-});
-
-describe("projectResumeDetailDoc (async fetch)", () => {
-    it.skip("fetches analysis from resume_analyses via by_resume index (Phase 2)");
-    it.skip("returns undefined analysis when no resume_analyses row exists");
-    it.skip("filters out archived rows — only active rows reach the detail view");
 });

--- a/packages/convex/__tests__/resumes-list-projections.test.ts
+++ b/packages/convex/__tests__/resumes-list-projections.test.ts
@@ -100,11 +100,23 @@ describe("projectResumeListDoc", () => {
 // ---------------------------------------------------------------------------
 
 describe("projectResumeDetailDoc", () => {
-  it("projects detail content with work history", () => {
+  it("projects detail content with work history", async () => {
     const resume = makeResume({
       content: { name: "Alice", workHistory: [{ companyName: "Acme", jobTitle: "Engineer", raw: "Acme - Engineer (2020-2023)" }] },
     });
-    const projected = projectResumeDetailDoc(resume as any);
+    // Phase 3 completion: projectResumeDetailDoc is now async and fetches
+    // analysis from resume_analyses via by_resume index. Mock ctx.db.query
+    // chain to return no cold row (resume has no analysis in this fixture).
+    const mockCtx = {
+      db: {
+        query: () => ({
+          withIndex: () => ({
+            unique: async () => null,
+          }),
+        }),
+      },
+    } as any;
+    const projected = await projectResumeDetailDoc(mockCtx, resume as any);
 
     expect(projected.content).toBeDefined();
     expect(projected.externalId).toBe("ext-1");

--- a/packages/convex/convex/lib/resumes_list_projections.ts
+++ b/packages/convex/convex/lib/resumes_list_projections.ts
@@ -5,6 +5,7 @@
  * normalizing filter arguments, matching filter criteria, and sorting.
  */
 import type { Doc } from "../_generated/dataModel";
+import type { QueryCtx } from "../_generated/server";
 import {
     isRecord,
     normalizeResumeLocationHierarchy,
@@ -316,8 +317,11 @@ export function projectResumeListDoc(resume: Doc<"resumes">): ResumeListProjecte
     };
 }
 
-export function projectResumeDetailDoc(resume: Doc<"resumes">): ResumeListProjectedDoc {
-    return {
+export async function projectResumeDetailDoc(
+    ctx: QueryCtx,
+    resume: Doc<"resumes">,
+): Promise<ResumeListProjectedDoc> {
+    const base = {
         _id: resume._id,
         externalId: resume.externalId,
         ...(resume.identityKey ? { identityKey: resume.identityKey } : {}),
@@ -326,13 +330,30 @@ export function projectResumeDetailDoc(resume: Doc<"resumes">): ResumeListProjec
         crawledAt: resume.crawledAt,
         source: resume.source,
         tags: resume.tags,
-        ...(resume.analysis ? { analysis: resume.analysis } : {}),
-        ...(resume.analyses ? { analyses: resume.analyses } : {}),
         ...(resume.confirmedScore === undefined ? {} : { confirmedScore: resume.confirmedScore }),
         ...(resume.confirmedAt === undefined ? {} : { confirmedAt: resume.confirmedAt }),
         ...(resume.primaryRuleScore === undefined ? {} : { primaryRuleScore: resume.primaryRuleScore }),
         ...(resume.isArchived === true ? { isArchived: true, archivedAt: resume.archivedAt } : {}),
         ...(resume.ingestData ? { ingestData: projectResumeListIngestData(resume.ingestData) } : {}),
+    };
+
+    // Phase 3 completion: fetch analysis/analyses from the cold resume_analyses
+    // table via by_resume index. Only active rows are visible to the detail
+    // view — archived rows (flipped by clearAnalyses) are invisible but
+    // retained for audit/undo.
+    const coldRow = await ctx.db
+        .query("resume_analyses")
+        .withIndex("by_resume", (q) => q.eq("resumeId", resume._id))
+        .unique();
+
+    if (!coldRow || coldRow.status !== "active") {
+        return base;
+    }
+
+    return {
+        ...base,
+        ...(coldRow.analysis ? { analysis: coldRow.analysis } : {}),
+        ...(coldRow.analyses ? { analyses: coldRow.analyses } : {}),
     };
 }
 

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -638,7 +638,7 @@ export const getResumeDetail = query({
             return null;
         }
 
-        return projectResumeDetailDoc(resume);
+        return await projectResumeDetailDoc(ctx, resume);
     },
 });
 

--- a/packages/convex/convex/resumes_mutations.ts
+++ b/packages/convex/convex/resumes_mutations.ts
@@ -294,6 +294,15 @@ export const clearAnalyses = mutation({
             if (!resume) continue;
             if (!resume.analysis && !resume.analyses) continue;
 
+            // Phase 3 completion: after patching the hot doc, sync the cold
+            // resume_analyses row. Non-surgical clear → archive the row.
+            // Surgical (jobDescriptionId) clear → patch the map; archive only
+            // if the map is now empty AND current analysis is cleared.
+            const coldRow = await ctx.db
+                .query("resume_analyses")
+                .withIndex("by_resume", (q) => q.eq("resumeId", resume._id))
+                .unique();
+
             if (args.jobDescriptionId && resume.analyses) {
                 const analyses = { ...resume.analyses };
                 const matchingKeys = Object.keys(analyses).filter((key) =>
@@ -308,6 +317,26 @@ export const clearAnalyses = mutation({
                         analyses,
                         ...(isCurrentAnalysis ? { analysis: undefined } : {}),
                     });
+                    // Sync cold row: archive only if map is now empty AND no current analysis.
+                    if (coldRow) {
+                        const remainingKeys = Object.keys(analyses).length;
+                        const hasCurrent = isCurrentAnalysis ? false : resume.analysis !== undefined;
+                        if (remainingKeys === 0 && !hasCurrent) {
+                            await ctx.db.patch(coldRow._id, {
+                                status: "archived",
+                                archivedAt: Date.now(),
+                                analysis: undefined,
+                                analyses: {},
+                                updatedAt: Date.now(),
+                            });
+                        } else {
+                            await ctx.db.patch(coldRow._id, {
+                                analysis: isCurrentAnalysis ? undefined : coldRow.analysis,
+                                analyses,
+                                updatedAt: Date.now(),
+                            });
+                        }
+                    }
                     cleared += 1;
                 }
             } else {
@@ -315,6 +344,14 @@ export const clearAnalyses = mutation({
                     analysis: undefined,
                     analyses: undefined,
                 });
+                // Non-surgical clear: always archive the cold row.
+                if (coldRow) {
+                    await ctx.db.patch(coldRow._id, {
+                        status: "archived",
+                        archivedAt: Date.now(),
+                        updatedAt: Date.now(),
+                    });
+                }
                 cleared += 1;
             }
         }
@@ -457,6 +494,30 @@ export const deleteResumes = mutation({
         }
         for (const digestId of digestBatches) {
             await ctx.db.delete(digestId);
+        }
+
+        // Phase 3 completion: hard-delete resume_analyses rows for deleted
+        // resumes. Resume is gone — no audit value in orphan cold-table rows.
+        // Same batched by_resume lookup pattern as digest cleanup above.
+        const analysesBatches: Array<Id<"resume_analyses">> = [];
+        for (let i = 0; i < existingResumeIds.length; i += DIGEST_LOOKUP_BATCH) {
+            const batchIds = existingResumeIds.slice(i, i + DIGEST_LOOKUP_BATCH);
+            const analysesResults = await Promise.all(
+                batchIds.map((resumeId) =>
+                    ctx.db
+                        .query("resume_analyses")
+                        .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+                        .collect()
+                )
+            );
+            for (const batch of analysesResults) {
+                for (const row of batch) {
+                    analysesBatches.push(row._id);
+                }
+            }
+        }
+        for (const rowId of analysesBatches) {
+            await ctx.db.delete(rowId);
         }
 
         for (const resume of existingResumes) {
@@ -625,6 +686,20 @@ export const hardResetIngestData = mutation({
                 primaryRuleScore: undefined,
                 searchText: undefined,
             });
+            // Phase 3 completion: archive the cold resume_analyses row to
+            // keep it in sync with the cleared hot doc. Soft-clear preserves
+            // the analysis blob for audit/undo.
+            const coldRow = await ctx.db
+                .query("resume_analyses")
+                .withIndex("by_resume", (q) => q.eq("resumeId", resume._id))
+                .unique();
+            if (coldRow && coldRow.status === "active") {
+                await ctx.db.patch(coldRow._id, {
+                    status: "archived",
+                    archivedAt: Date.now(),
+                    updatedAt: Date.now(),
+                });
+            }
             await ctx.runMutation(internal.resumes_search.upsertResumeDigest, { resumeId: resume._id });
             cleared += 1;
         }


### PR DESCRIPTION
## Summary

Phase 2 + Phase 3 of the resume_analyses Phase 3 completion bundle. Follows PR #1272 (Phase 0+1, merged).

**Spec:** `~/wiki/projects/trends/work/2026-06-15-resume-analyses-phase3-completion-cleanup/spec.md`
**Plan:** `~/wiki/projects/trends/work/2026-06-15-resume-analyses-phase3-completion-cleanup/plan.md`

### Phase 2 — Read path migration

- `projectResumeDetailDoc` is now **async** — fetches `analysis`/`analyses` from `resume_analyses` via the `by_resume` index instead of reading from the hot doc
- Filters by `status: "active"` — archived rows are invisible to the detail view but retained for audit/undo
- Signature change: `(ctx: QueryCtx, resume: Doc<"resumes">) => Promise<ResumeListProjectedDoc>`. Single prod caller (`getResumeDetail` at `resumes.ts:641`) updated to await
- Plan Q1 decision applied: async over additive helper (avoids stale-field bugs from callers forgetting the enrich step)

### Phase 3 — Write path cleanup

- `clearAnalyses` (non-surgical): archives cold row (`status: "archived"` + `archivedAt`). Soft-clear preserves the analysis blob.
- `clearAnalyses` (surgical, with `jobDescriptionId`): patches the cold-row `analyses` map; archives only when the map is empty AND the current analysis is cleared (Plan Q3 conditional)
- `deleteResumes`: hard-deletes `resume_analyses` rows for deleted resumes (same batched `by_resume` pattern as `resume_digests` cleanup). Resume is gone — no audit value in orphan rows
- `hardResetIngestData`: archives cold rows for cleared resumes (soft-clear, consistent with `clearAnalyses`)

### What does NOT change

- **Phase 4 (deploy-risk)** is NOT in this PR: removing `analysis`/`analyses` from the hot `resumes` schema validator requires running `backfillResumeAnalysesFromResumes` on prod first. Will ship as a separate PR with explicit deploy-time sequencing.
- **Phase 5 (docs)** is NOT in this PR: `concepts/convex-digest-first-query-pattern.md` update + parent plan reconciliation will ship alongside or after Phase 4.

## Test plan

- [x] `npx tsc --noEmit -p packages/convex/tsconfig.json` — clean
- [x] 3 new `projectResumeDetailDoc` async tests un-skipped from Phase 0 stubs (fetch via `by_resume`, no-row case, archived-row filter)
- [x] `reingest-integration.test.ts` mock updated to support `resume_analyses` query chain
- [x] `make check` — all green
- [x] `npm test` — 5600 passed, 3 pre-existing failures (same baseline as PR #1272): `install-deploy-safety`, `resumes-export DEBUG columns`, `resumes-packets userComment`
- [ ] CI green on this PR

## Follow-up phases (separate PRs)

- **Phase 4**: remove `analysis`/`analyses` from hot `resumes` schema validator. **Deploy-risk** — `backfillResumeAnalysesFromResumes` must run on prod before schema push.
- **Phase 5**: update `concepts/convex-digest-first-query-pattern.md` + reconcile parent digest-first plan
- Un-skip remaining 14 Phase 0 stubs (need convex-test fixture setup for clearAnalyses/deleteResumes integration tests)

## Sources Used

- Spec: `projects/trends/work/2026-06-15-resume-analyses-phase3-completion-cleanup/spec.md`
- Plan: `projects/trends/work/2026-06-15-resume-analyses-phase3-completion-cleanup/plan.md`
- Prep reports: `projects/trends/requirements/2026-06-15-dev-loop-preflight-prep.md`, `2026-06-15-dev-loop-preflight-prep-focused-bundle.md`
- Code probes: `resumes_list_projections.ts:319-340`, `resumes.ts:633-643`, `resumes_mutations.ts:269-330, 395-474, 593-638`