### PR TITLE
feat(convex): migrate JD-usage query to cold resume_analyses (Phase 4 Step 1 / Q4)

### DIFF
--- a/packages/convex/__tests__/job-descriptions-convex-test.test.ts
+++ b/packages/convex/__tests__/job-descriptions-convex-test.test.ts
@@ -4,7 +4,7 @@
  * Covers: list, create, update, get, list_all, listAllForWorkspace,
  * delete_jd, delete_batch, list_with_usage (deprecated), list_with_usage_action.
  */
-import { createTest } from "./test-helpers.js";
+import { createTest, seedResume, seedResumeAnalysesColdRow } from "./test-helpers.js";
 import { describe, expect, it } from "vitest";
 import { api } from "../convex/_generated/api.js";
 import { internal } from "../convex/_generated/api.js";
@@ -525,5 +525,64 @@ describe("job_descriptions: list_with_usage (deprecated)", () => {
     await expect(
       t.query(api.job_descriptions.list_with_usage, {}),
     ).rejects.toThrow("no longer available");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_with_usage_action (cold-table JD usage — Phase 4 Step 1)
+// ---------------------------------------------------------------------------
+
+describe("job_descriptions: list_with_usage_action (cold-table JD usage)", () => {
+  it("counts resumes per JD from cold resume_analyses rows, excluding archived", async () => {
+    const t = createTest();
+
+    const jdA = await insertSystemJD(t, { title: "JD A" });
+    const jdB = await insertSystemJD(t, { title: "JD B" });
+    const jdAId = String(jdA);
+    const jdBId = String(jdB);
+
+    // Resume 1: active cold row whose current analysis targets JD A.
+    const r1 = await seedResume(t);
+    await seedResumeAnalysesColdRow(t, r1, {
+      analysis: { score: 80, summary: "s1", highlights: [], recommendation: "proceed", jobDescriptionId: jdAId },
+      analyses: {},
+    });
+
+    // Resume 2: active cold row with a cached analysis key matching JD B.
+    const r2 = await seedResume(t);
+    await seedResumeAnalysesColdRow(t, r2, {
+      analyses: { [jdBId]: { score: 70 } },
+    });
+
+    // Resume 3: ARCHIVED cold row with stale analyses matching JD A — must NOT count.
+    // (Mirrors non-surgical clearAnalyses: status flips to archived but fields persist.)
+    const r3 = await seedResume(t);
+    await seedResumeAnalysesColdRow(t, r3, {
+      status: "archived",
+      analysis: { score: 60, summary: "stale", highlights: [], recommendation: "proceed", jobDescriptionId: jdAId },
+      analyses: { [jdAId]: { score: 60 } },
+    });
+
+    // Resume 4: no cold row at all — must NOT count.
+    await seedResume(t);
+
+    const result = await t.action(api.job_descriptions.list_with_usage_action, {});
+
+    const usageByTitle = Object.fromEntries(result.map((jd) => [jd.title, jd.usageCount]));
+    expect(usageByTitle["JD A"]).toBe(1); // only r1; r3 archived excluded
+    expect(usageByTitle["JD B"]).toBe(1); // only r2
+  });
+
+  it("reports zero usage for JDs with no matching analyses", async () => {
+    const t = createTest();
+
+    const jdA = await insertSystemJD(t, { title: "Lonely JD" });
+    await seedResume(t); // resume with no cold row
+
+    const result = await t.action(api.job_descriptions.list_with_usage_action, {});
+
+    const lonely = result.find((jd) => jd.title === "Lonely JD");
+    expect(lonely?.usageCount).toBe(0);
+    expect(String(jdA)).toBeDefined();
   });
 });

--- a/packages/convex/__tests__/resumes-mutations-convex-test.test.ts
+++ b/packages/convex/__tests__/resumes-mutations-convex-test.test.ts
@@ -9,7 +9,7 @@ import { convexTest } from "convex-test";
 import { describe, expect, it } from "vitest";
 import { api, internal } from "../convex/_generated/api.js";
 import schema from "../convex/schema.js";
-import { seedResume } from "./test-helpers.js";
+import { seedResume, seedResumeAnalysesColdRow } from "./test-helpers.js";
 
 const modules = (import.meta as any).glob("../**/*.ts", { eager: false });
 
@@ -349,9 +349,10 @@ describe("resumes: listResumeScanBatch", () => {
 // ---------------------------------------------------------------------------
 
 describe("resumes: listResumeUsageBatch", () => {
-    it("returns analysis and analyses fields for each resume", async () => {
+    it("sources analysis/analyses from the cold resume_analyses row", async () => {
         const t = convexTest(schema, modules);
-        await seedResume(t, {
+        const resumeId = await seedResume(t);
+        await seedResumeAnalysesColdRow(t, resumeId, {
             analysis: { score: 70, summary: "ok", highlights: [], recommendation: "proceed" },
             analyses: { "jd:test": { score: 70 } },
         });
@@ -359,8 +360,37 @@ describe("resumes: listResumeUsageBatch", () => {
         const result = await t.query(internal.resumes.listResumeUsageBatch, { limit: 10 });
 
         expect(result.page.length).toBeGreaterThanOrEqual(1);
-        expect(result.page[0]).toHaveProperty("analysis");
-        expect(result.page[0]).toHaveProperty("analyses");
+        expect(result.page[0].analysis).toEqual({ score: 70, summary: "ok", highlights: [], recommendation: "proceed" });
+        expect(result.page[0].analyses).toEqual({ "jd:test": { score: 70 } });
+    });
+
+    it("excludes analysis/analyses from archived cold rows (active-only)", async () => {
+        const t = convexTest(schema, modules);
+        const resumeId = await seedResume(t);
+        // An archived row retains stale analysis/analyses (mirrors non-surgical
+        // clearAnalyses), but must NOT contribute — reading without the active
+        // guard would over-count cleared resumes.
+        await seedResumeAnalysesColdRow(t, resumeId, {
+            status: "archived",
+            analysis: { score: 70, summary: "stale", highlights: [], recommendation: "proceed" },
+            analyses: { "jd:test": { score: 70 } },
+        });
+
+        const result = await t.query(internal.resumes.listResumeUsageBatch, { limit: 10 });
+
+        expect(result.page[0].analysis).toBeUndefined();
+        expect(result.page[0].analyses).toBeUndefined();
+    });
+
+    it("returns undefined analysis/analyses for resumes with no cold row", async () => {
+        const t = convexTest(schema, modules);
+        await seedResume(t);
+
+        const result = await t.query(internal.resumes.listResumeUsageBatch, { limit: 10 });
+
+        expect(result.page.length).toBeGreaterThanOrEqual(1);
+        expect(result.page[0].analysis).toBeUndefined();
+        expect(result.page[0].analyses).toBeUndefined();
     });
 
     it("returns empty page when no resumes exist", async () => {

--- a/packages/convex/__tests__/test-helpers.ts
+++ b/packages/convex/__tests__/test-helpers.ts
@@ -4,6 +4,7 @@
 import { convexTest } from "convex-test";
 import schema from "../convex/schema.js";
 import { buildResumeDigest } from "../convex/lib/resume_digests.js";
+import type { Id } from "../convex/_generated/dataModel.js";
 
 const modules = (import.meta as any).glob("../**/*.ts", { eager: false });
 
@@ -39,6 +40,28 @@ export function seedResume(t: ReturnType<typeof convexTest>, overrides: Record<s
             await ctx.db.insert("resume_digests", digest as any);
         }
         return resumeId;
+    });
+}
+
+/**
+ * Insert a resume_analyses (cold-table) row for a resume. Mirrors the Phase 3
+ * cold write path so tests can exercise readers (JD-usage, backup, migration
+ * validators) that have migrated off the hot resume.analysis/analyses fields.
+ *
+ * `status` defaults to omitted (treated as active by readers per the Phase 3
+ * back-compat contract). Pass `{ status: "archived" }` to seed a cleared row.
+ */
+export function seedResumeAnalysesColdRow(
+    t: ReturnType<typeof convexTest>,
+    resumeId: Id<"resumes">,
+    overrides: Record<string, unknown> = {},
+) {
+    return t.run(async (ctx) => {
+        return ctx.db.insert("resume_analyses", {
+            resumeId,
+            updatedAt: Date.now(),
+            ...overrides,
+        });
     });
 }
 

--- a/packages/convex/convex/resumes_mutations.ts
+++ b/packages/convex/convex/resumes_mutations.ts
@@ -252,13 +252,32 @@ export const listResumeUsageBatch = internalQuery({
                 maximumRowsRead: PAGINATE_MAX_ROWS_READ,
             });
 
+        // Phase 4 Step 1: source analysis/analyses from the cold resume_analyses
+        // table instead of the hot resume doc, so JD-usage counts survive the
+        // upcoming removal of analysis/analyses from the resumes schema.
+        //
+        // Only ACTIVE rows contribute. A non-surgical clearAnalyses archives the
+        // cold row but leaves its analysis/analyses fields populated (only the
+        // status flips); the hot doc, by contrast, is set to undefined. Reading
+        // without the status guard would therefore over-count archived resumes.
+        // status === undefined is treated as active (pre-Phase-1 rows).
+        const rows = await Promise.all(
+            page.page.map(async (resume): Promise<ResumeUsageScanRow> => {
+                const coldRow = await ctx.db
+                    .query("resume_analyses")
+                    .withIndex("by_resume", (q) => q.eq("resumeId", resume._id))
+                    .unique();
+                if (!coldRow || coldRow.status === "archived") {
+                    return { analysis: undefined, analyses: undefined };
+                }
+                return { analysis: coldRow.analysis, analyses: coldRow.analyses };
+            }),
+        );
+
         return {
             continueCursor: page.continueCursor,
             isDone: page.isDone,
-            page: page.page.map((resume): ResumeUsageScanRow => ({
-                analysis: resume.analysis,
-                analyses: resume.analyses,
-            })),
+            page: rows,
         };
     },
 });


### PR DESCRIPTION
## Summary

Phase 4 Step 1 (Requirement 1 of the [cold-table reader migration spec](https://github.com/ptdevhk/trends/blob/main/logs/2026-06-16-dev-loop-queue-goal.md)). \`listResumeUsageBatch\` now sources \`analysis\`/\`analyses\` from the **cold \`resume_analyses\` table** (\`by_resume\` index, batched per page via \`Promise.all\`) instead of the hot \`resume\` doc, so \`job_descriptions:list_with_usage_action\` JD-usage counts survive the upcoming removal of \`analysis\`/\`analyses\` from the \`resumes\` schema.

### Critical correctness detail — active-only filter
Only **ACTIVE** cold rows contribute. A non-surgical \`clearAnalyses\` archives the cold row but **leaves its \`analysis\`/\`analyses\` populated** (only \`status\` flips to \`\"archived\"\`), whereas the hot doc is set to \`undefined\`. Reading without the active-status guard would therefore **over-count cleared resumes**. \`status === undefined\` is treated as active (pre-Phase-1 rows), per the Phase 3 back-compat contract.

This restores exact parity with the prior hot-doc behavior.

### Consumer unchanged
The matching logic in \`job_descriptions.ts\` is unchanged — the return shape (\`ResumeUsageScanRow\`) is identical, just re-sourced.

## Tests
- \`resumes-mutations-convex-test\`: re-sourced to cold rows; added **active-only (archived excluded)** and **missing-cold-row** cases.
- \`resumes-mutations-extended\`: passes **unchanged** (\`updateAnalysis\` already dual-writes the cold row via \`doUpsertResumeAnalysis\`).
- \`job-descriptions-convex-test\`: new **end-to-end \`list_with_usage_action\` regression test** — seeded resumes with analyses for 2 JDs (active current-analysis, active cached-key, archived-stale, no-cold-row) → counts \`A=1, B=1\`. This is the spec's required \`counts unchanged\` regression test.
- \`test-helpers\`: shared \`seedResumeAnalysesColdRow\` helper (reused by Phase 4 Step 2).

## Verification
- \`npx vitest run\` on the 3 affected files → 79 passed
- \`make check\` → green (incl. Convex typecheck)
- \`npm test\` → 297 files / 5626 passed, 7 skipped, 0 failed

Unblocks Phase 4 Step 2 (backup + validators) and Step 3 (hot-field removal).

Refs: Q4 / Req 1 in \`logs/2026-06-16-dev-loop-queue-goal.md\`