### PR TITLE
test(api): fix routes/resumes* test-type errors (T2 batch)

### DIFF
--- a/apps/api/src/routes/__tests__/resumes-packets-route.test.ts
+++ b/apps/api/src/routes/__tests__/resumes-packets-route.test.ts
@@ -6,7 +6,7 @@ import Papa from "papaparse";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createAuthContext } from "../test-auth-helpers";
-import type { ResumeItem } from "../types/resume.js";
+import type { ResumeItem } from "../../types/resume";
 
 function createFixtureRoot(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "resumes-packets-route-"));

--- a/apps/api/src/routes/manual-resume-import.test.ts
+++ b/apps/api/src/routes/manual-resume-import.test.ts
@@ -3,6 +3,7 @@ import JSZip from "jszip";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { workspaceMiddleware } from "../middleware/workspace";
+import { parseJsonBody } from "../test-utils";
 import { createAuthContext } from "./test-auth-helpers";
 
 type ConvexCall = {
@@ -30,7 +31,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): ConvexCall {
+function parseConvexCall(input: Request | string | URL, init?: RequestInit): ConvexCall {
   const requestUrl = typeof input === "string"
     ? input
     : input instanceof URL
@@ -99,7 +100,9 @@ ${paragraphs}
   </w:body>
 </w:document>`);
 
-  const buffer = await zip.generateAsync({ type: "uint8array" });
+  // arraybuffer (not uint8array) so the value is an ArrayBuffer, which is a
+  // valid BlobPart; a Uint8Array<ArrayBufferLike> from @types/node 25 is not.
+  const buffer = await zip.generateAsync({ type: "arraybuffer" });
   return new File([buffer], name, { type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document" });
 }
 
@@ -1602,7 +1605,7 @@ describe("manual resume import route", () => {
     const response = await requestManualImport(formData);
 
     expect(response.status).toBe(400);
-    const body = await response.json();
+    const body = await parseJsonBody<{ success: unknown; error: { name?: string } }>(response);
     expect(body.success).toBe(false);
     // zod v4 validation error from OpenAPI layer — handler's safeParse is unreachable
     expect(body.error).toMatchObject({ name: "ZodError" });

--- a/apps/api/src/routes/resume-import.test.ts
+++ b/apps/api/src/routes/resume-import.test.ts
@@ -27,7 +27,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): ConvexCall {
+function parseConvexCall(input: Request | string | URL, init?: RequestInit): ConvexCall {
   const requestUrl = typeof input === "string"
     ? input
     : input instanceof URL

--- a/apps/api/src/routes/resume-submit.test.ts
+++ b/apps/api/src/routes/resume-submit.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createApp } from "../app";
 import { config } from "../services/config";
+import { parseJsonBody } from "../test-utils";
 
 type ConvexCall = {
   pathName: string;
@@ -15,7 +16,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): ConvexCall {
+function parseConvexCall(input: Request | string | URL, init?: RequestInit): ConvexCall {
   const requestUrl = typeof input === "string"
     ? input
     : input instanceof URL
@@ -371,7 +372,10 @@ describe("resume submit route", () => {
 
       const statusResponse = await app.request("/api/search-profiles/51job-cn-cnc-sales/status");
       expect(statusResponse.status).toBe(200);
-      const statusBody = await statusResponse.json();
+      const statusBody = await parseJsonBody<{
+        success: unknown;
+        status: { taskId: string; completedAt: string };
+      }>(statusResponse);
       expect(statusBody).toMatchObject({
         success: true,
         status: {

--- a/apps/api/src/routes/resumes-backup.test.ts
+++ b/apps/api/src/routes/resumes-backup.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createApp } from "../app";
+import { parseJsonBody } from "../test-utils";
 import { createAuthContext } from "./test-auth-helpers";
 
 type ConvexCall = {
@@ -13,7 +14,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): ConvexCall {
+function parseConvexCall(input: Request | string | URL, init?: RequestInit): ConvexCall {
   const requestUrl = typeof input === "string"
     ? input
     : input instanceof URL
@@ -150,7 +151,7 @@ describe("resume backup and reset routes", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-disposition")).toMatch(/^attachment; filename="resume-backup-.+\.json"$/);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ metadata: Record<string, unknown>; resumes: unknown[] }>(response);
     expect(payload.metadata.generatedBy).toBe("trends-api backup");
     expect(payload.metadata.totalResumes).toBe(1);
     expect(payload.resumes).toHaveLength(1);
@@ -288,9 +289,9 @@ describe("resume backup and reset routes", () => {
     });
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ metadata: Record<string, unknown>; resumes: { name: string }[] }>(response);
     expect(payload.metadata.totalResumes).toBe(2);
-    expect(payload.resumes.map((item: { name: string }) => item.name)).toEqual(["Alice", "Bob"]);
+    expect(payload.resumes.map((item) => item.name)).toEqual(["Alice", "Bob"]);
     expect(calls).toHaveLength(3);
   });
 

--- a/apps/api/src/routes/resumes-export.test.ts
+++ b/apps/api/src/routes/resumes-export.test.ts
@@ -16,7 +16,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): ConvexCall {
+function parseConvexCall(input: Request | string | URL, init?: RequestInit): ConvexCall {
   const requestUrl = typeof input === "string"
     ? input
     : input instanceof URL
@@ -481,7 +481,10 @@ describe("resume export route", () => {
     });
 
     const workbook = new ExcelJS.Workbook();
-    await workbook.xlsx.load(Buffer.from(await response.arrayBuffer()));
+    // exceljs load() accepts the ArrayBuffer directly (same as production
+    // feedback-import-service.ts); avoids the @types/node-25 Buffer-generic
+    // mismatch that Buffer.from() introduces.
+    await workbook.xlsx.load(await response.arrayBuffer());
     const sheet = workbook.getWorksheet("Resumes");
     const brandHitsColumn = findColumnIndex(sheet, "Brand Hits");
     const aiScoreColumn = findColumnIndex(sheet, "AI Score");

--- a/apps/api/src/routes/resumes.search-integration.test.ts
+++ b/apps/api/src/routes/resumes.search-integration.test.ts
@@ -19,6 +19,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createApp } from "../app";
+import { parseJsonBody } from "../test-utils";
 import { createAuthContext } from "./test-auth-helpers";
 
 // ── Helpers ────────────────────────────────────────────────────────────
@@ -32,7 +33,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): ConvexCall {
+function parseConvexCall(input: Request | string | URL, init?: RequestInit): ConvexCall {
     const requestURL = typeof input === "string"
         ? input
         : input instanceof URL
@@ -185,7 +186,7 @@ describe("BFF search dispatcher integration", () => {
             const response = await app.request("/api/resumes?source=convex&q=CNC%20销售&limit=5");
 
             expect(response.status).toBe(200);
-            const payload = await response.json();
+            const payload = await parseJsonBody<{ success: unknown; summary: Record<string, unknown> }>(response);
             expect(payload.success).toBe(true);
             expect(payload.summary.source).toBe("convex");
 
@@ -273,7 +274,7 @@ describe("BFF search dispatcher integration", () => {
             const response = await app.request("/api/resumes?source=convex&q=CNC%20销售&limit=5");
             expect(response.status).toBe(200);
 
-            const payload = await response.json();
+            const payload = await parseJsonBody<{ success: unknown; data: unknown[] }>(response);
             expect(payload.success).toBe(true);
             expect(payload.data).toHaveLength(0);
         });
@@ -423,7 +424,7 @@ describe("BFF search dispatcher integration", () => {
             );
 
             expect(response.status).toBe(200);
-            const payload = await response.json();
+            const payload = await parseJsonBody<{ success: unknown }>(response);
             expect(payload.success).toBe(true);
 
             expect(calls.some((c) => c.pathName === "resumes_search:scanResumeDigestPage")).toBe(true);
@@ -477,7 +478,7 @@ describe("BFF search dispatcher integration", () => {
             );
 
             expect(response.status).toBe(200);
-            const payload = await response.json();
+            const payload = await parseJsonBody<{ success: unknown; data: { name: string }[] }>(response);
             expect(payload.success).toBe(true);
             expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["r1"]);
         });

--- a/apps/api/src/routes/resumes.test.ts
+++ b/apps/api/src/routes/resumes.test.ts
@@ -5,6 +5,7 @@ import { MatchStorage, type StoredMatch } from "../services/match-storage";
 import { ResumeService } from "../services/resume-service";
 import { SessionManager } from "../services/session-manager";
 import { logger } from "../services/logger";
+import { parseJsonBody } from "../test-utils";
 import { createAuthContext } from "./test-auth-helpers";
 
 type ConvexCall = {
@@ -17,7 +18,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function parseConvexCall(
-  input: RequestInfo | URL,
+  input: Request | string | URL,
   init?: RequestInit,
   expectedEndpoint?: "/api/query" | "/api/mutation" | "/api/action",
 ): ConvexCall {
@@ -66,9 +67,11 @@ function convexSuccess(value: unknown): Response {
   );
 }
 
-function createTestApp(authContext = createAuthContext({ workspaceSlug: "dev", role: "admin" })) {
+function createTestApp(
+  authContext: ReturnType<typeof createAuthContext> | null = createAuthContext({ workspaceSlug: "dev", role: "admin" }),
+) {
   return createApp({
-    authContext,
+    authContext: authContext ?? undefined,
   });
 }
 
@@ -352,7 +355,7 @@ describe("resume routes", () => {
     const response = await app.request("/api/resumes?source=convex&q=CNC%20%E9%94%80%E5%94%AE&limit=5");
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ success: unknown; summary: Record<string, unknown>; data: unknown[] }>(response);
     expect(payload.success).toBe(true);
     expect(payload.summary.source).toBe("convex");
     expect(payload.summary.keywordGroups).toEqual(
@@ -453,7 +456,7 @@ describe("resume routes", () => {
     });
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ summary: Record<string, unknown> }>(response);
     expect(payload.summary.statusCounts).toMatchObject({
       new: 1,
       shortlisted: 0,
@@ -546,7 +549,7 @@ describe("resume routes", () => {
     });
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ summary: Record<string, unknown>; data: unknown[] }>(response);
     expect(payload.summary.total).toBe(1);
     expect(payload.summary.returned).toBe(1);
     expect(payload.summary.statusCounts).toMatchObject({
@@ -594,7 +597,7 @@ describe("resume routes", () => {
     });
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ summary: Record<string, unknown> }>(response);
     expect(payload.summary.statusCounts).toBeUndefined();
     expect(calls).toEqual([
       expect.objectContaining({
@@ -674,7 +677,7 @@ describe("resume routes", () => {
     );
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ success: unknown; summary: Record<string, unknown> }>(response);
     expect(payload.success).toBe(true);
     expect(payload.summary.statusCounts).toBeUndefined();
     expect(calls.map((call) => call.pathName)).toEqual([
@@ -838,7 +841,7 @@ describe("resume routes", () => {
     });
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ query: Record<string, unknown>; results: unknown[] }>(response);
     expect(payload.query).toEqual(
       expect.objectContaining({
         source: "convex",
@@ -904,7 +907,7 @@ describe("resume routes", () => {
     const response = await app.request("/api/resumes?source=convex&limit=2&offset=2");
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ success: unknown; summary: Record<string, unknown>; data: { name: string; ingestData?: unknown }[] }>(response);
     expect(payload.success).toBe(true);
     expect(payload.summary).toEqual(expect.objectContaining({
       total: 4,
@@ -964,7 +967,7 @@ describe("resume routes", () => {
     const response = await app.request("/api/resumes?source=convex&q=cnc%20sales&limit=2&offset=2");
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ success: unknown; summary: Record<string, unknown>; data: { name: string }[] }>(response);
     expect(payload.success).toBe(true);
     expect(payload.summary).toEqual(expect.objectContaining({
       total: 4,
@@ -1014,7 +1017,7 @@ describe("resume routes", () => {
     const response = await app.request("/api/resumes?source=convex&q=cnc%20sales&limit=2&offset=2&sortBy=name&sortOrder=desc");
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody(response);
     expect(payload.success).toBe(true);
     expect(calls[0]).toEqual(expect.objectContaining({
       pathName: "resumes_search:scanResumeDigestPage",
@@ -1094,7 +1097,7 @@ describe("resume routes", () => {
     );
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ success: unknown; summary: Record<string, unknown>; data: { name: string }[] }>(response);
     expect(payload.success).toBe(true);
     expect(payload.summary).toEqual(expect.objectContaining({
       total: 2,
@@ -1160,7 +1163,7 @@ describe("resume routes", () => {
     // AND-mode now uses scanResumeDigestPage instead of the action
     expect(calls.some((c) => c.pathName === "resumes_search:scanResumeDigestPage")).toBe(true);
     // Required keywords are applied as local filters in BFF AND-mode path
-    const payload = await response.json();
+    const payload = await parseJsonBody(response);
     expect(payload.success).toBe(true);
   });
 
@@ -1188,7 +1191,7 @@ describe("resume routes", () => {
     const response = await app.request("/api/resumes?source=convex&limit=2&offset=2&locations=%E4%B8%9C%E8%8E%9E&requiredKeywords=CNC");
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ success: unknown; data: { name: string }[] }>(response);
     expect(payload.success).toBe(true);
     expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Carla", "Dylan"]);
     expect(calls[0]).toEqual(expect.objectContaining({
@@ -1221,7 +1224,7 @@ describe("resume routes", () => {
     const response = await app.request("/api/resumes?source=convex&limit=2&offset=2&sortBy=experience");
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody(response);
     expect(payload.success).toBe(true);
     expect(calls[0]).toEqual(expect.objectContaining({
       pathName: "resumes:listWithIngestDataPage",
@@ -1277,7 +1280,7 @@ describe("resume routes", () => {
     );
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ success: unknown; summary: Record<string, unknown>; data: { name: string }[] }>(response);
     expect(payload.success).toBe(true);
     expect(payload.summary).toEqual(expect.objectContaining({
       total: 2,
@@ -1350,7 +1353,7 @@ describe("resume routes", () => {
     );
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ success: unknown; summary: Record<string, unknown>; data: { name: string }[] }>(response);
     expect(payload.success).toBe(true);
     expect(payload.summary).toEqual(expect.objectContaining({
       total: 2,
@@ -1403,7 +1406,7 @@ describe("resume routes", () => {
     const response = await app.request("/api/resumes?source=convex&limit=1&offset=1&sortBy=score&jobDescriptionId=jd-1&q=cnc%20sales");
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ success: unknown; summary: Record<string, unknown>; data: { name: string }[] }>(response);
     expect(payload.success).toBe(true);
     expect(payload.summary).toEqual(expect.objectContaining({
       total: 2,
@@ -1460,7 +1463,7 @@ describe("resume routes", () => {
     const response = await app.request("/api/resumes?source=convex&limit=2&sortBy=score&jobDescriptionId=jd-1&q=cnc%20sales");
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ success: unknown; data: { name: string }[] }>(response);
     expect(payload.success).toBe(true);
     expect(payload.data.map((item: { name: string }) => item.name)).toEqual(["Carla", "Alice"]);
     expect(getMatchesPageSpy).not.toHaveBeenCalled();
@@ -1576,7 +1579,7 @@ describe("resume routes", () => {
     const response = await app.request("/api/resumes?source=convex&limit=2&sortBy=score&jobDescriptionId=jd-1&q=cnc%20sales");
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ success: unknown; summary: Record<string, unknown>; data: { name: string }[] }>(response);
     expect(payload.success).toBe(true);
     expect(payload.summary).toEqual(expect.objectContaining({
       total: 2,
@@ -1635,7 +1638,7 @@ describe("resume routes", () => {
     );
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ success: unknown; summary: Record<string, unknown>; data: { name: string }[] }>(response);
     expect(payload.success).toBe(true);
     expect(payload.summary).toEqual(expect.objectContaining({
       total: 3,
@@ -1688,7 +1691,7 @@ describe("resume routes", () => {
     const response = await app.request("/api/resumes?source=convex&limit=2&offset=2&sortBy=score&jobDescriptionId=jd-1");
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ success: unknown; summary: Record<string, unknown>; data: { name: string }[] }>(response);
     expect(payload.success).toBe(true);
     expect(payload.summary).toEqual(expect.objectContaining({
       total: 4,
@@ -1743,7 +1746,7 @@ describe("resume routes", () => {
     const response = await app.request("/api/resumes?source=convex&limit=2&jobDescriptionId=jd-1&minMatchScore=70");
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ success: unknown; summary: Record<string, unknown>; data: { name: string }[] }>(response);
     expect(payload.success).toBe(true);
     expect(payload.summary).toEqual(expect.objectContaining({
       total: 2,
@@ -1806,7 +1809,7 @@ describe("resume routes", () => {
     );
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ success: unknown; summary: Record<string, unknown>; data: { name: string }[] }>(response);
     expect(payload.success).toBe(true);
     expect(payload.summary).toEqual(expect.objectContaining({
       total: 2,
@@ -2102,7 +2105,7 @@ describe("resume routes", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: unknown; data: { summary?: string; keyFactors: unknown[]; scrubbedFields?: unknown[]; protectedAttributesExcluded?: unknown } }>(response);
       expect(payload.success).toBe(true);
       expect(payload.data.summary).toBe("Candidate scored 85/100 for CNC operator role.");
       expect(payload.data.keyFactors.length).toBe(2);
@@ -2124,7 +2127,7 @@ describe("resume routes", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.success).toBe(true);
       expect(payload.data).toBeNull();
     });
@@ -2155,7 +2158,7 @@ describe("resume routes", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.success).toBe(true);
       expect(payload.data).toBeNull();
       expect(loggerWarnSpy).toHaveBeenCalledWith(
@@ -2173,7 +2176,7 @@ describe("resume routes", () => {
       });
 
       expect(response.status).toBe(400);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.success).toBe(false);
     });
 
@@ -2186,7 +2189,7 @@ describe("resume routes", () => {
       });
 
       expect(response.status).toBe(400);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.success).toBe(false);
     });
 
@@ -2237,7 +2240,7 @@ describe("resume routes", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: unknown; data: unknown[] }>(response);
       expect(payload.success).toBe(true);
       expect(payload.data.length).toBe(2);
     });
@@ -2259,7 +2262,7 @@ describe("resume routes", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ data: unknown[] }>(response);
       expect(payload.data.length).toBe(1);
     });
 
@@ -2302,7 +2305,7 @@ describe("resume routes", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ data: unknown[] }>(response);
       expect(payload.data.length).toBe(1);
     });
 
@@ -2335,7 +2338,7 @@ describe("resume routes", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.success).toBe(true);
     });
 

--- a/apps/api/src/routes/resumes_admin.test.ts
+++ b/apps/api/src/routes/resumes_admin.test.ts
@@ -6,6 +6,7 @@ import { createAuthMiddleware } from "../middleware/auth";
 import { workspaceMiddleware } from "../middleware/workspace";
 import type { AuthStorage } from "../services/auth-storage";
 import { resetResumeScreeningDb } from "../services/database";
+import { parseJsonBody } from "../test-utils";
 import { createAuthHeaders } from "./test-auth-helpers";
 
 vi.mock("../services/notification-service", () => ({
@@ -60,7 +61,7 @@ describe("resumes_admin", () => {
       });
 
       expect(response.status).toBe(403);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.error).toContain("Admin access");
     });
   });
@@ -102,7 +103,7 @@ describe("resumes_admin", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.success).toBe(true);
       expect(payload.dryRun).toBe(true);
       expect(payload.wouldClear).toBe(42);
@@ -135,7 +136,7 @@ describe("resumes_admin", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.success).toBe(true);
       expect(payload.dryRun).toBe(true);
       expect(payload.jobDescriptionId).toBe("jd-1");
@@ -168,7 +169,7 @@ describe("resumes_admin", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: boolean; dryRun: boolean; wouldDelete: Record<string, unknown> }>(response);
       expect(payload.success).toBe(true);
       expect(payload.dryRun).toBe(true);
       expect(payload.wouldDelete.resumes).toBe(100);
@@ -194,7 +195,7 @@ describe("resumes_admin", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.archived).toBe(2);
       expect(payload.requested).toBe(2);
     });
@@ -217,7 +218,7 @@ describe("resumes_admin", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.unarchived).toBe(1);
     });
 
@@ -256,7 +257,7 @@ describe("resumes_admin", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.success).toBe(true);
       expect(payload.results).toBeDefined();
     });
@@ -270,7 +271,7 @@ describe("resumes_admin", () => {
       });
 
       expect(response.status).toBe(400);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.success).toBe(false);
     });
   });
@@ -322,7 +323,7 @@ describe("resumes_admin", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.success).toBe(true);
       expect(payload.notified).toBe(false);
       expect(payload.reason).toContain("No active anomaly alerts");
@@ -347,7 +348,7 @@ describe("resumes_admin", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: boolean; notified: boolean; channels: Record<string, unknown>[] }>(response);
       expect(payload.success).toBe(true);
       expect(payload.notified).toBe(true);
       expect(payload.channels).toHaveLength(1);

--- a/apps/api/src/routes/resumes_diagnostics.test.ts
+++ b/apps/api/src/routes/resumes_diagnostics.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import resumesDiagnosticsRoutes from "./resumes_diagnostics";
 import { workspaceMiddleware } from "../middleware/workspace";
 import { createAuthContext } from "./test-auth-helpers";
+import { parseJsonBody } from "../test-utils";
 
 function createTestApp() {
   const app = new OpenAPIHono();
@@ -67,7 +68,7 @@ describe("resumes_diagnostics", () => {
       const response = await app.request("/api/resumes/analysis-tasks");
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: unknown; tasks: { _id: string; status: string }[] }>(response);
       expect(payload.success).toBe(true);
       expect(payload.tasks).toHaveLength(2);
       expect(payload.tasks[0]._id).toBe("task-1");
@@ -82,7 +83,7 @@ describe("resumes_diagnostics", () => {
       const response = await app.request("/api/resumes/analysis-tasks");
 
       expect(response.status).toBe(500);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: unknown; error: string }>(response);
       expect(payload.success).toBe(false);
       expect(payload.error).toContain("Convex timeout");
     });
@@ -94,7 +95,7 @@ describe("resumes_diagnostics", () => {
       const response = await app.request("/api/resumes/skills-version");
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: unknown; version: number }>(response);
       expect(payload.success).toBe(true);
       expect(typeof payload.version).toBe("number");
     });
@@ -117,7 +118,7 @@ describe("resumes_diagnostics", () => {
       const response = await app.request("/api/resumes/field-coverage");
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: unknown; scanned: number; missingSearchText: number }>(response);
       expect(payload.success).toBe(true);
       expect(payload.scanned).toBe(200);
       expect(payload.missingSearchText).toBe(10);
@@ -151,7 +152,7 @@ describe("resumes_diagnostics", () => {
       const response = await app.request("/api/resumes/field-coverage");
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ scanned: number; missingSearchText: number }>(response);
       expect(payload.scanned).toBe(300);
       expect(payload.missingSearchText).toBe(12);
       expect(callCount).toBe(2);
@@ -172,7 +173,7 @@ describe("resumes_diagnostics", () => {
       const response = await app.request("/api/resumes/diagnostics");
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: unknown; summary: Record<string, unknown>; data: { resumeId: string }[] }>(response);
       expect(payload.success).toBe(true);
       expect(payload.summary.archived).toBe(false);
       expect(payload.data).toHaveLength(1);
@@ -195,7 +196,7 @@ describe("resumes_diagnostics", () => {
       const response = await app.request("/api/resumes/diagnostics?archived=true&sourceKey=seek");
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: unknown }>(response);
       expect(payload.success).toBe(true);
       expect(calls[0].path).toBe("resumes_diagnostics:listArchivedDiagnostics");
     });

--- a/apps/api/src/routes/resumes_import.test.ts
+++ b/apps/api/src/routes/resumes_import.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import resumesImportRoutes from "./resumes_import";
 import { workspaceMiddleware } from "../middleware/workspace";
 import { createAuthContext } from "./test-auth-helpers";
+import { parseJsonBody } from "../test-utils";
 
 function createTestApp(input: { workspaceSlug?: string; role?: "user" | "admin" } = {}) {
   const app = new OpenAPIHono();
@@ -50,7 +51,7 @@ describe("resumes_import", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: unknown }>(response);
       expect(payload.success).toBe(true);
     });
 
@@ -69,7 +70,7 @@ describe("resumes_import", () => {
       });
 
       expect(response.status).toBe(403);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ error: unknown }>(response);
       expect(payload.error).toContain("Admin access");
     });
   });
@@ -84,7 +85,7 @@ describe("resumes_import", () => {
       });
 
       expect(response.status).toBe(400);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: unknown }>(response);
       expect(payload.success).toBe(false);
     });
   });
@@ -108,7 +109,7 @@ describe("resumes_import", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ metadata: Record<string, unknown>; resumes: unknown[] }>(response);
       expect(payload.metadata).toBeDefined();
       expect(payload.metadata.version).toBe("2");
       expect(Array.isArray(payload.resumes)).toBe(true);

--- a/apps/api/src/routes/resumes_match.test.ts
+++ b/apps/api/src/routes/resumes_match.test.ts
@@ -3,10 +3,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import resumesMatchRoutes from "./resumes_match";
 import { workspaceMiddleware } from "../middleware/workspace";
-import { MatchStorage } from "../services/match-storage";
+import { MatchStorage, type StoredMatch } from "../services/match-storage";
 import { SessionManager } from "../services/session-manager";
 import type { AuthContext } from "../services/auth-types";
 import { createAuthContext } from "./test-auth-helpers";
+import { parseJsonBody } from "../test-utils";
 
 function createTestApp(authContext: AuthContext | null = createAuthContext({ workspaceSlug: "dev", role: "user" })) {
   const app = new OpenAPIHono();
@@ -21,17 +22,16 @@ function createTestApp(authContext: AuthContext | null = createAuthContext({ wor
   return app;
 }
 
-function makeStoredMatch(overrides: Partial<{ resumeId: string; score: number; scoreSource: "rule" | "ai"; jobDescriptionId: string }> = {}) {
+function makeStoredMatch(overrides: Partial<{ resumeId: string; score: number; scoreSource: "rule" | "ai"; jobDescriptionId: string }> = {}): StoredMatch {
   return {
     id: 1,
     resumeId: overrides.resumeId ?? "r1",
     jobDescriptionId: overrides.jobDescriptionId ?? "jd1",
     score: overrides.score ?? 85,
-    recommendation: "strong" as const,
+    recommendation: "strong_match",
     highlights: ["5 years CNC experience"],
     concerns: [],
     summary: "Strong candidate",
-    breakdown: undefined,
     scoreSource: overrides.scoreSource ?? "rule",
     matchedAt: "2026-05-26T12:00:00Z",
   };
@@ -98,7 +98,7 @@ describe("resumes_match", () => {
       });
 
       expect(response.status).toBe(400);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.error).toContain("jobDescriptionId or keywords is required");
     });
 
@@ -115,7 +115,7 @@ describe("resumes_match", () => {
       });
 
       expect(response.status).toBe(400);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.error).toContain("persist=false only supports rules_only mode");
     });
 
@@ -131,7 +131,7 @@ describe("resumes_match", () => {
       });
 
       expect(response.status).toBe(400);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.error).toContain("source=convex only supports persist=false");
     });
 
@@ -151,7 +151,7 @@ describe("resumes_match", () => {
       });
 
       expect(response.status).toBe(404);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.error).toContain("Session not found");
     });
   });
@@ -169,7 +169,7 @@ describe("resumes_match", () => {
       });
 
       expect(response.status).toBe(400);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.error).toContain("match-stream does not support source=convex");
     });
 
@@ -185,7 +185,7 @@ describe("resumes_match", () => {
       });
 
       expect(response.status).toBe(400);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.error).toContain("match-stream does not support persist=false");
     });
 
@@ -198,7 +198,7 @@ describe("resumes_match", () => {
       });
 
       expect(response.status).toBe(400);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.error).toContain("jobDescriptionId or keywords is required");
     });
 
@@ -225,7 +225,7 @@ describe("resumes_match", () => {
       const response = await app.request("/api/resumes/matches");
 
       expect(response.status).toBe(400);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.error).toContain("sessionId or jobDescriptionId is required");
     });
 
@@ -237,7 +237,7 @@ describe("resumes_match", () => {
       const response = await app.request("/api/resumes/matches?sessionId=sess-1");
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: boolean; results: { resumeId: string; score: number }[] }>(response);
       expect(payload.success).toBe(true);
       expect(payload.results).toHaveLength(1);
       expect(payload.results[0].resumeId).toBe("r1");
@@ -252,7 +252,7 @@ describe("resumes_match", () => {
       const response = await app.request("/api/resumes/matches?jobDescriptionId=jd-sales");
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: boolean; results: { jobDescriptionId: string }[] }>(response);
       expect(payload.success).toBe(true);
       expect(payload.results).toHaveLength(1);
       expect(payload.results[0].jobDescriptionId).toBe("jd-sales");
@@ -268,7 +268,7 @@ describe("resumes_match", () => {
       const response = await app.request("/api/resumes/match-runs");
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: boolean; runs: { id: string; status: string }[] }>(response);
       expect(payload.success).toBe(true);
       expect(payload.runs).toHaveLength(1);
       expect(payload.runs[0].id).toBe("run-1");
@@ -296,7 +296,7 @@ describe("resumes_match", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.success).toBe(true);
       expect(payload.deleted).toBe(15);
     });
@@ -311,7 +311,7 @@ describe("resumes_match", () => {
 
       expect(response.status).toBe(200);
       expect(clearSpy).toHaveBeenCalledWith("jd1");
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload.jobDescriptionId).toBe("jd1");
     });
   });

--- a/apps/api/src/routes/resumes_packets.test.ts
+++ b/apps/api/src/routes/resumes_packets.test.ts
@@ -64,7 +64,7 @@ function makeExportResumePayload() {
 function makeEntryContext(overrides: Record<string, unknown> = {}) {
   return {
     resumeId: "r-1",
-    match: 0.85,
+    match: { score: 0.85, recommendation: "strong_match" as const },
     action: "shortlist" as const,
     status: "contacted" as const,
     ruleScore: 0.7,
@@ -198,7 +198,7 @@ describe("normalizeExportResumePayload", () => {
 describe("toExportEntryFields", () => {
   it("extracts entry fields from context", () => {
     const result = toExportEntryFields(makeEntryContext());
-    expect(result.match).toBe(0.85);
+    expect(result.match?.score).toBe(0.85);
     expect(result.action).toBe("shortlist");
     expect(result.status).toBe("contacted");
     expect(result.ruleScore).toBe(0.7);
@@ -244,7 +244,7 @@ describe("toExportEntry", () => {
     const result = toExportEntry("r-1", resume, fields);
     expect(result.key).toBe("r-1");
     expect(result.resume).toBe(resume);
-    expect(result.match).toBe(0.85);
+    expect(result.match?.score).toBe(0.85);
     expect(result.action).toBe("shortlist");
   });
 
@@ -503,6 +503,7 @@ describe("toPublicReviewPacketRun", () => {
           matchedRows: 8,
           importedRows: 8,
           reviewedCount: 7,
+          reviewedResumeIds: ["r1", "r2", "r3", "r4", "r5", "r6", "r7"],
           statusUpdates: 5,
           actionUpdates: 3,
           noteUpdates: 2,

--- a/apps/api/src/routes/resumes_search.test.ts
+++ b/apps/api/src/routes/resumes_search.test.ts
@@ -5,6 +5,7 @@ import resumesSearchRoutes from "./resumes_search";
 import { workspaceMiddleware } from "../middleware/workspace";
 import { ResumeService } from "../services/resume-service";
 import type { AuthContext } from "../services/auth-types";
+import { parseJsonBody } from "../test-utils";
 import { createAuthContext } from "./test-auth-helpers";
 
 function createTestApp(authContext: AuthContext | null = null) {
@@ -35,7 +36,7 @@ describe("resumes_search", () => {
       const response = await app.request("/api/resumes/samples");
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: unknown; samples: { name: string }[] }>(response);
       expect(payload.success).toBe(true);
       expect(payload.samples).toHaveLength(1);
       expect(payload.samples[0].name).toBe("sample-initial");
@@ -48,6 +49,7 @@ describe("resumes_search", () => {
         groups: [],
         mode: "AND",
         flatTerms: ["CNC", "数控"],
+        originalKeyword: "cnc",
         sourceMapping: {},
       });
 
@@ -55,7 +57,7 @@ describe("resumes_search", () => {
       const response = await app.request("/api/resumes/keyword-expansion?q=cnc");
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: unknown; summary: Record<string, unknown> }>(response);
       expect(payload.success).toBe(true);
       expect(payload.summary.keyword).toBe("cnc");
       expect(payload.summary.expandedTo).toContain("CNC");
@@ -68,9 +70,9 @@ describe("ResumesQuerySchema semantic search params", () => {
   it("allows anonymous resume list requests for the hr workspace", async () => {
     vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
       items: [],
-      sample: undefined,
+      sample: { name: "sample-initial", filename: "sample-initial.json", size: 0, updatedAt: "2026-04-01" },
       metadata: undefined,
-      indexes: [],
+      indexes: new Map(),
     });
 
     const app = createTestApp();
@@ -84,9 +86,9 @@ describe("ResumesQuerySchema semantic search params", () => {
   it("rejects anonymous resume list requests without an hr workspace header", async () => {
     vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
       items: [],
-      sample: undefined,
+      sample: { name: "sample-initial", filename: "sample-initial.json", size: 0, updatedAt: "2026-04-01" },
       metadata: undefined,
-      indexes: [],
+      indexes: new Map(),
     });
 
     const app = createTestApp();
@@ -98,9 +100,9 @@ describe("ResumesQuerySchema semantic search params", () => {
   it("rejects anonymous resume list requests for the dev workspace", async () => {
     vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
       items: [],
-      sample: undefined,
+      sample: { name: "sample-initial", filename: "sample-initial.json", size: 0, updatedAt: "2026-04-01" },
       metadata: undefined,
-      indexes: [],
+      indexes: new Map(),
     });
 
     const app = createTestApp();
@@ -114,9 +116,9 @@ describe("ResumesQuerySchema semantic search params", () => {
   it("rejects resume list requests from users outside the selected workspace", async () => {
     vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
       items: [],
-      sample: undefined,
+      sample: { name: "sample-initial", filename: "sample-initial.json", size: 0, updatedAt: "2026-04-01" },
       metadata: undefined,
-      indexes: [],
+      indexes: new Map(),
     });
 
     const app = createTestApp(createAuthContext({ workspaceSlug: "hr", role: "user" }));
@@ -130,9 +132,9 @@ describe("ResumesQuerySchema semantic search params", () => {
   it("accepts enableSemantic parameter", async () => {
     vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
       items: [],
-      sample: undefined,
+      sample: { name: "sample-initial", filename: "sample-initial.json", size: 0, updatedAt: "2026-04-01" },
       metadata: undefined,
-      indexes: [],
+      indexes: new Map(),
     });
 
     const app = createTestApp(createAuthContext({ workspaceSlug: "dev", role: "user" }));
@@ -144,9 +146,9 @@ describe("ResumesQuerySchema semantic search params", () => {
   it("accepts semanticWeight parameter", async () => {
     vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
       items: [],
-      sample: undefined,
+      sample: { name: "sample-initial", filename: "sample-initial.json", size: 0, updatedAt: "2026-04-01" },
       metadata: undefined,
-      indexes: [],
+      indexes: new Map(),
     });
 
     const app = createTestApp(createAuthContext({ workspaceSlug: "dev", role: "user" }));
@@ -158,9 +160,9 @@ describe("ResumesQuerySchema semantic search params", () => {
   it("accepts semanticLimit parameter", async () => {
     vi.spyOn(ResumeService.prototype, "loadSample").mockReturnValue({
       items: [],
-      sample: undefined,
+      sample: { name: "sample-initial", filename: "sample-initial.json", size: 0, updatedAt: "2026-04-01" },
       metadata: undefined,
-      indexes: [],
+      indexes: new Map(),
     });
 
     const app = createTestApp(createAuthContext({ workspaceSlug: "dev", role: "user" }));

--- a/apps/api/src/test-utils.ts
+++ b/apps/api/src/test-utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared test utilities for apps/api route/service tests.
+ *
+ * `parseJsonBody` centralizes the single audited cast over `Response.json()`,
+ * which returns `unknown` under `@types/node` (undici) types. Route tests read
+ * their own mocked JSON responses; rather than sprinkle `as any` (which would
+ * defeat the test-file typecheck gate — see the Q3 phantom-filter blind spot),
+ * the caller declares the expected response shape via `T`.
+ *
+ * Default `T` is `Record<string, unknown>` — the honest type for an untyped
+ * JSON object — which suffices for tests that read only top-level fields
+ * (e.g. `payload.success`, or pass `payload` whole to `expect()`). Tests that
+ * read NESTED fields (e.g. `payload.summary.statusCounts`) must pass an
+ * explicit `T` declaring those nested shapes; `any` is forbidden.
+ */
+export async function parseJsonBody<T = Record<string, unknown>>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}


### PR DESCRIPTION
## What

Second target (T2) of the \`2026-06-16-typecheck-test-files-blindspot\` work item: clean all test-file type errors in the \`routes/resumes*\` cluster (and related resume routes) so the typecheck gate (added in #1285) reports **0** for these files.

Baseline: **551 → 334** total apps/api test-type errors (this PR removes 217).

## Approach — no \`as any\` / \`@ts-ignore\`

A new shared helper \`apps/api/src/test-utils.ts\` → \`parseJsonBody<T>(response)\` centralizes the single audited cast over \`Response.json()\` (which returns \`unknown\` under @types/node undici). Call sites declare real shapes for nested reads; the default \`Record<string, unknown>\` handles top-level reads. This is the Q3-style protection: a wrong field passed to a typed production function still fails the gate.

## Fixes by category

| Category | Count | Fix |
|---|---|---|
| \`TS18046\` response.json → unknown | ~175 | \`parseJsonBody<T>\` with real shapes |
| \`TS2552\` \`RequestInfo\` (DOM type, absent under \`lib:ES2022\`) | 6 | fetch-mock helper uses \`Request \| string \| URL\` (Node-undici equiv) |
| Category-b **mock-shape drift** (the valuable catches) | several | fix the mock to match the real production type |
| \`TS2322\`/\`TS2345\` @types/node-25 lib artifacts | 2 | pass the raw value the lib accepts |

### Category-b findings (these are exactly what the gate is for)
- **resumes_search**: \`loadSample\` mock returned \`sample: undefined\` + \`indexes: []\` — now returns a real \`ResumeSampleFile\` + \`new Map()\` (matches \`ResumeService.loadSample\` return type). \`expandSearchQuery\` mock now includes the required \`originalKeyword\`.
- **resumes_match**: \`recommendation: \"strong\"\` → \`\"strong_match\"\` (the real \`MatchingResult\` union).
- **resumes_packets**: \`match\` mock was a bare number \`0.85\`; the type is \`{ score, recommendation }\`. Now provides the real object; assertion checks \`match.score\`. \`ReviewPacketImportStats\` mock adds the required \`reviewedResumeIds\`.
- **resumes-packets-route**: wrong import path \`../types/resume.js\` → \`../../types/resume\` (file lives in \`routes/__tests__/\`).

### Lib artifacts
- \`resumes-export\`: pass raw \`ArrayBuffer\` to \`exceljs.load()\` (matches production \`feedback-import-service.ts\`), avoiding the @types/node-25 \`Buffer<ArrayBufferLike>\` generic mismatch.
- \`manual-resume-import\`: \`zip.generateAsync({ type: \"arraybuffer\" })\` (was \`uint8array\`) so the result is a valid \`BlobPart\`.

## No production type bug surfaced

All category-b cases were stale **mocks**, not production defects — the production return types are correct.

## Verification

- \`npm --workspace @trends/api run typecheck:tests\` → **0 errors** for every \`routes/*resume*\` file (cluster fully clean).
- Suppression sweep: \`grep -nE \"as any|@ts-ignore|@ts-expect-error\" apps/api/src/routes/*resume*\` → only a documentation mention in \`test-utils.ts\` (explaining what *not* to do).
- \`npm test\` → **299 files / 5656 passed, 7 skipped, 0 failures**.
- \`make check\` → green (gate still report-only; T5 will flip to hard once global count hits 0).

## Remaining (T3–T5)

334 test-type errors remain across the rest of apps/api (industry, scoring-evaluation, admin_users, middleware, auth, services/__tests__, …). T3–T5 continue the batched cleanup using the same \`parseJsonBody\` pattern.