### PR TITLE
feat(convex): migrate backup + merge validators to cold resume_analyses (Phase 4 Step 2 / Q5)

### DIFF
--- a/packages/convex/__tests__/migrations-convex-test.test.ts
+++ b/packages/convex/__tests__/migrations-convex-test.test.ts
@@ -15,7 +15,7 @@
  * Each test inserts realistic data, runs the migration, and verifies
  * the database state matches expectations.
  */
-import { createTest } from "./test-helpers.js";
+import { createTest, seedResumeAnalysesColdRow } from "./test-helpers.js";
 import { describe, expect, it } from "vitest";
 import { api } from "../convex/_generated/api.js";
 
@@ -690,6 +690,62 @@ describe("migration: mergeDuplicateResumesByIdentity", () => {
     expect(result.duplicateGroupCount).toBeGreaterThanOrEqual(2);
     // With batchSize=100, both groups should be processed
     expect(result.processedGroupCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it("merges analyses from cold resume_analyses rows into the canonical cold row", async () => {
+    const t = createTest();
+
+    const sharedKey = "cold-analysis-merge-key";
+    // Canonical: cold row with current analysis + one cached analysis.
+    const canonicalId = await insertResume(t, {
+      externalId: "cold-canonical",
+      identityKey: sharedKey,
+      crawledAt: 300,
+      tags: [],
+    });
+    await seedResumeAnalysesColdRow(t, canonicalId, {
+      analysis: { score: 80, summary: "primary", highlights: [], recommendation: "yes" },
+      analyses: { jd1: { score: 80 } },
+    });
+    // Duplicate: cold row with a different cached analysis.
+    const dupId = await insertResume(t, {
+      externalId: "cold-duplicate",
+      identityKey: sharedKey,
+      crawledAt: 200,
+      tags: [],
+    });
+    await seedResumeAnalysesColdRow(t, dupId, {
+      analyses: { jd2: { score: 90 } },
+    });
+
+    const result = await t.mutation(
+      api.migrations.mergeDuplicateResumesByIdentity,
+      { dryRun: false, batchSize: 10 },
+    );
+
+    expect(result.patchedCanonicals).toBe(1);
+    expect(result.deleted).toBe(1);
+    expect(result.groups[0].mergedAnalysisCount).toBe(2);
+
+    // Canonical's cold row now carries both merged analyses + the primary analysis.
+    const canonicalCold = await t.run(async (ctx) => {
+      return ctx.db
+        .query("resume_analyses")
+        .withIndex("by_resume", (q: any) => q.eq("resumeId", canonicalId))
+        .first();
+    });
+    expect(canonicalCold).toBeDefined();
+    expect(Object.keys(canonicalCold!.analyses ?? {}).sort()).toEqual(["jd1", "jd2"]);
+    expect((canonicalCold!.analysis as Record<string, unknown>)?.score).toBe(80);
+
+    // The duplicate's resume is deleted; its cold row must not be orphaned.
+    const dupCold = await t.run(async (ctx) => {
+      return ctx.db
+        .query("resume_analyses")
+        .withIndex("by_resume", (q: any) => q.eq("resumeId", dupId))
+        .first();
+    });
+    expect(dupCold).toBeNull();
   });
 });
 

--- a/packages/convex/__tests__/migrations-pure-helpers.test.ts
+++ b/packages/convex/__tests__/migrations-pure-helpers.test.ts
@@ -492,6 +492,61 @@ describe("mergeAnalyses", () => {
 });
 
 // ---------------------------------------------------------------------------
+// analysisRichness / sortForCanonical / mergeAnalyses — cold-table views
+// (Phase 4 Step 2: cold view overrides hot fields; hot is the fallback)
+// ---------------------------------------------------------------------------
+
+describe("analysis helpers — cold-table viewsById", () => {
+  function makeResume(id: string, analysis?: unknown, analyses?: Record<string, unknown>) {
+    return { _id: id, crawledAt: 100, analysis, analyses, content: {}, externalId: id, source: "test", tags: [] } as never;
+  }
+
+  it("analysisRichness prefers the cold view over hot fields", () => {
+    const resume = makeResume("r1", { score: 5 }, { a: 1 }); // hot richness = 2
+    const views = new Map([["r1", { analysis: undefined, analyses: { a: 1, b: 2, c: 3 } }]]);
+    expect(analysisRichness(resume, views)).toBe(3);
+  });
+
+  it("analysisRichness falls back to hot fields when no cold view is present", () => {
+    const resume = makeResume("r1", { score: 5 }, { a: 1 });
+    expect(analysisRichness(resume)).toBe(2);
+    expect(analysisRichness(resume, new Map())).toBe(2);
+  });
+
+  it("sortForCanonical breaks ties by cold-view richness", () => {
+    const a = makeResume("a", undefined, { x: 1 }); // hot richness 1
+    const b = makeResume("b", undefined, undefined); // hot richness 0
+    // Invert richness via cold views: b is richer than a.
+    const views = new Map([
+      ["a", { analyses: undefined }],
+      ["b", { analyses: { x: 1, y: 2 } }],
+    ]);
+    expect(sortForCanonical([a, b], views)).toEqual([b, a]);
+  });
+
+  it("mergeAnalyses merges from cold views; resumes without a view fall back to hot", () => {
+    const r1 = makeResume("r1", undefined, { hot: 1 });
+    const r2 = makeResume("r2", undefined, { cold: 2 });
+    const views = new Map([
+      ["r1", { analyses: { coldView: 9 } }], // r1: cold overrides hot → {coldView:9}, hot:{hot:1} ignored
+      // r2 has no view → falls back to hot { cold: 2 }
+    ]);
+    const result = mergeAnalyses([r1, r2], views);
+    expect(result.analyses).toEqual({ coldView: 9, cold: 2 });
+  });
+
+  it("mergeAnalyses picks primary analysis from the cold view", () => {
+    const r1 = makeResume("r1", undefined, undefined);
+    const r2 = makeResume("r2", undefined, undefined);
+    const views = new Map([
+      ["r2", { analysis: { score: 7 } }],
+    ]);
+    const result = mergeAnalyses([r1, r2], views);
+    expect(result.analysis).toEqual({ score: 7 });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // groupDuplicatesByIdentity
 // ---------------------------------------------------------------------------
 

--- a/packages/convex/__tests__/resumes-list-for-backup-convex-test.test.ts
+++ b/packages/convex/__tests__/resumes-list-for-backup-convex-test.test.ts
@@ -4,7 +4,7 @@
  * Replaces resumes-list-for-backup.test.ts (hand-crafted mocks)
  * with proper convex-test infrastructure.
  */
-import { createTest } from "./test-helpers.js";
+import { createTest, seedResumeAnalysesColdRow } from "./test-helpers.js";
 import { describe, expect, it } from "vitest";
 import { api } from "../convex/_generated/api.js";
 
@@ -112,5 +112,62 @@ describe("resumes: listForBackup", () => {
     // Should only include the resume matching profileId "2002"
     expect(result.page).toHaveLength(1);
     expect((result.page[0] as Record<string, unknown>).externalId).toBe("seek:profile:2002");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listForBackup — cold-table analysis projection (Phase 4 Step 2)
+// ---------------------------------------------------------------------------
+
+describe("resumes: listForBackup — analysis projection from cold resume_analyses", () => {
+  it("snapshots analysis/analyses from the active cold row", async () => {
+    const t = createTest();
+    const resumeId = await insertResume(t, { externalId: "cold-active", crawledAt: 100 });
+    await seedResumeAnalysesColdRow(t, resumeId, {
+      analysis: { score: 82, summary: "s", highlights: [], recommendation: "proceed" },
+      analyses: { "jd-1": { score: 82 } },
+    });
+
+    const result = await t.query(api.resumes.listForBackup, {
+      paginationOpts: { cursor: null, numItems: 50 },
+    });
+
+    expect(result.page).toHaveLength(1);
+    const row = result.page[0] as Record<string, unknown>;
+    expect((row.analysis as Record<string, unknown>).score).toBe(82);
+    expect(row.analyses).toEqual({ "jd-1": { score: 82 } });
+  });
+
+  it("excludes analysis/analyses from archived cold rows", async () => {
+    const t = createTest();
+    const resumeId = await insertResume(t, { externalId: "cold-archived", crawledAt: 100 });
+    // Archived rows retain stale analysis/analyses (mirrors non-surgical clear),
+    // but must NOT be snapshotted — the data is no longer live.
+    await seedResumeAnalysesColdRow(t, resumeId, {
+      status: "archived",
+      analysis: { score: 60, summary: "stale", highlights: [], recommendation: "proceed" },
+      analyses: { "jd-1": { score: 60 } },
+    });
+
+    const result = await t.query(api.resumes.listForBackup, {
+      paginationOpts: { cursor: null, numItems: 50 },
+    });
+
+    const row = result.page[0] as Record<string, unknown>;
+    expect(row.analysis).toBeUndefined();
+    expect(row.analyses).toBeUndefined();
+  });
+
+  it("returns undefined analysis/analyses when no cold row exists", async () => {
+    const t = createTest();
+    await insertResume(t, { externalId: "no-cold", crawledAt: 100 });
+
+    const result = await t.query(api.resumes.listForBackup, {
+      paginationOpts: { cursor: null, numItems: 50 },
+    });
+
+    const row = result.page[0] as Record<string, unknown>;
+    expect(row.analysis).toBeUndefined();
+    expect(row.analyses).toBeUndefined();
   });
 });

--- a/packages/convex/convex/migrations.ts
+++ b/packages/convex/convex/migrations.ts
@@ -1,5 +1,6 @@
 import { api, internal } from "./_generated/api";
 import { action, mutation } from "./_generated/server";
+import type { MutationCtx } from "./_generated/server";
 import type { Doc, Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import {
@@ -26,6 +27,7 @@ import { deriveResumeIdentityKey } from "./lib/resume_identity";
 import { parseAgeFromContent } from "./lib/age";
 import { DEFAULT_WORKSPACE_SLUG } from "./sessions";
 import { resolveResumeScanBatchSize, resolveDiagnosticsSourceKeyForResume } from "./resumes";
+import { doUpsertResumeAnalysis } from "./resumes_search";
 
 const JOB5156_HOST = "hr.job5156.com";
 const MANUAL_51JOB_SOURCE = "51job-manual";
@@ -420,13 +422,39 @@ export function rewrite51jobManualContent(content: unknown, source: string): {
     };
 }
 
-export function analysisRichness(resume: Doc<"resumes">): number {
+/**
+ * Effective analysis view for a resume — cold-sourced when a cold row exists.
+ * Used to thread Phase 4 cold-table reads through the merge/audit helpers
+ * without changing their hot-field fallback (which keeps legacy callers and
+ * hot-seeded tests working until Step 3 removes the hot fields).
+ */
+export type ResumeAnalysisView = {
+    analysis?: Doc<"resumes">["analysis"];
+    analyses?: Doc<"resumes">["analyses"];
+};
+
+/** Map of resume _id (string) → cold-sourced analysis view. */
+export type ResumeAnalysisViewById = Map<string, ResumeAnalysisView>;
+
+function resolveAnalysis(resume: Doc<"resumes">, viewsById?: ResumeAnalysisViewById): ResumeAnalysisView {
+    const view = viewsById?.get(String(resume._id));
+    if (view) {
+        // A cold row exists → it is authoritative (Phase 4 source of truth).
+        // An explicit undefined means "no analysis/analyses", NOT "fall back to
+        // hot" — otherwise cleared cold rows would resurrect stale hot data.
+        return { analysis: view.analysis, analyses: view.analyses };
+    }
+    return { analysis: resume.analysis, analyses: resume.analyses };
+}
+
+export function analysisRichness(resume: Doc<"resumes">, viewsById?: ResumeAnalysisViewById): number {
+    const { analysis, analyses } = resolveAnalysis(resume, viewsById);
     let richness = 0;
-    if (resume.analysis !== undefined) {
+    if (analysis !== undefined) {
         richness += 1;
     }
-    if (isRecord(resume.analyses)) {
-        richness += Object.keys(resume.analyses).length;
+    if (isRecord(analyses)) {
+        richness += Object.keys(analyses).length;
     }
     return richness;
 }
@@ -439,12 +467,12 @@ export function resumeIdentityKey(resume: Doc<"resumes">): string {
     });
 }
 
-export function sortForCanonical(resumes: Doc<"resumes">[]): Doc<"resumes">[] {
+export function sortForCanonical(resumes: Doc<"resumes">[], viewsById?: ResumeAnalysisViewById): Doc<"resumes">[] {
     return [...resumes].sort((left, right) => {
         if (left.crawledAt !== right.crawledAt) {
             return right.crawledAt - left.crawledAt;
         }
-        const richnessDiff = analysisRichness(right) - analysisRichness(left);
+        const richnessDiff = analysisRichness(right, viewsById) - analysisRichness(left, viewsById);
         if (richnessDiff !== 0) {
             return richnessDiff;
         }
@@ -452,7 +480,7 @@ export function sortForCanonical(resumes: Doc<"resumes">[]): Doc<"resumes">[] {
     });
 }
 
-export function mergeAnalyses(resumes: Doc<"resumes">[]): {
+export function mergeAnalyses(resumes: Doc<"resumes">[], viewsById?: ResumeAnalysisViewById): {
     analyses: Doc<"resumes">["analyses"];
     analysis: Doc<"resumes">["analysis"];
 } {
@@ -460,14 +488,15 @@ export function mergeAnalyses(resumes: Doc<"resumes">[]): {
     let primaryAnalysis: Doc<"resumes">["analysis"] = undefined;
 
     for (const resume of resumes) {
-        if (primaryAnalysis === undefined && resume.analysis !== undefined) {
-            primaryAnalysis = resume.analysis;
+        const { analysis, analyses } = resolveAnalysis(resume, viewsById);
+        if (primaryAnalysis === undefined && analysis !== undefined) {
+            primaryAnalysis = analysis;
         }
 
-        if (!isRecord(resume.analyses)) {
+        if (!isRecord(analyses)) {
             continue;
         }
-        for (const [key, value] of Object.entries(resume.analyses)) {
+        for (const [key, value] of Object.entries(analyses)) {
             if (!(key in mergedAnalyses)) {
                 mergedAnalyses[key] = value as NonNullable<Doc<"resumes">["analyses"]>[string];
             }
@@ -478,6 +507,32 @@ export function mergeAnalyses(resumes: Doc<"resumes">[]): {
         analyses: mergedAnalyses,
         analysis: primaryAnalysis,
     };
+}
+
+/**
+ * Build a resumeId → active cold analysis-view map for a set of resumes.
+ * Only resumes with an ACTIVE cold row (status !== "archived") get an entry,
+ * so resumes without a cold row fall back to their hot fields via
+ * {@link resolveAnalysis}. Used by the merge/audit migrations to read analyses
+ * from the cold table (Phase 4 Step 2) without breaking hot-field callers.
+ */
+export async function fetchActiveAnalysisViews(
+    ctx: MutationCtx,
+    resumes: Doc<"resumes">[],
+): Promise<ResumeAnalysisViewById> {
+    const views: ResumeAnalysisViewById = new Map();
+    await Promise.all(
+        resumes.map(async (resume) => {
+            const coldRow = await ctx.db
+                .query("resume_analyses")
+                .withIndex("by_resume", (q) => q.eq("resumeId", resume._id))
+                .unique();
+            if (coldRow && coldRow.status !== "archived") {
+                views.set(String(resume._id), { analysis: coldRow.analysis, analyses: coldRow.analyses });
+            }
+        }),
+    );
+    return views;
 }
 
 export function groupDuplicatesByIdentity(resumes: Doc<"resumes">[]): Array<{
@@ -1210,9 +1265,12 @@ export const auditDuplicateResumesByIdentity = mutation({
                 numItems: resolveResumeScanBatchSize(args.batchSize),
             });
         const duplicateGroups = groupDuplicatesByIdentity(resumes.page);
+        // Phase 4 Step 2: read analysis richness from the cold table so canonical
+        // selection stays correct after the hot fields are removed.
+        const viewsById = await fetchActiveAnalysisViews(ctx, resumes.page);
 
         const groups = duplicateGroups.map((group) => {
-            const ordered = sortForCanonical(group.resumes);
+            const ordered = sortForCanonical(group.resumes, viewsById);
             const canonical = ordered[0];
             const duplicates = ordered.slice(1);
             return {
@@ -1306,6 +1364,9 @@ export const mergeDuplicateResumesByIdentity = mutation({
                 numItems: resolveResumeScanBatchSize(args.batchSize),
             });
         const duplicateGroups = groupDuplicatesByIdentity(resumes.page);
+        // Phase 4 Step 2: read analyses from the cold table so merge consolidates
+        // the correct data after the hot fields are removed.
+        const viewsById = await fetchActiveAnalysisViews(ctx, resumes.page);
         const effectiveBatchSize = Math.max(1, Math.trunc(args.batchSize));
         const targetGroups = duplicateGroups.slice(0, effectiveBatchSize);
 
@@ -1321,12 +1382,12 @@ export const mergeDuplicateResumesByIdentity = mutation({
             mergedAnalysisCount: number;
         }> = [];
         for (const group of targetGroups) {
-            const ordered = sortForCanonical(group.resumes);
+            const ordered = sortForCanonical(group.resumes, viewsById);
             const canonical = ordered[0];
             const duplicates = ordered.slice(1);
 
             const mergedTags = Array.from(new Set(ordered.flatMap((resume) => resume.tags)));
-            const mergedAnalysis = mergeAnalyses(ordered);
+            const mergedAnalysis = mergeAnalyses(ordered, viewsById);
 
             if (!args.dryRun) {
                 const patch: {
@@ -1347,9 +1408,29 @@ export const mergeDuplicateResumesByIdentity = mutation({
                 }
 
                 await ctx.db.patch(canonical._id, patch);
+                // Phase 4 Step 2: sync the canonical's cold resume_analyses row
+                // with the merged analyses (dual-write; hot patch above is retained
+                // until Step 3 removes the hot fields). Status resets to active.
+                await doUpsertResumeAnalysis(
+                    ctx,
+                    canonical._id,
+                    mergedAnalysis.analysis,
+                    mergedAnalysis.analyses && Object.keys(mergedAnalysis.analyses).length > 0
+                        ? mergedAnalysis.analyses
+                        : undefined,
+                );
                 patchedCanonicals += 1;
 
                 for (const duplicate of duplicates) {
+                    // Delete the duplicate's cold row so it does not orphan after
+                    // the resume itself is deleted (its analyses were merged above).
+                    const dupColdRow = await ctx.db
+                        .query("resume_analyses")
+                        .withIndex("by_resume", (q) => q.eq("resumeId", duplicate._id))
+                        .first();
+                    if (dupColdRow) {
+                        await ctx.db.delete(dupColdRow._id);
+                    }
                     await ctx.db.delete(duplicate._id);
                     deleted += 1;
                 }

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -422,8 +422,27 @@ export const listForBackup = query({
 
         const filtered = applyResumeBackupFilters(page.page, filterSets).sort(compareResumeBackupRows);
 
+        // Phase 4 Step 2: source analysis/analyses from the cold resume_analyses
+        // table (joined per resume via by_resume) so backups stay complete after
+        // the hot fields are removed. Only ACTIVE rows contribute — archived rows
+        // retain stale fields (non-surgical clear flips status only), so reading
+        // without the guard would snapshot analyses that are no longer live.
+        // Mirrors the active-only contract in listResumeUsageBatch.
+        const backupRows = await Promise.all(
+            filtered.map(async (row) => {
+                const coldRow = await ctx.db
+                    .query("resume_analyses")
+                    .withIndex("by_resume", (q) => q.eq("resumeId", row._id))
+                    .unique();
+                if (!coldRow || coldRow.status === "archived") {
+                    return { ...row, analysis: undefined, analyses: undefined };
+                }
+                return { ...row, analysis: coldRow.analysis, analyses: coldRow.analyses };
+            }),
+        );
+
         return {
-            page: filtered,
+            page: backupRows,
             continueCursor: page.continueCursor,
             isDone: page.isDone,
         };


### PR DESCRIPTION
## Summary

Phase 4 Step 2 (Requirement 2 of the [cold-table reader migration spec](https://github.com/ptdevhk/trends/blob/main/logs/2026-06-16-dev-loop-queue-goal.md)). The remaining hot-doc readers — **backup shape** and the **merge/audit validators** — now source analysis data from the cold \`resume_analyses\` table, so they stay correct after Step 3 removes \`analysis\`/\`analyses\` from the \`resumes\` schema.

### Backup (\`resumes.ts:listForBackup\`)
\`analysis\`/\`analyses\` are now snapshotted from the cold row (\`by_resume\` join, per page). Only **ACTIVE** cold rows contribute — archived rows retain stale fields after a non-surgical clear, so reading without the guard would snapshot dead data. Mirrors the active-only contract shipped in \`listResumeUsageBatch\` (Step 1, #1283).

### Merge/audit validators (\`migrations.ts\`)
- \`analysisRichness\` / \`sortForCanonical\` / \`mergeAnalyses\` take an optional cold-view map (\`ResumeAnalysisViewById\`). A cold view is **authoritative** when present — an explicit \`undefined\` means *no analysis*, not *fall back to hot* (otherwise cleared cold rows resurrect stale hot data). Resumes with **no** cold row fall back to hot fields, so legacy callers and the existing hot-seeded tests are unchanged.
- \`auditDuplicateResumesByIdentity\` + \`mergeDuplicateResumesByIdentity\` fetch active cold views per page and thread them through sort/merge.
- The merge **write path** now dual-writes: the canonical's cold row is synced via \`doUpsertResumeAnalysis\` (merged analyses, status \`active\`) alongside the retained hot patch; deleted duplicates have their cold rows removed (no orphans).

### \`backfillAnalysesValidator\` — intentionally NOT migrated
It is a one-time **hot-field shape normalizer**; the cold table already enforces the strict \`analysisResultValidator\`, so there is nothing to normalize on the cold side. It stays valid while the hot field exists and becomes obsolete at Step 3. Migrating it to cold reads would be semantically wrong.

## Tests
- \`resumes-list-for-backup\`: cold-active snapshot, archived exclusion, no-cold-row.
- \`migrations-pure-helpers\`: cold-view authority + hot fallback for richness/sort/merge.
- \`migrations-convex-test\`: cold-only merge fixture → canonical cold row carries merged analyses; duplicate cold row cleaned up.
- Existing hot-seeded merge/audit/backfill tests pass **unchanged** (hot fallback).

## Verification
- \`npx vitest run\` on the 3 affected files → 194 passed
- \`make check\` → green (incl. Convex typecheck)
- \`npm test\` → 299 files / 5656 passed, 7 skipped, 0 failed

This completes the autonomous queue (Q1–Q5). Phase 4 Step 3 (hot-field removal + prod backfill) remains human-only.

Refs: Q5 / Req 2 in \`logs/2026-06-16-dev-loop-queue-goal.md\`