### PR TITLE
test: fix 3 pre-existing baseline test failures (1A/1B/1C)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ dev-convex:
 dev-convex-stop:
 	@project_root="$(CURDIR)"; \
 	convex_port="$${CONVEX_PORT:-3210}"; \
-	site_port="3211"; \
+	site_port="$${CONVEX_SITE_PORT:-3211}"; \
 	tmux_session="$${CONVEX_TMUX_SESSION:-trends-convex}"; \
 	pids="$$( { \
 		lsof -tiTCP:"$$convex_port" -sTCP:LISTEN 2>/dev/null; \
@@ -188,7 +188,7 @@ dev-convex-ensure:
 # Show local Convex listener/process/data status
 dev-convex-status:
 	@convex_port="$${CONVEX_PORT:-3210}"; \
-	site_port="3211"; \
+	site_port="$${CONVEX_SITE_PORT:-3211}"; \
 	state_dir="$${CONVEX_STATE_DIR:-$$HOME/.convex/anonymous-convex-backend-state/anonymous-agent}"; \
 	echo "Local Convex listeners:"; \
 	ss -ltnp "( sport = :$$convex_port or sport = :$$site_port )" || true; \

--- a/apps/api/src/routes/__tests__/resumes-packets-route.test.ts
+++ b/apps/api/src/routes/__tests__/resumes-packets-route.test.ts
@@ -487,7 +487,14 @@ describe("resumes packets route", () => {
 
   it("exports via form-encoded payload (legacy download endpoint)", async () => {
     root = createFixtureRoot();
-    const { createApp, ResumeService } = await loadModules(root);
+    const { createApp, ResumeService, workspaceConfigService } = await loadModules(root);
+
+    // The legacy download endpoint shares buildResumeExportResponse with the
+    // JSON export route, so it resolves the workspace export-fields config.
+    // Mock it to no stored entry (default core column set, which includes
+    // userComment) so the test is deterministic instead of depending on a
+    // seeded local Convex backend.
+    vi.spyOn(workspaceConfigService, "getExportFieldsConfig").mockResolvedValue(null);
 
     vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
       items: [

--- a/apps/api/src/routes/resumes-export.test.ts
+++ b/apps/api/src/routes/resumes-export.test.ts
@@ -82,6 +82,27 @@ function mockWorkspaceExportFieldsConfig(fields: string[], includeDebugWhenEnabl
   });
 }
 
+/**
+ * Mocks the workspace export-fields config fetch to return no stored entry.
+ * With no workspace config, the export service falls back to the default
+ * column set (core fields, plus debug fields when DEBUG is active) — this
+ * keeps the test deterministic instead of hitting a real local Convex backend
+ * that may carry a seeded "dev" workspace config.
+ */
+function mockNoWorkspaceExportFieldsConfig(): void {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const call = parseConvexCall(input, init);
+    expect(call).toMatchObject({
+      pathName: "workspace_config:get",
+      args: {
+        workspaceSlug: "dev",
+        configKey: "export-fields",
+      },
+    });
+    return convexSuccess(null);
+  });
+}
+
 function buildSampleResume(overrides: Partial<ResumeItem> & { resumeId: string; name: string }): ResumeItem {
   return {
     resumeId: overrides.resumeId,
@@ -532,6 +553,7 @@ describe("resume export route", () => {
     const originalDebug = process.env.DEBUG;
     process.env.DEBUG = "true";
     try {
+      mockNoWorkspaceExportFieldsConfig();
       vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
         items: [
           buildSampleResume({

--- a/scripts/install-deploy-safety.test.ts
+++ b/scripts/install-deploy-safety.test.ts
@@ -197,7 +197,13 @@ describe("non-Docker Convex startup safety", () => {
         encoding: "utf8",
         env: {
           ...process.env,
+          // Randomize BOTH ports so the test reaches the "no local Convex
+          // processes found" branch deterministically regardless of whether a
+          // real dev stack is listening on the default 3210/3211 ports on this
+          // host. Distinct ranges avoid the two randoms colliding with each
+          // other; both sit well clear of the default ports.
           CONVEX_PORT: String(39000 + Math.floor(Math.random() * 10000)),
+          CONVEX_SITE_PORT: String(49000 + Math.floor(Math.random() * 10000)),
           CONVEX_STATE_DIR: tempDir,
         },
       });


### PR DESCRIPTION
## Summary

Fixes the 3 pre-existing test failures that polluted every \`npm test\ run. All three shared a common root cause: **tests that depend on host/Convex state instead of being deterministic**.

### 1A — \`scripts/install-deploy-safety.test.ts\`
\`dev-convex-status\` test randomized \`CONVEX_PORT\` but \`site_port\` was hardcoded to \`3211\` inside the recipe. On hosts where the real dev stack listens on \`3210/3211\` (the site proxy), \`lsof -tiTCP:3211\` matched the live backend, so the test never reached the "no local Convex processes found" branch.

**Fix:** Make \`site_port\` overridable via \`CONVEX_SITE_PORT\` (default \`3211\`, consistent with \`convex_port\` already being overridable) in \`dev-convex-status\` and \`dev-convex-stop\`; the test now sets both ports to randomized high ports.

### 1B — \`apps/api/src/routes/resumes-export.test.ts\`
The "DEBUG columns" test mocked \`loadSample\` but not the workspace export-fields config fetch. Since the route always resolves the \`dev\` workspace config, the unmocked fetch hit the real local Convex backend and picked up its seeded \`dev\` config (\`resumeId\`+\`name\` only) — so debug columns never appeared. Regression from the export-fields settings UI work.

**Fix:** Add \`mockNoWorkspaceExportFieldsConfig()\` (returns no stored entry → null config → default core+debug column path) and use it here.

### 1C — \`apps/api/src/routes/__tests__/resumes-packets-route.test.ts\`
The legacy download endpoint test set \`X-Workspace-Slug: dev\` but never mocked the workspace config. It shares \`buildResumeExportResponse\` with the JSON route, so it resolved the \`dev\` config from real local Convex (\`resumeId\`+\`name\`), dropping \`userComment\`.

**Fix:** Spy on \`workspaceConfigService.getExportFieldsConfig\` → \`null\` (default core column set includes \`userComment\`).

## Test plan
- [x] \`npx vitest run scripts/install-deploy-safety.test.ts\` — 36/36 pass
- [x] \`npx vitest run apps/api/src/routes/resumes-export.test.ts\` — 6/6 pass
- [x] \`npx vitest run apps/api/src/routes/__tests__/resumes-packets-route.test.ts\` — 15/15 pass
- [x] \`make check\` green (governance + typecheck + lint)