### PR TITLE
test: remove misleading minExperience phantom-filter assertions (Q3)

### DIFF
--- a/apps/api/src/routes/__tests__/bff-filter-alignment.test.ts
+++ b/apps/api/src/routes/__tests__/bff-filter-alignment.test.ts
@@ -31,11 +31,9 @@ describe("bffMatchesResumeFilters", () => {
   });
 
   describe("experience filter — graceful degradation", () => {
-    it("resumes with empty experience pass minExperience filter", () => {
-      const doc = makeDoc({ content: { experience: "" } });
-      expect(bffMatchesResumeFilters(doc, "", { minExperience: 1 })).toBe(true);
-    });
-
+    // NOTE: only `maxExperience` is a supported resume-list filter. `minExperience`
+    // is a JD/search-profile/rule-scoring concept and intentionally NOT enforced
+    // here (not present on BffResumeFilters / ResumeListFilterArgs / ResumeFilters).
     it("resumes with unknown experience are excluded by maxExperience", () => {
       const doc = makeDoc({ content: { experience: "" } });
       expect(bffMatchesResumeFilters(doc, "", { maxExperience: 5 })).toBe(false);

--- a/apps/api/src/services/__tests__/bff-filter-utils.test.ts
+++ b/apps/api/src/services/__tests__/bff-filter-utils.test.ts
@@ -138,10 +138,6 @@ describe("bff-filter-utils", () => {
       it("excludes doc with unknown experience when maxExperience is set", () => {
         expect(bffMatchesResumeFilters(docNoExp, loweredSearchText, { maxExperience: 5 })).toBe(false);
       });
-
-      it("includes doc with unknown experience when only minExperience is set", () => {
-        expect(bffMatchesResumeFilters(docNoExp, loweredSearchText, { minExperience: 3 })).toBe(true);
-      });
     });
 
     describe("education filter", () => {

--- a/apps/api/src/services/resume-service.test.ts
+++ b/apps/api/src/services/resume-service.test.ts
@@ -461,31 +461,8 @@ describe("ResumeService", () => {
   });
 
   describe("experience filter graceful degradation", () => {
-    it("resumes with empty experience pass minExperience filter", () => {
-      const root = createFixtureRoot();
-      roots.push(root);
-      const service = new ResumeService(root);
-      const items = [
-        {
-          name: "Seek MY",
-          profileUrl: "https://example.com/seek-my",
-          activityStatus: "Active",
-          age: "",
-          experience: "",
-          education: "",
-          location: "Malaysia",
-          selfIntro: "",
-          jobIntention: "Sales",
-          expectedSalary: "",
-          workHistory: [],
-          extractedAt: "2026-03-20T00:00:00.000Z",
-        },
-      ];
-
-      const filtered = service.filterResumes(items, { minExperience: 1 });
-      expect(filtered).toHaveLength(1);
-    });
-
+    // NOTE: only `maxExperience` is a supported resume-list filter; `minExperience`
+    // is a JD/search-profile concept, not enforced by ResumeService.filterResumes.
     it("resumes with unknown experience are excluded by maxExperience", () => {
       const root = createFixtureRoot();
       roots.push(root);


### PR DESCRIPTION
## Summary

Three resume-list filter tests passed \`{ minExperience: N }\` to filter functions and asserted it was ignored (\`=== true\`), documenting **behavior that does not exist**:

- \`routes/__tests__/bff-filter-alignment.test.ts\` — "resumes with empty experience pass minExperience filter"
- \`services/__tests__/bff-filter-utils.test.ts\` — "includes doc with unknown experience when only minExperience is set"
- \`services/resume-service.test.ts\` — "resumes with empty experience pass minExperience filter"

**Decision: delete (not implement).** \`minExperience\` is NOT a resume-list filter. It is a JD / search-profile / rule-scoring concept, intentionally absent from:
- \`ResumeListFilterArgs\` (Convex source-of-truth — has \`maxExperience\` only)
- \`BffResumeFilters\` (BFF AND-mode)
- \`ResumeFilters\` (BFF OR-mode \`ResumeService.filterResumes\`)

All three paths support \`maxExperience\` only — a consistent, intentional design. Implementing a \`minExperience\` floor would be an unsolicited product-feature addition (no code path sends it to the resume list) with semantic decisions, out of scope for an autonomous "small/correctness" cycle.

### Audit
\`matchesResumeListFilters\` was audited: **every** \`ResumeListFilterArgs\` field is enforced (\`maxExperience, minRoleYears, roleFilterType, minAge/maxAge, education, locations, skills, requiredKeywords, keywords, minSalary/maxSalary, sources, showArchived\`). There are no phantom **fields** — only these phantom **test assertions**.

### Root cause
The phantom slipped past \`make check\` because \`apps/api/tsconfig.json\` excludes \`**/*.test.ts\` from \`tsc\`, and vitest runs tests without typechecking. (Enabling typecheck on test files is a worthwhile follow-up but out of scope here.)

The real \`maxExperience\` graceful-degradation coverage is retained in all three files; a clarifying \`NOTE\` was left in place of the removed cases.

## Verification
- \`npx vitest run\` on the 3 edited files → 114 passed
- \`make check\` → green
- \`npm test\` → 297 files / 5619 passed, 7 skipped, 0 failed

Refs: Q3 in \`logs/2026-06-16-dev-loop-queue-goal.md\`