### PR TITLE
test(api): fix admin_users + middleware + auth test-type errors (T4)

### DIFF
--- a/apps/api/src/middleware/rate-limit.test.ts
+++ b/apps/api/src/middleware/rate-limit.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { parseJsonBody } from "../test-utils";
 import { rateLimit } from "./rate-limit.js";
 
 function createRateLimitedApp(limit: number = 5, windowMs: number = 10_000) {
@@ -31,7 +32,7 @@ describe("rateLimit middleware", () => {
     await app.request("/test");
     const res = await app.request("/test");
     expect(res.status).toBe(429);
-    const body = await res.json();
+    const body = await parseJsonBody(res);
     expect(body.success).toBe(false);
     expect(body.error).toContain("Too many requests");
   });

--- a/apps/api/src/middleware/workspace.test.ts
+++ b/apps/api/src/middleware/workspace.test.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 import { formatWorkspaceSlugList, listWorkspaceSlugs } from "@trends/shared";
 
+import { parseJsonBody } from "../test-utils";
 import { workspaceMiddleware } from "./workspace.js";
 import { serverTimingMiddleware } from "./server-timing.js";
 
@@ -25,7 +26,7 @@ describe("workspaceMiddleware", () => {
     const app = createTestApp();
     const res = await app.request("/test");
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = await parseJsonBody(res);
     expect(body.workspaceSlug).toBe("dev");
   });
 
@@ -35,7 +36,7 @@ describe("workspaceMiddleware", () => {
       headers: { "X-Workspace-Slug": "hr" },
     });
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = await parseJsonBody(res);
     expect(body.workspaceSlug).toBe("hr");
   });
 
@@ -43,7 +44,7 @@ describe("workspaceMiddleware", () => {
     const app = createTestApp();
     const res = await app.request("/test?workspaceSlug=hr");
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = await parseJsonBody(res);
     expect(body.workspaceSlug).toBe("hr");
   });
 
@@ -53,7 +54,7 @@ describe("workspaceMiddleware", () => {
       headers: { "X-Workspace-Slug": "dev" },
     });
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = await parseJsonBody(res);
     expect(body.workspaceSlug).toBe("dev");
   });
 
@@ -63,7 +64,7 @@ describe("workspaceMiddleware", () => {
       headers: { "X-Workspace-Slug": "  hr  " },
     });
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = await parseJsonBody(res);
     expect(body.workspaceSlug).toBe("hr");
   });
 
@@ -71,7 +72,7 @@ describe("workspaceMiddleware", () => {
     const app = createTestApp();
     const res = await app.request("/test?workspaceSlug=%20hr%20");
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = await parseJsonBody(res);
     expect(body.workspaceSlug).toBe("hr");
   });
 
@@ -81,7 +82,7 @@ describe("workspaceMiddleware", () => {
       headers: { "X-Workspace-Slug": "invalid-workspace" },
     });
     expect(res.status).toBe(400);
-    const body = await res.json();
+    const body = await parseJsonBody(res);
     expect(body.success).toBe(false);
     expect(body.error).toContain("Invalid workspace slug");
     expect(body.error).toContain(`Allowed: ${formatWorkspaceSlugList()}`);
@@ -93,7 +94,7 @@ describe("workspaceMiddleware", () => {
       headers: { "X-Workspace-Slug": slug },
     });
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = await parseJsonBody(res);
     expect(body.workspaceSlug).toBe(slug);
   });
 });

--- a/apps/api/src/routes/admin_users.test.ts
+++ b/apps/api/src/routes/admin_users.test.ts
@@ -13,6 +13,7 @@ import { AuthStorage } from "../services/auth-storage.js";
 import { config } from "../services/config.js";
 import { resetResumeScreeningDb } from "../services/database.js";
 import { hashPassword, verifyPassword } from "../services/local-password-provider.js";
+import { parseJsonBody } from "../test-utils";
 import { createAdminUserRoutes } from "./admin_users.js";
 
 async function seedLocalUser(storage: AuthStorage, overrides: { username?: string; password?: string; email?: string; workspace?: string; role?: "user" | "admin" } = {}) {
@@ -90,7 +91,7 @@ describe("POST /api/admin/reset-password", () => {
   it("returns 404 when AUTH_ADMIN_RESET_ENABLED is false", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "admin-reset-off-"));
     const storage = new AuthStorage(root);
-    const eventStorage = new AuthEventStorage(storage.db);
+    const eventStorage = new AuthEventStorage(root);
     const devAdmin = await seedDevAdmin(storage);
     await seedLocalUser(storage, { username: "target-user" });
     const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
@@ -111,7 +112,7 @@ describe("POST /api/admin/reset-password", () => {
   it("resets password, revokes sessions, and records event when dev-admin resets a local user", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "admin-reset-ok-"));
     const storage = new AuthStorage(root);
-    const eventStorage = new AuthEventStorage(storage.db);
+    const eventStorage = new AuthEventStorage(root);
     const devAdmin = await seedDevAdmin(storage);
     const target = await seedLocalUser(storage, { username: "target-user", password: "old-pass" });
     const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
@@ -127,7 +128,7 @@ describe("POST /api/admin/reset-password", () => {
     });
 
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = await parseJsonBody<{ success: unknown; temporaryPassword: string }>(res);
     expect(body.success).toBe(true);
     expect(body.temporaryPassword).toEqual(expect.any(String));
     expect(body.temporaryPassword.length).toBeGreaterThanOrEqual(16);
@@ -156,7 +157,7 @@ describe("POST /api/admin/reset-password", () => {
   it("returns 404 with precise message when username has no local identity", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "admin-reset-noid-"));
     const storage = new AuthStorage(root);
-    const eventStorage = new AuthEventStorage(storage.db);
+    const eventStorage = new AuthEventStorage(root);
     const devAdmin = await seedDevAdmin(storage);
     const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
     const session = sessions.createSession(devAdmin.user.id);
@@ -169,7 +170,7 @@ describe("POST /api/admin/reset-password", () => {
     });
 
     expect(res.status).toBe(404);
-    const body = await res.json();
+    const body = await parseJsonBody(res);
     expect(body.error).toContain("No local password identity found");
     expect(body.error).toContain("ghost-user");
   });
@@ -177,7 +178,7 @@ describe("POST /api/admin/reset-password", () => {
   it("returns 404 when target identity is Casdoor-only (not local)", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "admin-reset-casdoor-"));
     const storage = new AuthStorage(root);
-    const eventStorage = new AuthEventStorage(storage.db);
+    const eventStorage = new AuthEventStorage(root);
     const devAdmin = await seedDevAdmin(storage);
     // Seed a Casdoor-only identity (no local provider identity)
     const casdoorUser = storage.createUser({ email: "casdoor@example.com", displayName: "Casdoor User" });
@@ -200,14 +201,14 @@ describe("POST /api/admin/reset-password", () => {
     });
 
     expect(res.status).toBe(404);
-    const body = await res.json();
+    const body = await parseJsonBody(res);
     expect(body.error).toContain("No local password identity found");
   });
 
   it("returns 403 when caller is hr-admin (non-dev workspace)", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "admin-reset-hradmin-"));
     const storage = new AuthStorage(root);
-    const eventStorage = new AuthEventStorage(storage.db);
+    const eventStorage = new AuthEventStorage(root);
     const hrAdmin = await seedLocalUser(storage, { username: "hr-admin", workspace: "hr", role: "admin" });
     await seedLocalUser(storage, { username: "target-user" });
     const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
@@ -228,7 +229,7 @@ describe("POST /api/admin/reset-password", () => {
   it("returns 403 when caller is dev-user (non-admin role)", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "admin-reset-devuser-"));
     const storage = new AuthStorage(root);
-    const eventStorage = new AuthEventStorage(storage.db);
+    const eventStorage = new AuthEventStorage(root);
     const devUser = await seedLocalUser(storage, { username: "dev-user", workspace: "dev", role: "user" });
     await seedLocalUser(storage, { username: "target-user" });
     const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
@@ -247,7 +248,7 @@ describe("POST /api/admin/reset-password", () => {
   it("returns 401 when caller is unauthenticated", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "admin-reset-unauth-"));
     const storage = new AuthStorage(root);
-    const eventStorage = new AuthEventStorage(storage.db);
+    const eventStorage = new AuthEventStorage(root);
     await seedLocalUser(storage, { username: "target-user" });
     const app = createTestApp(storage, eventStorage);
 
@@ -263,7 +264,7 @@ describe("POST /api/admin/reset-password", () => {
   it("does not leak the temporary password in event metadata", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "admin-reset-noleak-"));
     const storage = new AuthStorage(root);
-    const eventStorage = new AuthEventStorage(storage.db);
+    const eventStorage = new AuthEventStorage(root);
     const devAdmin = await seedDevAdmin(storage);
     const target = await seedLocalUser(storage, { username: "target-user" });
     const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
@@ -275,7 +276,7 @@ describe("POST /api/admin/reset-password", () => {
       headers: authHeaders("dev", session),
       body: JSON.stringify({ username: "target-user" }),
     });
-    const body = await res.json();
+    const body = await parseJsonBody<{ temporaryPassword: string }>(res);
 
     const events = eventStorage.listRecent({ limit: 50 });
     const resetEvent = events.find((e) => e.type === "password_reset_completed");
@@ -290,7 +291,7 @@ describe("POST /api/admin/reset-password", () => {
   it("rotates the credential so the old password fails and the temp password works", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "admin-reset-rotate-"));
     const storage = new AuthStorage(root);
-    const eventStorage = new AuthEventStorage(storage.db);
+    const eventStorage = new AuthEventStorage(root);
     const devAdmin = await seedDevAdmin(storage);
     const target = await seedLocalUser(storage, { username: "target-user", password: "old-pass-123" });
     const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
@@ -302,7 +303,7 @@ describe("POST /api/admin/reset-password", () => {
       headers: authHeaders("dev", session),
       body: JSON.stringify({ username: "target-user" }),
     });
-    const body = await res.json();
+    const body = await parseJsonBody<{ temporaryPassword: string }>(res);
     const updated = storage.findPasswordCredential(target.user.id);
 
     expect(await verifyPassword(body.temporaryPassword, updated!)).toBe(true);
@@ -312,7 +313,7 @@ describe("POST /api/admin/reset-password", () => {
   it("returns 400 when dev-admin attempts to reset own password", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "admin-reset-self-"));
     const storage = new AuthStorage(root);
-    const eventStorage = new AuthEventStorage(storage.db);
+    const eventStorage = new AuthEventStorage(root);
     const devAdmin = await seedDevAdmin(storage);
     const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
     const session = sessions.createSession(devAdmin.user.id);
@@ -325,7 +326,7 @@ describe("POST /api/admin/reset-password", () => {
     });
 
     expect(res.status).toBe(400);
-    const body = await res.json();
+    const body = await parseJsonBody(res);
     expect(body.error).toMatch(/change-password/i);
     // No reset happened
     const events = eventStorage.listRecent({ limit: 50 });

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -15,6 +15,7 @@ import { config } from "../services/config.js";
 import { getResumeScreeningDb, resetResumeScreeningDb } from "../services/database.js";
 import { hashPassword } from "../services/local-password-provider.js";
 import { CasdoorOidcProvider } from "../services/oidc-provider.js";
+import { parseJsonBody } from "../test-utils";
 import { createAuthRoutes } from "./auth.js";
 
 // Helper to create app with event storage for event logging tests
@@ -494,7 +495,7 @@ describe("auth routes", () => {
   it("locks out login after 5 rapid failures for the same username from one IP", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "trends-auth-bruteforce-"));
     const storage = new AuthStorage(root);
-    const eventStorage = new AuthEventStorage(storage.db);
+    const eventStorage = new AuthEventStorage(root);
     await seedLocalUser(storage);
     const app = createTestApp(storage, eventStorage);
 
@@ -594,7 +595,7 @@ describe("auth routes", () => {
   it("changePassword revokes all other sessions for the user", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "trends-auth-cp-revoke-"));
     const storage = new AuthStorage(root);
-    const eventStorage = new AuthEventStorage(storage.db);
+    const eventStorage = new AuthEventStorage(root);
     const user = await seedLocalUser(storage);
     const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
 
@@ -629,7 +630,7 @@ describe("auth routes", () => {
   it("revoke-all endpoint revokes all sessions except the caller's current one", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "trends-auth-revoke-all-"));
     const storage = new AuthStorage(root);
-    const eventStorage = new AuthEventStorage(storage.db);
+    const eventStorage = new AuthEventStorage(root);
     const user = await seedLocalUser(storage);
     const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
 
@@ -778,7 +779,7 @@ describe("GET /api/auth/events", () => {
     });
 
     expect(response.status).toBe(200);
-    const body = await response.json();
+    const body = await parseJsonBody<{ success: unknown; events: unknown[] }>(response);
     expect(body.success).toBe(true);
     expect(body.events).toHaveLength(2);
   });


### PR DESCRIPTION
## What

Fourth target (T4) of the \`2026-06-16-typecheck-test-files-blindspot\` work item: clean all test-file type errors in \`routes/admin_users\` (30), \`routes/auth\` (8), and \`middleware/*\` (12).

Baseline: **260 → 210** total apps/api test-type errors (this PR removes 50).

## Fixes

| Category | Count | Fix |
|---|---|---|
| \`TS18046\` response.json → unknown | 24 | shared \`parseJsonBody<T>\` helper |
| Category-b **\`storage.db\` misuse** (the valuable catch) | 20 (10 sites × 2 errors) | see below |

### Category-b: \`AuthEventStorage(storage.db)\` → \`AuthEventStorage(root)\`

The admin_users + auth tests constructed \`new AuthEventStorage(storage.db)\`. Two defects the gate surfaced:
1. **\`TS2341\`** — \`storage.db\` is **private** on \`AuthStorage\`; the test reached into private state to share the DB.
2. **\`TS2345\`** — \`AuthEventStorage\`'s constructor takes \`projectRoot?: string\` (production: \`new AuthEventStorage(config.projectRoot)\`), NOT a \`Database\`. Passing \`storage.db\` would call \`getResumeScreeningDb(<Database>)\` — a latent runtime bug (a DB object interpreted as a path).

Fix: \`new AuthEventStorage(root)\` — matches production semantics. \`AuthStorage(root)\` and \`AuthEventStorage(root)\` both call \`getResumeScreeningDb(root)\`, so they share the same DB. Two independent implementers converged on this exact fix (admin_users + auth), confirming it's correct.

Found in: \`admin_users.test.ts\` (10 sites), \`auth.test.ts\` (3 sites). No production type bug — production constructs \`AuthEventStorage\` correctly; only the tests were stale.

## Verification

- \`typecheck:tests\` → **0 errors** for admin_users, auth, middleware/*.
- Suppression sweep clean (no \`as any\`/\`@ts-ignore\`/\`as never\`).
- \`npm test\` → **299 files / 5656 passed, 7 skipped, 0 failures** (auth + admin_users runtime behavior verified — the \`storage.db\`→\`root\` change is behavior-preserving because both share \`getResumeScreeningDb(root)\`).
- \`make check\` → green.

## Remaining (T5)

210 test-type errors remain across the rest of apps/api (other routes + \`services/__tests__\`). T5 finishes the cleanup and flips the gate to hard-blocking.