### PR TITLE
test(api): add non-blocking test-file typecheck gate (T1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 		local-run-crawler local-run-mcp local-run-mcp-http local-run-worker local-run-worker-once run crawl mcp mcp-http worker worker-once \
 		on-prod-install on-prod-deploy on-prod-deploy-check on-prod-uninstall on-prod-refresh-env on-prod-preview-restore-full-state prod-install prod-deploy prod-deploy-check install deploy deploy-check uninstall refresh-env preview-restore-full-state restore-preview-full-state \
 		install-deps fetch-docs clean check help docker docker-build docker-down \
-		check-python check-node check-build \
+		check-python check-node check-node-tests-types check-build \
 		test test-python test-node test-resume test-extension-keyword-mode test-api-search-profiles test-worker-resume-tasks test-collect-url-smoke \
 		migration-test migration-test-fresh-sandbox \
 		build-static build-static-fresh build-extension-zip serve-static \
@@ -1241,6 +1241,39 @@ check-node:
 		npm run --workspaces --if-present typecheck; \
 		npm run --workspace @trends/web lint; \
 		npm run --workspace @trends/browser-extension lint; \
+	fi
+	@$(MAKE) check-node-tests-types
+
+# Test-file typecheck gate (apps/api). Catches phantom-type test assertions
+# (e.g. Q3's minExperience) that the package tsconfig excludes from `tsc`.
+# Wired into check-node. Adds ~10s (the test program re-typechecks apps/api
+# source; composite project references would dedupe but are a separate
+# initiative). Currently REPORT-ONLY: the baseline of latent test type errors
+# is being cleaned up in batches (T2-T5). When that count hits 0, flip the
+# default below to `hard` so new test-file type errors block make check.
+TESTS_TYPES_GATE ?= report-only
+check-node-tests-types:
+	@echo "Running apps/api test-file typecheck (gate=$(TESTS_TYPES_GATE))..."
+	@mkdir -p logs
+	@if npm run --workspace @trends/api typecheck:tests > logs/tests-types.log 2>&1; then \
+		echo "  apps/api test-file types: 0 errors"; \
+	elif [ "$(TESTS_TYPES_GATE)" = "hard" ]; then \
+		ERRS=$$(grep -cE "error TS[0-9]+" logs/tests-types.log || true); \
+		if [ "$$ERRS" -gt 0 ]; then \
+			echo "  apps/api test-file typecheck FAILED ($$ERRS errors):"; \
+			grep -E "error TS[0-9]+" logs/tests-types.log | head -n 10 | sed 's/^/    /'; \
+			[ "$$ERRS" -gt 10 ] && echo "    ... ($$((ERRS - 10)) more in logs/tests-types.log)"; \
+		else \
+			echo "  apps/api test-file typecheck FAILED (no TS errors — likely a tooling/infra failure):"; \
+			tail -n 20 logs/tests-types.log | sed 's/^/    /'; \
+		fi; \
+		echo "  Run 'npm --workspace @trends/api run typecheck:tests' for full output."; \
+		exit 1; \
+	else \
+		ERRS=$$(grep -cE "error TS[0-9]+" logs/tests-types.log || true); \
+		echo "  apps/api test-file typecheck: $$ERRS errors (report-only — cleanup in progress, T2-T5)"; \
+		grep -E "error TS[0-9]+" logs/tests-types.log | head -n 10 | sed 's/^/    /'; \
+		[ "$$ERRS" -gt 10 ] && echo "    ... ($$((ERRS - 10)) more in logs/tests-types.log)"; \
 	fi
 
 # Build validation (for CI)

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
+    "typecheck:tests": "tsc -p tsconfig.tests.json",
     "openapi:gen": "tsx src/openapi.ts"
   },
   "dependencies": {

--- a/apps/api/tsconfig.tests.json
+++ b/apps/api/tsconfig.tests.json
@@ -1,0 +1,14 @@
+// Test-file typecheck gate. Extends the package tsconfig but widens rootDir to
+// null so the no-emit typecheck can follow test-only deep imports into sibling
+// packages (packages/convex/convex/*) without TS6059 rootDir violations.
+// rootDir: "./src" is build-output layout; it does not apply to a no-emit gate.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "rootDir": null
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What

Closes the Q3 typecheck blind spot. `apps/api/tsconfig.json` excludes \`**/*.test.ts\` from \`tsc\`, so phantom-type test assertions (e.g. Q3's \`minExperience\` passing an unsupported filter to \`bffMatchesResumeFilters\`) slipped past \`make check\` + vitest. This PR adds a **test-file typecheck gate**, wired into \`make check\`.

First target (T1) of the \`2026-06-16-typecheck-test-files-blindspot\` work item.

## Changes

- **\`apps/api/tsconfig.tests.json\`** — extends the package tsconfig; widens \`rootDir\` to \`null\` so the no-emit typecheck can follow test-only deep imports into \`packages/convex/convex/*\` without \`TS6059\` rootDir violations; \`noEmit\`, \`declaration: false\`.
- **\`apps/api/package.json\`** — \`"typecheck:tests": "tsc -p tsconfig.tests.json"\` script.
- **\`Makefile\`** — \`check-node-tests-types\` target wired into \`check-node\`.

## Gate behavior

Ships **report-only** (\`TESTS_TYPES_GATE ?= report-only\`) so the baseline of latent test-file type errors does not block every PR while the cleanup batches (T2–T5) land. Supports \`TESTS_TYPES_GATE=hard\` to flip to hard-blocking once error count hits 0 (T5).

- Report-only: prints the error count + first 10 errors, exits 0.
- Hard: blocks \`make check\`, surfaces a diagnostic tail on non-tsc (tooling/infra) failures.

## Verification

- **TDD red**: a probe mirroring Q3 (object literal with a phantom property on a typed interface) → \`TS2353\` caught by the new gate. Probe removed after confirmation.
- **Baseline established**: \`551\` latent test-file type errors across \`apps/api/src/**\` (T2–T5 will clean in route/domain batches).
- \`make check\` green; \`npm test\` green (**299 files / 5656 passed, 7 skipped, 0 failures**).
- \`rootDir: null\` is a valid TS idiom (schema permits \`null\` to unset an inherited option); JSONC comment documents the rationale. \`logs/tests-types.log\` (gitignored) used instead of \`/tmp\`.

## Follow-ups (tracked, not in this PR)

- T2–T5: clean the 551 errors in batches, then flip \`TESTS_TYPES_GATE ?= hard\`.
- Out-of-scope nit: \`search-text-builder.test.ts\` uses a 5-level cross-package relative import that forces the \`rootDir: null\` workaround; a proper \`@trends/convex\` re-export would remove it.