### PR TITLE
test: un-skip resume_analyses bundle stubs with real convex-test coverage

### DIFF
--- a/packages/convex/__tests__/resume-analyses-cleanup-paths.test.ts
+++ b/packages/convex/__tests__/resume-analyses-cleanup-paths.test.ts
@@ -1,16 +1,18 @@
 /**
  * Phase 2+3 tests for resume_analyses cleanup paths.
  *
- * projectResumeDetailDoc tests are unit-level (mocked ctx) — un-skipped
- * in this file. clearAnalyses/deleteResumes tests are integration-level
- * (convex-test) — stubs remain, to be un-skipped when fixture setup is
- * streamlined.
+ * projectResumeDetailDoc tests are unit-level (mocked ctx).
+ * deleteResumes / hardResetIngestData / clearAnalyses tests are
+ * integration-level (convex-test).
  *
  * See: projects/trends/work/2026-06-15-resume-analyses-phase3-completion-cleanup/plan.md
  */
 import { describe, expect, it } from "vitest";
 import { projectResumeDetailDoc } from "../convex/lib/resumes_list_projections.js";
 import type { Doc } from "../convex/_generated/dataModel.js";
+import { createTest, seedResume } from "./test-helpers.js";
+import { api, internal } from "../convex/_generated/api.js";
+import { doUpsertResumeAnalysis } from "../convex/resumes_search.js";
 
 // Helper: mock ctx.db.query chain for resume_analyses lookup.
 function mockCtxWithColdRow(coldRow: Record<string, unknown> | null) {
@@ -104,16 +106,190 @@ describe("projectResumeDetailDoc (async fetch)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Integration-level stubs (need convex-test fixture setup)
+// Integration-level tests (convex-test)
 // ---------------------------------------------------------------------------
 
 describe("deleteResumes cleanup", () => {
-    it.skip("hard-deletes resume_analyses rows for deleted resumes");
-    it.skip("hard-deletes resume_analyses rows in hardResetIngestData");
+    it("hard-deletes resume_analyses rows for deleted resumes", async () => {
+        const t = createTest();
+        const resumeId = await seedResume(t);
+
+        // Give it analysis data + a cold row.
+        await t.mutation(internal.resumes.updateAnalysis, {
+            resumeId,
+            analysis: {
+                score: 70,
+                summary: "to be deleted",
+                highlights: [],
+                recommendation: "proceed",
+            },
+        });
+        await t.run(async (ctx) => {
+            const resume = await ctx.db.get(resumeId);
+            await doUpsertResumeAnalysis(ctx, resume!);
+        });
+
+        // Confirm cold row exists before delete.
+        let row = await t.run(async (ctx) =>
+            ctx.db
+                .query("resume_analyses")
+                .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+                .unique(),
+        );
+        expect(row).not.toBeNull();
+
+        await t.mutation(api.resumes.deleteResumes, { resumeIds: [String(resumeId)] });
+
+        // Cold row + resume are both gone.
+        row = await t.run(async (ctx) =>
+            ctx.db
+                .query("resume_analyses")
+                .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+                .unique(),
+        );
+        expect(row).toBeNull();
+
+        const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
+        expect(resume).toBeNull();
+    });
+
+    it("archives the cold resume_analyses row when resetting ingest data (soft-clear for audit)", async () => {
+        const t = createTest();
+        const resumeId = await seedResume(t, {
+            analysis: {
+                score: 80,
+                summary: "reset-ingest",
+                highlights: [],
+                recommendation: "proceed",
+            },
+            searchText: "stale search text",
+        });
+
+        await t.run(async (ctx) => {
+            const resume = await ctx.db.get(resumeId);
+            await doUpsertResumeAnalysis(ctx, resume!);
+        });
+
+        await t.mutation(api.resumes.hardResetIngestData, {});
+
+        const rows = await t.run(async (ctx) =>
+            ctx.db
+                .query("resume_analyses")
+                .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+                .collect(),
+        );
+        // Row still exists (NOT hard-deleted) but is now archived.
+        expect(rows).toHaveLength(1);
+        expect(rows[0].status).toBe("archived");
+        expect(rows[0].archivedAt).toBeDefined();
+    });
 });
 
 describe("clearAnalyses soft-clear", () => {
-    it.skip("flips cold row to status:archived with archivedAt when clearing all analyses");
-    it.skip("keeps cold row active when surgical (jobDescriptionId) clear leaves keys in analyses map");
-    it.skip("flips cold row to archived when surgical clear empties the analyses map AND clears current analysis");
+    it("flips cold row to status:archived with archivedAt when clearing all analyses", async () => {
+        const t = createTest();
+        const resumeId = await seedResume(t, {
+            analysis: {
+                score: 85,
+                summary: "clear-all",
+                highlights: [],
+                recommendation: "proceed",
+            },
+            analyses: { "jd:1": { score: 85 } },
+        });
+
+        await t.run(async (ctx) => {
+            const resume = await ctx.db.get(resumeId);
+            await doUpsertResumeAnalysis(ctx, resume!);
+        });
+
+        // Non-surgical clear (no jobDescriptionId) → archive.
+        await t.mutation(api.resumes.clearAnalyses, { resumeIds: [resumeId] });
+
+        const row = await t.run(async (ctx) =>
+            ctx.db
+                .query("resume_analyses")
+                .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+                .unique(),
+        );
+        expect(row!.status).toBe("archived");
+        expect(row!.archivedAt).toBeDefined();
+    });
+
+    it("keeps cold row active when surgical (jobDescriptionId) clear leaves keys in analyses map", async () => {
+        const t = createTest();
+        const resumeId = await seedResume(t);
+
+        // Two distinct JD keys; current analysis for a JD that is NOT cleared.
+        await t.run(async (ctx) => {
+            await ctx.db.patch(resumeId, {
+                analysis: {
+                    score: 80,
+                    summary: "surgical-keep",
+                    highlights: [],
+                    recommendation: "proceed",
+                    jobDescriptionId: "jd-keep",
+                },
+                analyses: { "jd-clear": { score: 70 }, "jd-keep": { score: 80 } },
+            });
+        });
+        await t.run(async (ctx) => {
+            const resume = await ctx.db.get(resumeId);
+            await doUpsertResumeAnalysis(ctx, resume!);
+        });
+
+        // Surgical clear of one JD — the other remains.
+        await t.mutation(api.resumes.clearAnalyses, {
+            resumeIds: [resumeId],
+            jobDescriptionId: "jd-clear",
+        });
+
+        const row = await t.run(async (ctx) =>
+            ctx.db
+                .query("resume_analyses")
+                .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+                .unique(),
+        );
+        expect(row!.status).toBe("active");
+        expect(row!.analyses).toHaveProperty("jd-keep");
+        expect(row!.analyses).not.toHaveProperty("jd-clear");
+    });
+
+    it("flips cold row to archived when surgical clear empties the analyses map AND clears current analysis", async () => {
+        const t = createTest();
+        const resumeId = await seedResume(t);
+
+        // Exactly one key that matches the cleared JD; current analysis for same JD.
+        await t.run(async (ctx) => {
+            await ctx.db.patch(resumeId, {
+                analysis: {
+                    score: 80,
+                    summary: "surgical-empty",
+                    highlights: [],
+                    recommendation: "proceed",
+                    jobDescriptionId: "jd-only",
+                },
+                analyses: { "jd-only": { score: 80 } },
+            });
+        });
+        await t.run(async (ctx) => {
+            const resume = await ctx.db.get(resumeId);
+            await doUpsertResumeAnalysis(ctx, resume!);
+        });
+
+        // Surgical clear empties the map AND clears current analysis → archive.
+        await t.mutation(api.resumes.clearAnalyses, {
+            resumeIds: [resumeId],
+            jobDescriptionId: "jd-only",
+        });
+
+        const row = await t.run(async (ctx) =>
+            ctx.db
+                .query("resume_analyses")
+                .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+                .unique(),
+        );
+        expect(row!.status).toBe("archived");
+        expect(row!.archivedAt).toBeDefined();
+    });
 });

--- a/packages/convex/__tests__/resume-analyses-upsert-helpers.test.ts
+++ b/packages/convex/__tests__/resume-analyses-upsert-helpers.test.ts
@@ -1,34 +1,399 @@
 /**
- * Phase 0 scaffolding for resume_analyses upsert helper coverage.
+ * Convex-test coverage for resume_analyses upsert helpers.
  *
- * Stubs `it.skip()` placeholder tests for:
- * - doUpsertResumeDigest (6 production call sites)
- * - doUpsertResumeAnalysis (5 production call sites)
+ * Integration tests (convex-test) for:
+ * - doUpsertResumeDigest (resume_digests hot-table sync)
+ * - doUpsertResumeAnalysis (resume_analyses cold-table sync)
  *
- * Tests will be un-skipped incrementally as Phases 1-3 of the
- * resume-analyses-phase3-completion-cleanup bundle land. See:
- *   projects/trends/work/2026-06-15-resume-analyses-phase3-completion-cleanup/plan.md
- *
- * TDD discipline: RED phase establishes the test skeleton before any
- * production code changes. Skipped tests are intentional — they document
- * the coverage matrix the bundle will fill in.
+ * See: projects/trends/work/2026-06-15-resume-analyses-phase3-completion-cleanup/plan.md
  */
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { createTest, seedResume } from "./test-helpers.js";
+import { internal } from "../convex/_generated/api.js";
+import { doUpsertResumeDigest, doUpsertResumeAnalysis } from "../convex/resumes_search.js";
 
 describe("doUpsertResumeDigest", () => {
-    it.skip("inserts a new row with all fields populated");
-    it.skip("patches an existing row in place");
-    it.skip("is idempotent on re-upsert (same input → same end state)");
-    it.skip("populates digest fields from a representative resume fixture");
-    it.skip("throws or no-ops on invalid resumeId");
-    it.skip("maintains parity with resume_digests schema after upsert");
+    it("inserts a new row with all fields populated", async () => {
+        const t = createTest();
+        // Insert a resume directly — do NOT use seedResume (which pre-inserts a digest).
+        const resumeId = await t.run(async (ctx) =>
+            ctx.db.insert("resumes", {
+                externalId: "digest-insert-1",
+                identityKey: "profileUrl:example.com/candidates/d1",
+                content: { name: "Digest Candidate" },
+                hash: "hash-d1",
+                source: "example.com",
+                sourceKey: "test",
+                tags: ["test"],
+                crawledAt: Date.now(),
+            })
+        );
+
+        await t.run(async (ctx) => {
+            const resume = await ctx.db.get(resumeId);
+            await doUpsertResumeDigest(ctx, resume!);
+        });
+
+        const row = await t.run(async (ctx) =>
+            ctx.db
+                .query("resume_digests")
+                .withIndex("by_resumeId", (q) => q.eq("resumeId", resumeId))
+                .first(),
+        );
+        expect(row).not.toBeNull();
+        expect(row!.resumeId).toBe(resumeId);
+        expect(row!.source).toBe("example.com");
+        expect(row!.externalId).toBe("digest-insert-1");
+        expect(row!.updatedAt).toBeTypeOf("number");
+    });
+
+    it("patches an existing row in place", async () => {
+        const t = createTest();
+        // seedResume pre-inserts a digest row.
+        const resumeId = await seedResume(t);
+        const beforeId = await t.run(async (ctx) => {
+            const row = await ctx.db
+                .query("resume_digests")
+                .withIndex("by_resumeId", (q) => q.eq("resumeId", resumeId))
+                .first();
+            return row?._id;
+        });
+
+        // Change the resume, then re-upsert the digest.
+        await t.run(async (ctx) => {
+            await ctx.db.patch(resumeId, { primaryRuleScore: 99 });
+        });
+        await t.run(async (ctx) => {
+            const resume = await ctx.db.get(resumeId);
+            await doUpsertResumeDigest(ctx, resume!);
+        });
+
+        const rows = await t.run(async (ctx) =>
+            ctx.db
+                .query("resume_digests")
+                .withIndex("by_resumeId", (q) => q.eq("resumeId", resumeId))
+                .collect(),
+        );
+        expect(rows).toHaveLength(1);
+        expect(rows[0]._id).toBe(beforeId);
+        expect(rows[0].primaryRuleScore).toBe(99);
+    });
+
+    it("is idempotent on re-upsert (same input → same end state)", async () => {
+        const t = createTest();
+        const resumeId = await seedResume(t);
+
+        await t.run(async (ctx) => {
+            const resume = await ctx.db.get(resumeId);
+            await doUpsertResumeDigest(ctx, resume!);
+            await doUpsertResumeDigest(ctx, resume!);
+        });
+
+        const rows = await t.run(async (ctx) =>
+            ctx.db
+                .query("resume_digests")
+                .withIndex("by_resumeId", (q) => q.eq("resumeId", resumeId))
+                .collect(),
+        );
+        expect(rows).toHaveLength(1);
+    });
+
+    it("populates digest fields from a representative resume fixture", async () => {
+        const t = createTest();
+        const resumeId = await seedResume(t, {
+            externalId: "digest-fixture-1",
+            identityKey: "profileUrl:example.com/candidates/df1",
+            analysis: {
+                score: 88,
+                summary: "Great candidate",
+                highlights: [],
+                recommendation: "proceed",
+                breakdown: { fit: 90 },
+            },
+            primaryRuleScore: 77,
+        });
+
+        const row = await t.run(async (ctx) =>
+            ctx.db
+                .query("resume_digests")
+                .withIndex("by_resumeId", (q) => q.eq("resumeId", resumeId))
+                .first(),
+        );
+        expect(row).not.toBeNull();
+        // displayScore is derived from analysis.score.
+        expect(row!.displayScore).toBe(88);
+        expect(row!.displayRecommendation).toBe("proceed");
+        expect(row!.displayBreakdown).toEqual({ fit: 90 });
+        expect(row!.primaryRuleScore).toBe(77);
+    });
+
+    it("no-ops on a deleted resumeId (internal mutation guard)", async () => {
+        const t = createTest();
+        const doomedId = await seedResume(t, { externalId: "digest-doomed" });
+        await t.run(async (ctx) => {
+            await ctx.db.delete(doomedId);
+        });
+
+        // Guard: if (!resume) return; — resolves without throwing (void → null).
+        await expect(
+            t.mutation(internal.resumes_search.upsertResumeDigest, { resumeId: doomedId }),
+        ).resolves.toBeNull();
+    });
+
+    it("maintains parity with resume_digests schema after upsert", async () => {
+        const t = createTest();
+        // Insert a resume without a digest, then upsert.
+        const resumeId = await t.run(async (ctx) =>
+            ctx.db.insert("resumes", {
+                externalId: "schema-parity-1",
+                identityKey: "profileUrl:example.com/candidates/sp1",
+                content: { name: "Schema Parity" },
+                hash: "hash-sp1",
+                source: "example.com",
+                sourceKey: "test",
+                tags: ["test"],
+                crawledAt: Date.now(),
+            })
+        );
+        await t.run(async (ctx) => {
+            const resume = await ctx.db.get(resumeId);
+            await doUpsertResumeDigest(ctx, resume!);
+        });
+
+        const row = await t.run(async (ctx) =>
+            ctx.db
+                .query("resume_digests")
+                .withIndex("by_resumeId", (q) => q.eq("resumeId", resumeId))
+                .first(),
+        );
+        expect(row).not.toBeNull();
+        expect(row!.resumeId).toBe(resumeId);
+        expect(row!.updatedAt).toBeTypeOf("number");
+        expect(row).toHaveProperty("source");
+        expect(row).toHaveProperty("crawledAt");
+    });
 });
 
 describe("doUpsertResumeAnalysis", () => {
-    it.skip("inserts a new row with analysis blob");
-    it.skip("patches an existing row in place");
-    it.skip("is idempotent on re-upsert");
-    it.skip("populates analysis/analyses from a representative resume fixture");
-    it.skip("resets status to active and clears archivedAt on every upsert (Phase 3)");
-    it.skip("preserves analysis/analyses parity with hot doc (until Phase 4 removes hot fields)");
+    it("inserts a new row with analysis blob", async () => {
+        const t = createTest();
+        const resumeId = await seedResume(t);
+        await t.mutation(internal.resumes.updateAnalysis, {
+            resumeId,
+            analysis: {
+                score: 85,
+                summary: "Strong candidate",
+                highlights: ["expertise"],
+                recommendation: "proceed",
+            },
+        });
+
+        await t.run(async (ctx) => {
+            const resume = await ctx.db.get(resumeId);
+            await doUpsertResumeAnalysis(ctx, resume!);
+        });
+
+        const row = await t.run(async (ctx) =>
+            ctx.db
+                .query("resume_analyses")
+                .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+                .unique(),
+        );
+        expect(row).not.toBeNull();
+        expect(row!.analysis).toBeDefined();
+        expect(row!.analysis!.score).toBe(85);
+        expect(row!.status).toBe("active");
+        expect(row!.updatedAt).toBeTypeOf("number");
+    });
+
+    it("patches an existing row in place", async () => {
+        const t = createTest();
+        const resumeId = await seedResume(t);
+        // Set analysis directly on the hot doc — bypass updateAnalysis, which
+        // would auto-upsert the cold row and defeat the "patches existing" check.
+        await t.run(async (ctx) => {
+            await ctx.db.patch(resumeId, {
+                analysis: {
+                    score: 70,
+                    summary: "ok",
+                    highlights: [],
+                    recommendation: "skip",
+                },
+                analyses: { "jd:1": { score: 70 } },
+            });
+        });
+
+        // Pre-insert an archived cold row.
+        const preId = await t.run(async (ctx) =>
+            ctx.db.insert("resume_analyses", {
+                resumeId,
+                analysis: undefined,
+                analyses: {},
+                status: "archived",
+                archivedAt: Date.now(),
+                updatedAt: Date.now(),
+            })
+        );
+
+        await t.run(async (ctx) => {
+            const resume = await ctx.db.get(resumeId);
+            await doUpsertResumeAnalysis(ctx, resume!);
+        });
+
+        const rows = await t.run(async (ctx) =>
+            ctx.db
+                .query("resume_analyses")
+                .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+                .collect(),
+        );
+        expect(rows).toHaveLength(1);
+        expect(rows[0]._id).toBe(preId);
+        expect(rows[0].status).toBe("active");
+        expect(rows[0].archivedAt).toBeUndefined();
+    });
+
+    it("is idempotent on re-upsert", async () => {
+        const t = createTest();
+        const resumeId = await seedResume(t);
+        await t.mutation(internal.resumes.updateAnalysis, {
+            resumeId,
+            analysis: {
+                score: 60,
+                summary: "idempotent",
+                highlights: [],
+                recommendation: "proceed",
+            },
+        });
+
+        await t.run(async (ctx) => {
+            const resume = await ctx.db.get(resumeId);
+            await doUpsertResumeAnalysis(ctx, resume!);
+            await doUpsertResumeAnalysis(ctx, resume!);
+        });
+
+        const rows = await t.run(async (ctx) =>
+            ctx.db
+                .query("resume_analyses")
+                .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+                .collect(),
+        );
+        expect(rows).toHaveLength(1);
+        expect(rows[0].status).toBe("active");
+    });
+
+    it("populates analysis/analyses from a representative resume fixture", async () => {
+        const t = createTest();
+        const resumeId = await seedResume(t);
+        await t.mutation(internal.resumes.updateAnalysis, {
+            resumeId,
+            analysis: {
+                score: 92,
+                summary: "Fixture",
+                highlights: ["a", "b"],
+                recommendation: "proceed",
+                jobDescriptionId: "jd-fixture",
+            },
+        });
+
+        await t.run(async (ctx) => {
+            const resume = await ctx.db.get(resumeId);
+            await doUpsertResumeAnalysis(ctx, resume!);
+        });
+
+        const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
+        const row = await t.run(async (ctx) =>
+            ctx.db
+                .query("resume_analyses")
+                .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+                .unique(),
+        );
+        expect(row!.analysis).toEqual(resume!.analysis);
+        expect(row!.analyses).toEqual(resume!.analyses);
+    });
+
+    it("resets status to active and clears archivedAt on every upsert (Phase 3)", async () => {
+        const t = createTest();
+        const resumeId = await seedResume(t);
+        await t.mutation(internal.resumes.updateAnalysis, {
+            resumeId,
+            analysis: {
+                score: 80,
+                summary: "reset",
+                highlights: [],
+                recommendation: "proceed",
+            },
+        });
+
+        // First upsert creates the row (active).
+        await t.run(async (ctx) => {
+            const resume = await ctx.db.get(resumeId);
+            await doUpsertResumeAnalysis(ctx, resume!);
+        });
+
+        // Archive it (simulating a prior clearAnalyses soft-clear).
+        await t.run(async (ctx) => {
+            const row = await ctx.db
+                .query("resume_analyses")
+                .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+                .unique();
+            await ctx.db.patch(row!._id, { status: "archived", archivedAt: Date.now() });
+        });
+
+        // Re-upsert resets to active.
+        await t.run(async (ctx) => {
+            const resume = await ctx.db.get(resumeId);
+            await doUpsertResumeAnalysis(ctx, resume!);
+        });
+
+        const row = await t.run(async (ctx) =>
+            ctx.db
+                .query("resume_analyses")
+                .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+                .unique(),
+        );
+        expect(row!.status).toBe("active");
+        expect(row!.archivedAt).toBeUndefined();
+    });
+
+    it("preserves analysis/analyses parity with hot doc (until Phase 4 removes hot fields)", async () => {
+        const t = createTest();
+        const resumeId = await seedResume(t);
+        const analysis = {
+            score: 75,
+            summary: "parity",
+            highlights: ["z"],
+            recommendation: "proceed",
+            breakdown: { a: 1 },
+        };
+        const analyses = { "jd:1": { score: 75 }, "jd:2": { score: 80 } };
+
+        await t.run(async (ctx) => {
+            await ctx.db.patch(resumeId, { analysis, analyses });
+        });
+        await t.run(async (ctx) => {
+            const resume = await ctx.db.get(resumeId);
+            await doUpsertResumeAnalysis(ctx, resume!);
+        });
+
+        const row = await t.run(async (ctx) =>
+            ctx.db
+                .query("resume_analyses")
+                .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+                .unique(),
+        );
+        expect(row!.analysis).toEqual(analysis);
+        expect(row!.analyses).toEqual(analyses);
+    });
+
+    it("no-ops on a deleted resumeId (internal mutation guard)", async () => {
+        const t = createTest();
+        const doomedId = await seedResume(t, { externalId: "analysis-doomed" });
+        await t.run(async (ctx) => {
+            await ctx.db.delete(doomedId);
+        });
+
+        await expect(
+            t.mutation(internal.resumes_search.upsertResumeAnalysis, { resumeId: doomedId }),
+        ).resolves.toBeNull();
+    });
 });


### PR DESCRIPTION
## Summary

Replaces the 18 `it.skip` Phase-0 scaffolding stubs in the resume_analyses completion bundle with real convex-test integration coverage. These stubs documented the coverage matrix while Phases 1-3 landed; Phase 3 shipped (PRs #1272/#1273/#1276), so the coverage now exists to test against.

### 2A — \`packages/convex/__tests__/resume-analyses-upsert-helpers.test.ts\` (13 tests)
Real convex-test coverage for \`doUpsertResumeDigest\` (6) and \`doUpsertResumeAnalysis\` (7): insert/patch/idempotency, digest display-field population, schema parity, and the Phase-3 status-reset-to-active semantics (archived → active on re-upsert). Invalid-resumeId cases go through the internal mutation guards.

### 2B — \`packages/convex/__tests__/resume-analyses-cleanup-paths.test.ts\` (5 new tests)
\`deleteResumes\` hard-deletes cold rows; \`clearAnalyses\` soft-clear (non-surgical → archive; surgical → keep active while keys remain, archive when emptied). Existing \`projectResumeDetailDoc\` tests left intact.

## Stub-behavior contradiction found & resolved
The Phase-0 stub titled \"hard-deletes resume_analyses rows in \`hardResetIngestData\`\" was **wrong** — the shipped implementation (\`resumes_mutations.ts:689-702\`) **archives** the cold row (\`status:"archived"\`, \`archivedAt:now\`), preserving the blob for audit/undo. The test asserts the actual archive behavior and the title was corrected: *\"archives the cold resume_analyses row when resetting ingest data (soft-clear for audit)\"*.

## Test plan
- [x] \`npx vitest run\` on both files — **22 passed, 0 skipped, 0 failed**
- [x] Full \`npm test\` — no new failures (only the 3 Target-1 baseline failures, now fixed on main via #1277)
- [x] \`make check\` green