### PR TITLE
fix: make resume_analyses.status optional (Convex schema validation crash)

### DIFF
--- a/packages/convex/__tests__/resume-analyses-cleanup-paths.test.ts
+++ b/packages/convex/__tests__/resume-analyses-cleanup-paths.test.ts
@@ -65,6 +65,25 @@ describe("projectResumeDetailDoc (async fetch)", () => {
         expect(projected.analyses).toBeUndefined();
     });
 
+    it("treats rows with undefined status as active (backwards-compat with pre-Phase-1 rows)", async () => {
+        // Pre-existing rows created by PR #1269 before the status field was added
+        // have status: undefined. They must be visible to the detail view.
+        const resume = makeResume();
+        const legacyRow = {
+            _id: "ra1" as any,
+            resumeId: resume._id,
+            analysis: { jobDescriptionId: "jd1", score: 90 } as any,
+            analyses: undefined,
+            status: undefined,
+            archivedAt: undefined,
+            updatedAt: Date.now(),
+        };
+        const projected = await projectResumeDetailDoc(mockCtxWithColdRow(legacyRow), resume);
+
+        expect(projected.analysis).toBeDefined();
+        expect((projected.analysis as any).score).toBe(90);
+    });
+
     it("filters out archived rows — only active rows reach the detail view", async () => {
         const resume = makeResume();
         const archivedRow = {

--- a/packages/convex/convex/lib/resumes_list_projections.ts
+++ b/packages/convex/convex/lib/resumes_list_projections.ts
@@ -346,7 +346,7 @@ export async function projectResumeDetailDoc(
         .withIndex("by_resume", (q) => q.eq("resumeId", resume._id))
         .unique();
 
-    if (!coldRow || coldRow.status !== "active") {
+    if (!coldRow || coldRow.status === "archived") {
         return base;
     }
 

--- a/packages/convex/convex/resumes_mutations.ts
+++ b/packages/convex/convex/resumes_mutations.ts
@@ -693,7 +693,7 @@ export const hardResetIngestData = mutation({
                 .query("resume_analyses")
                 .withIndex("by_resume", (q) => q.eq("resumeId", resume._id))
                 .unique();
-            if (coldRow && coldRow.status === "active") {
+            if (coldRow && coldRow.status !== "archived") {
                 await ctx.db.patch(coldRow._id, {
                     status: "archived",
                     archivedAt: Date.now(),

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -528,7 +528,7 @@ export default defineSchema({
         resumeId: v.id("resumes"),
         analysis: v.optional(resumeAnalysisValidator),
         analyses: v.optional(v.record(v.string(), analysisResultValidator)),
-        status: v.union(v.literal("active"), v.literal("archived")),
+        status: v.optional(v.union(v.literal("active"), v.literal("archived"))),
         archivedAt: v.optional(v.number()),
         updatedAt: v.number(),
     })


### PR DESCRIPTION
## Summary

**Critical fix** — PR #1272 made `resume_analyses.status` a required field, but existing rows created by PR #1269 don't have it. Convex dev backend crashes on schema validation:

```
[CONVEX] ✖ Schema validation failed.
Document "mx72ka3kg14f6h07dqvnyg1wgn88qqh3" in table "resume_analyses"
does not match the schema: Object is missing the required field `status`.
```

### Fix

- `schema.ts`: `status: v.optional(v.union(v.literal("active"), v.literal("archived")))` — backwards-compatible
- `projectResumeDetailDoc`: `coldRow.status === "archived"` (was `!== "active"`) — undefined defaults to visible
- `hardResetIngestData`: `coldRow.status !== "archived"` (was `=== "active"`) — undefined defaults to archivable
- `doUpsertResumeAnalysis`: unchanged — still sets `status: "active"` explicitly on every write
- New test: pre-existing rows with `status: undefined` are visible to the detail view

The `backfillResumeAnalysesStatus` migration remains useful for explicitness but is no longer deploy-blocking.

## Test plan

- [x] `npx tsc --noEmit -p packages/convex/tsconfig.json` — clean
- [x] 38 tests passed (including new backwards-compat test), 17 skipped
- [x] `make check` — all green
- [ ] CI green on this PR
- [ ] Convex dev backend starts without schema validation errors

## Sources Used

- Convex error log: `Document "mx72ka3kg14f6h07dqvnyg1wgn88qqh3" missing required field "status"`
- Convex docs recommendation: "Consider wrapping the field validator in `v.optional(...)`"
- PR #1272 (Phase 1 — introduced the required field)
- PR #1269 (Phase 3 write side — created rows without the field)