### PR TITLE
test(api): finish test-type cleanup + flip typecheck gate hard (T5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1248,10 +1248,10 @@ check-node:
 # (e.g. Q3's minExperience) that the package tsconfig excludes from `tsc`.
 # Wired into check-node. Adds ~10s (the test program re-typechecks apps/api
 # source; composite project references would dedupe but are a separate
-# initiative). Currently REPORT-ONLY: the baseline of latent test type errors
-# is being cleaned up in batches (T2-T5). When that count hits 0, flip the
-# default below to `hard` so new test-file type errors block make check.
-TESTS_TYPES_GATE ?= report-only
+# initiative). HARD-BLOCKING as of T5: the latent test-type error baseline
+# reached 0 (PRs #1285-#1289), so new test-file type errors now fail make
+# check. Override with TESTS_TYPES_GATE=report-only for a non-blocking run.
+TESTS_TYPES_GATE ?= hard
 check-node-tests-types:
 	@echo "Running apps/api test-file typecheck (gate=$(TESTS_TYPES_GATE))..."
 	@mkdir -p logs

--- a/apps/api/src/routes/__tests__/bff-filter-alignment.test.ts
+++ b/apps/api/src/routes/__tests__/bff-filter-alignment.test.ts
@@ -424,7 +424,7 @@ describe("bffMatchesResumeFilters", () => {
       };
 
       expect(matchesResumeDigestFilters(digest, filters)).toBe(true);
-      expect(bffMatchesResumeFilters(doc, digest.searchText, filters)).toBe(true);
+      expect(bffMatchesResumeFilters(doc, digest.searchText ?? "", filters)).toBe(true);
     });
 
     it("normalizes digest roleFilterType before checking verified role years", () => {

--- a/apps/api/src/routes/actions.test.ts
+++ b/apps/api/src/routes/actions.test.ts
@@ -9,6 +9,7 @@ import { ActionStorage } from '../services/action-storage'
 import type { AuthStorage } from '../services/auth-storage'
 import { resetResumeScreeningDb } from '../services/database'
 import { createAuthHeaders } from './test-auth-helpers'
+import { parseJsonBody } from '../test-utils'
 
 function createTestApp(options: { storage?: AuthStorage; eventStorage?: AuthEventStorage } = {}) {
   const app = new OpenAPIHono()
@@ -120,7 +121,7 @@ describe('actions routes', () => {
         }),
       })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: boolean; action: { actionType: string } }>(response)
       expect(body.success).toBe(true)
       expect(body.action.actionType).toBe('star')
       expect(saveSpy).toHaveBeenCalledWith(
@@ -184,7 +185,7 @@ describe('actions routes', () => {
         headers: { 'X-Workspace-Slug': 'dev' },
       })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: boolean; actions: unknown[] }>(response)
       expect(body.success).toBe(true)
       expect(body.actions).toHaveLength(2)
     })

--- a/apps/api/src/routes/ai-summary.test.ts
+++ b/apps/api/src/routes/ai-summary.test.ts
@@ -44,7 +44,7 @@ function convexSuccess(value: unknown): Response {
   )
 }
 
-function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): {
+function parseConvexCall(input: Request | string | URL, init?: RequestInit): {
   method: "query" | "mutation"
   pathName: string
   args: Record<string, unknown>

--- a/apps/api/src/routes/blocks.test.ts
+++ b/apps/api/src/routes/blocks.test.ts
@@ -14,7 +14,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): ConvexCall {
+function parseConvexCall(input: Request | string | URL, init?: RequestInit): ConvexCall {
   const requestUrl = typeof input === 'string'
     ? input
     : input instanceof URL

--- a/apps/api/src/routes/candidate-status.test.ts
+++ b/apps/api/src/routes/candidate-status.test.ts
@@ -5,6 +5,7 @@ import { AuthEventStorage } from "../services/auth-event-storage";
 import { config } from "../services/config";
 import { resetResumeScreeningDb } from "../services/database";
 import { workspaceConfigService } from "../services/workspace-config-service";
+import { parseJsonBody } from "../test-utils";
 import { createAuthHeaders } from "./test-auth-helpers";
 
 type ConvexCall = {
@@ -17,7 +18,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): ConvexCall {
+function parseConvexCall(input: Request | string | URL, init?: RequestInit): ConvexCall {
   const requestUrl = typeof input === "string"
     ? input
     : input instanceof URL
@@ -164,7 +165,7 @@ describe("candidate-status route", () => {
     });
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ success: boolean; item: Record<string, unknown>; learningEntry?: { date: string; observation: string } }>(response);
     expect(payload).toMatchObject({
       success: true,
       item: {
@@ -239,7 +240,7 @@ describe("candidate-status route", () => {
     });
 
     expect(response.status).toBe(200);
-    const payload = await response.json();
+    const payload = await parseJsonBody<{ learningEntry?: { date: string; observation: string } }>(response);
     expect(payload.learningEntry).toEqual({
       date: "2026-03-03",
       observation: "reject_pattern: 经验不匹配 -> interviewed_reject",
@@ -332,7 +333,7 @@ describe("candidate-status route", () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = await response.json();
+      const payload = await parseJsonBody(response);
       expect(payload).toMatchObject({
         success: true,
         status: "appeal_submitted",
@@ -391,7 +392,7 @@ describe("candidate-status route", () => {
       });
 
       expect(response.status).toBe(400);
-      const payload = await response.json();
+      const payload = await parseJsonBody<{ success: boolean }>(response);
       expect(payload.success).toBe(false);
     });
   });

--- a/apps/api/src/routes/config.test.ts
+++ b/apps/api/src/routes/config.test.ts
@@ -10,6 +10,7 @@ import { customKeywordService } from '../services/custom-keyword-service'
 import { resetResumeScreeningDb } from '../services/database'
 import { workspaceConfigService } from '../services/workspace-config-service'
 import { createAuthHeaders } from './test-auth-helpers'
+import { parseJsonBody } from '../test-utils'
 
 function createTestApp(storage?: AuthStorage) {
   const app = new OpenAPIHono()
@@ -460,13 +461,26 @@ describe('config route workspace access', () => {
     })
 
     expect(response.status).toBe(200)
-    const payload = await response.json()
+    const payload = await parseJsonBody<{
+      success: boolean
+      metadata: {
+        identity: { appName: string }
+        navigation: {
+          system: unknown[]
+          systemSettings: unknown[]
+        }
+        labels: {
+          aiBreakdown: Array<{ key: string }>
+        }
+        capabilities: Array<{ id: string }>
+      }
+    }>(response)
     expect(payload.success).toBe(true)
     expect(payload.metadata.identity.appName).toBe('Trends')
     expect(payload.metadata.navigation.system.length).toBeGreaterThan(0)
     expect(payload.metadata.navigation.systemSettings.length).toBeGreaterThan(0)
-    expect(payload.metadata.labels.aiBreakdown.some((item: { key: string }) => item.key === 'industry_db')).toBe(true)
-    expect(payload.metadata.capabilities.some((item: { id: string }) => item.id === 'cli-system-inspect')).toBe(true)
+    expect(payload.metadata.labels.aiBreakdown.some((item) => item.key === 'industry_db')).toBe(true)
+    expect(payload.metadata.capabilities.some((item) => item.id === 'cli-system-inspect')).toBe(true)
   })
 
   it('loads resume display limits payload', async () => {

--- a/apps/api/src/routes/filter-presets.test.ts
+++ b/apps/api/src/routes/filter-presets.test.ts
@@ -5,6 +5,7 @@ import filterPresetsRoutes from './filter-presets'
 import { workspaceMiddleware } from '../middleware/workspace'
 import { workspaceConfigService } from '../services/workspace-config-service'
 import { createAuthContext } from './test-auth-helpers'
+import { parseJsonBody } from '../test-utils'
 
 // dev workspace = admin, hr workspace = user
 function createTestApp() {
@@ -55,42 +56,42 @@ describe('filter-presets routes', () => {
 
   describe('GET /api/filter-presets', () => {
     it('returns all presets', async () => {
-      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS as never)
+      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS)
       const app = createTestApp()
       const response = await app.request('/api/filter-presets', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: unknown; presets: unknown[] }>(response)
       expect(body.success).toBe(true)
       expect(body.presets).toHaveLength(3)
     })
 
     it('filters by category', async () => {
-      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS as never)
+      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS)
       const app = createTestApp()
       const response = await app.request('/api/filter-presets?category=engineering', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ presets: { category: string }[] }>(response)
       expect(body.presets).toHaveLength(2)
       expect(body.presets.every((p: { category: string }) => p.category === 'engineering')).toBe(true)
     })
 
     it('returns empty when category has no presets', async () => {
-      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS as never)
+      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS)
       const app = createTestApp()
       const response = await app.request('/api/filter-presets?category=marketing', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ presets: unknown[] }>(response)
       expect(body.presets).toHaveLength(0)
     })
   })
 
   describe('GET /api/filter-presets/categories', () => {
     it('returns categories', async () => {
-      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS as never)
+      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS)
       const app = createTestApp()
       const response = await app.request('/api/filter-presets/categories', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: unknown; categories: unknown[] }>(response)
       expect(body.success).toBe(true)
       expect(body.categories).toHaveLength(2)
     })
@@ -98,11 +99,11 @@ describe('filter-presets routes', () => {
 
   describe('GET /api/filter-presets/stats', () => {
     it('returns stats with byCategory counts', async () => {
-      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS as never)
+      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS)
       const app = createTestApp()
       const response = await app.request('/api/filter-presets/stats', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: unknown; stats: { total: unknown; byCategory: Record<string, unknown> } }>(response)
       expect(body.success).toBe(true)
       expect(body.stats.total).toBe(3)
       expect(body.stats.byCategory.engineering).toBe(2)
@@ -112,17 +113,17 @@ describe('filter-presets routes', () => {
 
   describe('GET /api/filter-presets/:id', () => {
     it('returns preset by id', async () => {
-      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS as never)
+      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS)
       const app = createTestApp()
       const response = await app.request('/api/filter-presets/senior-engineer', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: unknown; preset: { id: string } }>(response)
       expect(body.success).toBe(true)
       expect(body.preset.id).toBe('senior-engineer')
     })
 
     it('returns 404 for unknown id', async () => {
-      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS as never)
+      vi.spyOn(workspaceConfigService, 'getFilterPresets').mockResolvedValue(MOCK_PRESETS)
       const app = createTestApp()
       const response = await app.request('/api/filter-presets/nonexistent', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(404)
@@ -135,8 +136,8 @@ describe('filter-presets routes', () => {
         presets: [...MOCK_PRESETS.presets],
         categories: [...MOCK_PRESETS.categories],
       }
-      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig as never)
-      vi.spyOn(workspaceConfigService, 'setWorkspaceFilterPresets').mockResolvedValue(undefined as never)
+      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig)
+      vi.spyOn(workspaceConfigService, 'setWorkspaceFilterPresets').mockResolvedValue(undefined)
       const app = createTestApp()
       const response = await app.request('/api/filter-presets', {
         method: 'POST',
@@ -149,7 +150,7 @@ describe('filter-presets routes', () => {
         }),
       })
       expect(response.status).toBe(201)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: unknown; preset: { id: string } }>(response)
       expect(body.success).toBe(true)
       expect(body.preset.id).toBe('lead-engineer')
     })
@@ -174,7 +175,7 @@ describe('filter-presets routes', () => {
         presets: [...MOCK_PRESETS.presets],
         categories: [...MOCK_PRESETS.categories],
       }
-      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig as never)
+      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig)
       const app = createTestApp()
       const response = await app.request('/api/filter-presets', {
         method: 'POST',
@@ -194,8 +195,8 @@ describe('filter-presets routes', () => {
         presets: [...MOCK_PRESETS.presets],
         categories: [...MOCK_PRESETS.categories],
       }
-      const setSpy = vi.spyOn(workspaceConfigService, 'setWorkspaceFilterPresets').mockResolvedValue(undefined as never)
-      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig as never)
+      const setSpy = vi.spyOn(workspaceConfigService, 'setWorkspaceFilterPresets').mockResolvedValue(undefined)
+      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig)
       const app = createTestApp()
       const response = await app.request('/api/filter-presets', {
         method: 'POST',
@@ -219,8 +220,8 @@ describe('filter-presets routes', () => {
         presets: [...MOCK_PRESETS.presets],
         categories: [...MOCK_PRESETS.categories],
       }
-      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig as never)
-      vi.spyOn(workspaceConfigService, 'setWorkspaceFilterPresets').mockResolvedValue(undefined as never)
+      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig)
+      vi.spyOn(workspaceConfigService, 'setWorkspaceFilterPresets').mockResolvedValue(undefined)
       const app = createTestApp()
       const response = await app.request('/api/filter-presets/senior-engineer', {
         method: 'PUT',
@@ -231,7 +232,7 @@ describe('filter-presets routes', () => {
         }),
       })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: unknown; preset: { name: string; id: string } }>(response)
       expect(body.success).toBe(true)
       expect(body.preset.name).toBe('Senior Engineer (Updated)')
       expect(body.preset.id).toBe('senior-engineer')
@@ -252,7 +253,7 @@ describe('filter-presets routes', () => {
         presets: [...MOCK_PRESETS.presets],
         categories: [...MOCK_PRESETS.categories],
       }
-      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig as never)
+      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig)
       const app = createTestApp()
       const response = await app.request('/api/filter-presets/nonexistent', {
         method: 'PUT',
@@ -269,8 +270,8 @@ describe('filter-presets routes', () => {
         presets: [...MOCK_PRESETS.presets],
         categories: [...MOCK_PRESETS.categories],
       }
-      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig as never)
-      const setSpy = vi.spyOn(workspaceConfigService, 'setWorkspaceFilterPresets').mockResolvedValue(undefined as never)
+      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig)
+      const setSpy = vi.spyOn(workspaceConfigService, 'setWorkspaceFilterPresets').mockResolvedValue(undefined)
       const app = createTestApp()
       const response = await app.request('/api/filter-presets/senior-engineer', {
         method: 'DELETE',
@@ -295,7 +296,7 @@ describe('filter-presets routes', () => {
         presets: [...MOCK_PRESETS.presets],
         categories: [...MOCK_PRESETS.categories],
       }
-      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig as never)
+      vi.spyOn(workspaceConfigService, 'getWorkspaceFilterPresets').mockResolvedValue(workspaceConfig)
       const app = createTestApp()
       const response = await app.request('/api/filter-presets/nonexistent', {
         method: 'DELETE',

--- a/apps/api/src/routes/health.test.ts
+++ b/apps/api/src/routes/health.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import healthRoutes from './health'
 import { workspaceMiddleware } from '../middleware/workspace'
+import { parseJsonBody } from '../test-utils'
 
 function createTestApp() {
   const app = new OpenAPIHono()
@@ -22,7 +23,7 @@ describe('health routes', () => {
       headers: { 'X-Workspace-Slug': 'dev' },
     })
     expect(response.status).toBe(200)
-    const body = await response.json()
+    const body = await parseJsonBody<{ status: string; timestamp: string; version: string }>(response)
     expect(body.status).toBe('healthy')
     expect(body.timestamp).toBeTruthy()
     expect(body.version).toBeTruthy()
@@ -33,7 +34,7 @@ describe('health routes', () => {
     const response = await app.request('/health', {
       headers: { 'X-Workspace-Slug': 'dev' },
     })
-    const body = await response.json()
+    const body = await parseJsonBody<{ status: string; timestamp: string; version: string }>(response)
     expect(typeof body.version).toBe('string')
     expect(body.version.length).toBeGreaterThan(0)
   })
@@ -43,7 +44,7 @@ describe('health routes', () => {
     const response = await app.request('/health', {
       headers: { 'X-Workspace-Slug': 'dev' },
     })
-    const body = await response.json()
+    const body = await parseJsonBody<{ status: string; timestamp: string }>(response)
     expect(body.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/)
   })
 })

--- a/apps/api/src/routes/notifications.test.ts
+++ b/apps/api/src/routes/notifications.test.ts
@@ -10,6 +10,7 @@ import { workspaceMiddleware } from '../middleware/workspace'
 import type { AuthStorage } from '../services/auth-storage'
 import { resetResumeScreeningDb } from '../services/database'
 import { createAuthHeaders } from './test-auth-helpers'
+import { parseJsonBody } from '../test-utils'
 
 let defaultAuthHeaders: Record<string, string> = {}
 
@@ -61,7 +62,7 @@ describe('notifications routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/notifications/templates')
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ templates: { id: string }[] }>(response)
       expect(body.templates).toHaveLength(2)
       expect(body.templates[0].id).toBe('outreach-email')
     })
@@ -70,7 +71,7 @@ describe('notifications routes', () => {
       vi.spyOn(notificationTemplateService, 'listTemplates').mockReturnValue(MOCK_TEMPLATES as never)
       const app = createTestApp()
       const response = await app.request('/api/notifications/templates')
-      const body = await response.json()
+      const body = await parseJsonBody<{ templates: { id: string }[] }>(response)
       expect(body.templates[0]).not.toHaveProperty('body')
     })
   })
@@ -91,7 +92,7 @@ describe('notifications routes', () => {
         body: JSON.stringify(validDraft),
       })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody(response)
       expect(body.subject).toBe('Opportunity at TestCo')
     })
 
@@ -104,7 +105,7 @@ describe('notifications routes', () => {
         body: JSON.stringify(validDraft),
       })
       expect(response.status).toBe(500)
-      const body = await response.json()
+      const body = await parseJsonBody(response)
       expect(body.error).toBe('AI unavailable')
     })
 
@@ -129,7 +130,7 @@ describe('notifications routes', () => {
         body: JSON.stringify({ channel: 'email', templateId: 'outreach-email', data: {} }),
       })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody(response)
       expect(body.channel).toBe('email')
       expect(body.html).toContain('<pre')
       expect(body.markdown).toContain('New match')
@@ -144,7 +145,7 @@ describe('notifications routes', () => {
         body: JSON.stringify({ channel: 'feishu', templateId: 'outreach-email', data: {} }),
       })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody(response)
       expect(body.channel).toBe('feishu')
       expect(body.content).toContain('New match')
       expect(body).not.toHaveProperty('html')
@@ -174,7 +175,7 @@ describe('notifications routes', () => {
         body: JSON.stringify({ to: 'test@example.com', subject: 'Hello', body: '<p>Hi</p>' }),
       })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody(response)
       expect(body.success).toBe(true)
       expect(body.messageId).toBe('msg-123')
     })
@@ -212,7 +213,7 @@ describe('notifications routes', () => {
         body: JSON.stringify({ channel: 'email', templateId: 'outreach-email', to: 'test@example.com', data: {} }),
       })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody(response)
       expect(body.success).toBe(true)
       expect(body.channel).toBe('email')
       expect(body.messageId).toBe('msg-456')
@@ -228,7 +229,7 @@ describe('notifications routes', () => {
         body: JSON.stringify({ channel: 'wechat_work', templateId: 'match-alert', data: {} }),
       })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody(response)
       expect(body.success).toBe(true)
       expect(body.channel).toBe('wechat_work')
     })
@@ -243,7 +244,7 @@ describe('notifications routes', () => {
         body: JSON.stringify({ channel: 'feishu', templateId: 'match-alert', data: {} }),
       })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody(response)
       expect(body.success).toBe(true)
       expect(body.channel).toBe('feishu')
     })

--- a/apps/api/src/routes/review-packets.test.ts
+++ b/apps/api/src/routes/review-packets.test.ts
@@ -265,7 +265,6 @@ describe("review packet routes", () => {
       totalCount: 2,
       packetFilename: "packet-summary.xlsx",
       exportedAt: "2026-03-20T09:00:00+08:00",
-      feedbackImportedAt: "2026-03-20T10:00:00+08:00",
       items: [
         { resumeId: "resume-1", identityKey: "id-1", name: "Alice" },
         { resumeId: "resume-2", identityKey: "id-2", name: "Bob" },

--- a/apps/api/src/routes/rss.test.ts
+++ b/apps/api/src/routes/rss.test.ts
@@ -5,6 +5,7 @@ import rssRoutes from './rss'
 import { workspaceMiddleware } from '../middleware/workspace'
 import { DataService } from '../services/data-service'
 import { DataNotFoundError } from '../services/errors'
+import { parseJsonBody } from '../test-utils'
 
 function createTestApp() {
   const app = new OpenAPIHono()
@@ -16,8 +17,8 @@ function createTestApp() {
 const ADMIN_HEADERS = { 'X-Workspace-Slug': 'dev' }
 
 const MOCK_RSS_ITEMS = [
-  { title: 'Industry Update', feed: '36kr', publishedAt: '2026-05-22T10:00:00Z', url: 'https://example.com/1' },
-  { title: 'Tech News', feed: 'ithome', publishedAt: '2026-05-22T09:00:00Z', url: 'https://example.com/2' },
+  { title: 'Industry Update', feed_id: '36kr', feed_name: '36氪', published_at: '2026-05-22T10:00:00Z', url: 'https://example.com/1' },
+  { title: 'Tech News', feed_id: 'ithome', feed_name: 'IT之家', published_at: '2026-05-22T09:00:00Z', url: 'https://example.com/2' },
 ]
 
 describe('rss routes', () => {
@@ -27,18 +28,18 @@ describe('rss routes', () => {
 
   describe('GET /api/rss', () => {
     it('returns RSS items', async () => {
-      vi.spyOn(DataService.prototype, 'getLatestRss').mockReturnValue(MOCK_RSS_ITEMS as never)
+      vi.spyOn(DataService.prototype, 'getLatestRss').mockReturnValue(MOCK_RSS_ITEMS)
       const app = createTestApp()
       const response = await app.request('/api/rss', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: unknown; summary: Record<string, unknown>; data: unknown[] }>(response)
       expect(body.success).toBe(true)
       expect(body.data).toHaveLength(2)
       expect(body.summary.total).toBe(2)
     })
 
     it('passes feed, days, and limit params', async () => {
-      const rssSpy = vi.spyOn(DataService.prototype, 'getLatestRss').mockReturnValue(MOCK_RSS_ITEMS as never)
+      const rssSpy = vi.spyOn(DataService.prototype, 'getLatestRss').mockReturnValue(MOCK_RSS_ITEMS)
       const app = createTestApp()
       await app.request('/api/rss?feed=36kr,ithome&days=7&limit=20', { headers: ADMIN_HEADERS })
       expect(rssSpy).toHaveBeenCalledWith(expect.objectContaining({
@@ -55,17 +56,17 @@ describe('rss routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/rss', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: unknown; summary: Record<string, unknown>; data: unknown[] }>(response)
       expect(body.success).toBe(true)
       expect(body.data).toHaveLength(0)
       expect(body.summary.description).toContain('Run RSS crawler')
     })
 
     it('indicates multi-day range in description', async () => {
-      vi.spyOn(DataService.prototype, 'getLatestRss').mockReturnValue(MOCK_RSS_ITEMS as never)
+      vi.spyOn(DataService.prototype, 'getLatestRss').mockReturnValue(MOCK_RSS_ITEMS)
       const app = createTestApp()
       const response = await app.request('/api/rss?days=7', { headers: ADMIN_HEADERS })
-      const body = await response.json()
+      const body = await parseJsonBody<{ summary: Record<string, unknown> }>(response)
       expect(body.summary.description).toContain('last 7 days')
     })
   })

--- a/apps/api/src/routes/search-alerts.test.ts
+++ b/apps/api/src/routes/search-alerts.test.ts
@@ -5,6 +5,7 @@ import searchAlertsRoutes from './search-alerts'
 import { workspaceMiddleware } from '../middleware/workspace'
 import type { AuthContext } from '../services/auth-types'
 import { createAuthContext } from './test-auth-helpers'
+import { parseJsonBody } from '../test-utils'
 
 // search-alerts uses a local convexQuery/convexMutation that calls resolveConvexUrl + fetch.
 // We mock the global fetch to intercept Convex HTTP API calls.
@@ -97,7 +98,7 @@ describe('search-alerts routes', () => {
       const app = createTestApp()
       const response = await app.request('/', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: unknown; alerts: { _id: string }[] }>(response)
       expect(body.success).toBe(true)
       expect(body.alerts).toHaveLength(2)
       expect(body.alerts[0]._id).toBe('alert-1')
@@ -117,7 +118,7 @@ describe('search-alerts routes', () => {
       const app = createTestApp()
       const response = await app.request('/', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ alerts: unknown[] }>(response)
       expect(body.alerts).toHaveLength(0)
     })
   })
@@ -137,7 +138,7 @@ describe('search-alerts routes', () => {
         }),
       })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody(response)
       expect(body.success).toBe(true)
       expect(body.alertId).toBe('alert-new-1')
     })
@@ -197,7 +198,7 @@ describe('search-alerts routes', () => {
         body: JSON.stringify({ enabled: false }),
       })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody(response)
       expect(body.success).toBe(true)
     })
 
@@ -236,7 +237,7 @@ describe('search-alerts routes', () => {
         headers: ADMIN_HEADERS,
       })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody(response)
       expect(body.success).toBe(true)
     })
 

--- a/apps/api/src/routes/search-analytics.test.ts
+++ b/apps/api/src/routes/search-analytics.test.ts
@@ -5,6 +5,7 @@ import searchAnalyticsRoutes from './search-analytics'
 import { workspaceMiddleware } from '../middleware/workspace'
 import { SearchEventLogger } from '../services/search-event-logger'
 import { SkillsKnowledgeService } from '../services/skills-knowledge'
+import { parseJsonBody } from '../test-utils'
 
 function createTestApp() {
   const app = new OpenAPIHono()
@@ -44,7 +45,7 @@ describe('search-analytics routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/search-analytics/zero-results', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: unknown; items: { query: string }[] }>(response)
       expect(body.success).toBe(true)
       expect(body.items).toHaveLength(2)
       expect(body.items[0].query).toBe('5轴加工中心')
@@ -71,7 +72,7 @@ describe('search-analytics routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/search-analytics/summary', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: unknown; summary: Record<string, unknown> }>(response)
       expect(body.success).toBe(true)
       expect(body.summary.totalSearches).toBe(150)
       expect(body.summary.zeroResultRate).toBe(0.2)
@@ -101,7 +102,7 @@ describe('search-analytics routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/search-analytics/synonym-suggestions', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: unknown; suggestions: { canonical: string }[] }>(response)
       expect(body.success).toBe(true)
       expect(body.suggestions).toHaveLength(1)
       expect(body.suggestions[0].canonical).toBe('五轴加工')
@@ -129,7 +130,7 @@ describe('search-analytics routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/search-analytics/synonym-suggestions', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ suggestions: unknown[] }>(response)
       expect(body.suggestions).toHaveLength(0)
     })
   })
@@ -144,7 +145,7 @@ describe('search-analytics routes', () => {
         body: JSON.stringify({ query: 'CNC operator', resultCount: 25, topScore: 92.5 }),
       })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody(response)
       expect(body.success).toBe(true)
       expect(logSpy).toHaveBeenCalledWith({
         query: 'CNC operator',

--- a/apps/api/src/routes/search-profiles.test.ts
+++ b/apps/api/src/routes/search-profiles.test.ts
@@ -23,7 +23,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): ConvexCall {
+function parseConvexCall(input: Request | string | URL, init?: RequestInit): ConvexCall {
     const requestUrl = typeof input === "string"
         ? input
         : input instanceof URL

--- a/apps/api/src/routes/search.test.ts
+++ b/apps/api/src/routes/search.test.ts
@@ -5,6 +5,7 @@ import searchRoutes from './search'
 import { workspaceMiddleware } from '../middleware/workspace'
 import { DataService } from '../services/data-service'
 import { DataNotFoundError } from '../services/errors'
+import { parseJsonBody } from '../test-utils'
 
 function createTestApp() {
   const app = new OpenAPIHono()
@@ -36,7 +37,7 @@ describe('search routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/search?q=CNC', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody(response)
       expect(body.success).toBe(true)
       expect(body.results).toHaveLength(2)
       expect(body.total).toBe(2)
@@ -72,7 +73,7 @@ describe('search routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/search?q=nonexistent', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody(response)
       expect(body.success).toBe(true)
       expect(body.results).toHaveLength(0)
       expect(body.total).toBe(0)

--- a/apps/api/src/routes/summaries.test.ts
+++ b/apps/api/src/routes/summaries.test.ts
@@ -79,7 +79,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): {
+function parseConvexCall(input: Request | string | URL, init?: RequestInit): {
   pathName: string;
   args: Record<string, unknown>;
 } {
@@ -772,7 +772,7 @@ describe("summary preview route", () => {
     expect(listResponse.status).toBe(200);
     const listPayload = await listResponse.json() as {
       success: boolean;
-      items: Array<{ id: string; workspaceSlug: string; status: string }>;
+      items: Array<{ id: string; workspaceSlug: string; status: string; period: string }>;
     };
     expect(listPayload.success).toBe(true);
     expect(listPayload.items).toHaveLength(2);

--- a/apps/api/src/routes/taxonomy.test.ts
+++ b/apps/api/src/routes/taxonomy.test.ts
@@ -46,7 +46,7 @@ function convexSuccess(value: unknown): Response {
   )
 }
 
-function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): {
+function parseConvexCall(input: Request | string | URL, init?: RequestInit): {
   method: "query" | "mutation"
   pathName: string
   args: Record<string, unknown>

--- a/apps/api/src/routes/topics.test.ts
+++ b/apps/api/src/routes/topics.test.ts
@@ -5,6 +5,7 @@ import topicsRoutes from './topics'
 import { workspaceMiddleware } from '../middleware/workspace'
 import { DataService } from '../services/data-service'
 import { DataNotFoundError } from '../services/errors'
+import { parseJsonBody } from '../test-utils'
 
 function createTestApp() {
   const app = new OpenAPIHono()
@@ -17,13 +18,14 @@ const ADMIN_HEADERS = { 'X-Workspace-Slug': 'dev' }
 
 const MOCK_TOPICS_RESULT = {
   topics: [
-    { keyword: 'CNC', count: 42 },
-    { keyword: '智能制造', count: 28 },
+    { keyword: 'CNC', frequency: 42 },
+    { keyword: '智能制造', frequency: 28 },
   ],
   generated_at: '2026-05-22T12:00:00+08:00',
   mode: 'daily',
   extract_mode: 'frequency',
   total_keywords: 150,
+  description: 'Trending topics for today',
 }
 
 describe('topics routes', () => {
@@ -33,18 +35,18 @@ describe('topics routes', () => {
 
   describe('GET /api/topics', () => {
     it('returns trending topics', async () => {
-      vi.spyOn(DataService.prototype, 'getTrendingTopics').mockReturnValue(MOCK_TOPICS_RESULT as never)
+      vi.spyOn(DataService.prototype, 'getTrendingTopics').mockReturnValue(MOCK_TOPICS_RESULT)
       const app = createTestApp()
       const response = await app.request('/api/topics', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: unknown; topics: unknown[]; total_keywords: unknown }>(response)
       expect(body.success).toBe(true)
       expect(body.topics).toHaveLength(2)
       expect(body.total_keywords).toBe(150)
     })
 
     it('passes top_n, mode, and extract_mode params', async () => {
-      const topicsSpy = vi.spyOn(DataService.prototype, 'getTrendingTopics').mockReturnValue(MOCK_TOPICS_RESULT as never)
+      const topicsSpy = vi.spyOn(DataService.prototype, 'getTrendingTopics').mockReturnValue(MOCK_TOPICS_RESULT)
       const app = createTestApp()
       await app.request('/api/topics?top_n=20&mode=daily&extract_mode=auto_extract', { headers: ADMIN_HEADERS })
       expect(topicsSpy).toHaveBeenCalledWith(expect.objectContaining({
@@ -61,7 +63,7 @@ describe('topics routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/topics', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: unknown; topics: unknown[]; total_keywords: unknown }>(response)
       expect(body.success).toBe(true)
       expect(body.topics).toHaveLength(0)
       expect(body.total_keywords).toBe(0)

--- a/apps/api/src/routes/trends.test.ts
+++ b/apps/api/src/routes/trends.test.ts
@@ -5,6 +5,7 @@ import trendsRoutes from './trends'
 import { workspaceMiddleware } from '../middleware/workspace'
 import { DataService } from '../services/data-service'
 import { DataNotFoundError } from '../services/errors'
+import { parseJsonBody } from '../test-utils'
 
 function createTestApp() {
   const app = new OpenAPIHono()
@@ -16,8 +17,8 @@ function createTestApp() {
 const ADMIN_HEADERS = { 'X-Workspace-Slug': 'dev' }
 
 const MOCK_TRENDS = [
-  { title: 'AI in Manufacturing', platform: 'weibo', rank: 1, url: 'https://example.com/1' },
-  { title: 'CNC Automation', platform: 'zhihu', rank: 2, url: 'https://example.com/2' },
+  { title: 'AI in Manufacturing', platform: 'weibo', platform_name: '微博', rank: 1, url: 'https://example.com/1' },
+  { title: 'CNC Automation', platform: 'zhihu', platform_name: '知乎', rank: 2, url: 'https://example.com/2' },
 ]
 
 describe('trends routes', () => {
@@ -27,22 +28,22 @@ describe('trends routes', () => {
 
   describe('GET /api/trends', () => {
     it('returns latest trends', async () => {
-      vi.spyOn(DataService.prototype, 'getLatestNews').mockReturnValue(MOCK_TRENDS as never)
+      vi.spyOn(DataService.prototype, 'getLatestNews').mockReturnValue(MOCK_TRENDS)
       const app = createTestApp()
       const response = await app.request('/api/trends', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: unknown; summary: Record<string, unknown>; data: unknown[] }>(response)
       expect(body.success).toBe(true)
       expect(body.summary.total).toBe(2)
       expect(body.data).toHaveLength(2)
     })
 
     it('returns trends by date', async () => {
-      vi.spyOn(DataService.prototype, 'getNewsByDate').mockReturnValue(MOCK_TRENDS as never)
+      vi.spyOn(DataService.prototype, 'getNewsByDate').mockReturnValue(MOCK_TRENDS)
       const app = createTestApp()
       const response = await app.request('/api/trends?date=2026-05-22', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ summary: Record<string, unknown> }>(response)
       expect(body.summary.description).toContain('2026-05-22')
     })
 
@@ -53,14 +54,14 @@ describe('trends routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/trends', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: unknown; summary: Record<string, unknown>; data: unknown[] }>(response)
       expect(body.success).toBe(true)
       expect(body.data).toHaveLength(0)
       expect(body.summary.total).toBe(0)
     })
 
     it('passes platform and limit params', async () => {
-      const newsSpy = vi.spyOn(DataService.prototype, 'getLatestNews').mockReturnValue(MOCK_TRENDS as never)
+      const newsSpy = vi.spyOn(DataService.prototype, 'getLatestNews').mockReturnValue(MOCK_TRENDS)
       const app = createTestApp()
       await app.request('/api/trends?platform=weibo,zhihu&limit=10', { headers: ADMIN_HEADERS })
       expect(newsSpy).toHaveBeenCalledWith(expect.objectContaining({
@@ -72,17 +73,17 @@ describe('trends routes', () => {
 
   describe('GET /api/trends/:id', () => {
     it('returns trend by title', async () => {
-      vi.spyOn(DataService.prototype, 'getTrendByTitle').mockReturnValue(MOCK_TRENDS[0] as never)
+      vi.spyOn(DataService.prototype, 'getTrendByTitle').mockReturnValue(MOCK_TRENDS[0])
       const app = createTestApp()
       const response = await app.request('/api/trends/AI%20in%20Manufacturing', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: unknown; data: { title: string } }>(response)
       expect(body.success).toBe(true)
       expect(body.data.title).toBe('AI in Manufacturing')
     })
 
     it('decodes URL-encoded title', async () => {
-      const trendSpy = vi.spyOn(DataService.prototype, 'getTrendByTitle').mockReturnValue(MOCK_TRENDS[0] as never)
+      const trendSpy = vi.spyOn(DataService.prototype, 'getTrendByTitle').mockReturnValue(MOCK_TRENDS[0])
       const app = createTestApp()
       await app.request('/api/trends/CNC%20Automation', { headers: ADMIN_HEADERS })
       expect(trendSpy).toHaveBeenCalledWith('CNC Automation', expect.any(Object))

--- a/apps/api/src/routes/web-vitals.test.ts
+++ b/apps/api/src/routes/web-vitals.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import webVitalsRoutes from './web-vitals'
 import { workspaceMiddleware } from '../middleware/workspace'
 import { WebVitalsLogger } from '../services/web-vitals-logger'
+import { parseJsonBody } from '../test-utils'
 
 function createTestApp() {
   const app = new OpenAPIHono()
@@ -43,7 +44,7 @@ describe('web-vitals routes', () => {
         }),
       })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{ success: boolean }>(response)
       expect(body.success).toBe(true)
       expect(logSpy).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -88,7 +89,15 @@ describe('web-vitals routes', () => {
       const app = createTestApp()
       const response = await app.request('/api/web-vitals/summary', { headers: ADMIN_HEADERS })
       expect(response.status).toBe(200)
-      const body = await response.json()
+      const body = await parseJsonBody<{
+        success: boolean
+        summary: {
+          totalReports: number
+          metrics: {
+            LCP: { p50: number; p75: number; p95: number; good: number; needsImprovement: number; poor: number }
+          }
+        }
+      }>(response)
       expect(body.success).toBe(true)
       expect(body.summary.totalReports).toBe(42)
       expect(body.summary.metrics.LCP.p50).toBe(1.2)

--- a/apps/api/src/services/__tests__/brand-display-resolver.test.ts
+++ b/apps/api/src/services/__tests__/brand-display-resolver.test.ts
@@ -72,27 +72,27 @@ describe("pickPreferredZhHansFromAliases", () => {
 
 describe("brandEntryToDisplay", () => {
   it("uses nameEn as displayName when present", () => {
-    const brand: BrandEntry = { nameCn: "精雕", nameEn: "JingDiao" };
+    const brand: BrandEntry = { id: 1, nameCn: "精雕", nameEn: "JingDiao", type: "default", origin: "international" };
     const result = brandEntryToDisplay(brand);
     expect(result.displayName).toBe("JingDiao");
     expect(result.zhHans).toBe("精雕");
   });
 
   it("falls back to nameCn when nameEn is empty", () => {
-    const brand: BrandEntry = { nameCn: "精雕", nameEn: "" };
+    const brand: BrandEntry = { id: 1, nameCn: "精雕", nameEn: "", type: "default", origin: "international" };
     const result = brandEntryToDisplay(brand);
     expect(result.displayName).toBe("精雕");
     expect(result.zhHans).toBe("精雕");
   });
 
   it("falls back to nameCn when nameEn is whitespace", () => {
-    const brand: BrandEntry = { nameCn: "精雕", nameEn: "  " };
+    const brand: BrandEntry = { id: 1, nameCn: "精雕", nameEn: "  ", type: "default", origin: "international" };
     const result = brandEntryToDisplay(brand);
     expect(result.displayName).toBe("精雕");
   });
 
   it("trims nameCn for zhHans", () => {
-    const brand: BrandEntry = { nameCn: "  精雕  ", nameEn: "JingDiao" };
+    const brand: BrandEntry = { id: 1, nameCn: "  精雕  ", nameEn: "JingDiao", type: "default", origin: "international" };
     const result = brandEntryToDisplay(brand);
     expect(result.zhHans).toBe("精雕");
   });

--- a/apps/api/src/services/__tests__/manual-resume-import-service.test.ts
+++ b/apps/api/src/services/__tests__/manual-resume-import-service.test.ts
@@ -15,6 +15,8 @@ import {
   resolveImportLimit,
 } from "../manual-resume-import-service.js";
 
+type EnumeratedImportFile = Parameters<typeof fileResultBase>[0];
+
 describe("normalizeWhitespace", () => {
   it("replaces carriage returns with newlines", () => {
     expect(normalizeWhitespace("hello\rworld")).toBe("hello\nworld");
@@ -101,7 +103,7 @@ describe("buildBaseMetadata", () => {
     expect(result.keyword).toBe("CNC");
     expect(result.location).toBe("深圳");
     expect(result.searchProfileId).toBe("sp_123");
-    expect(result.collectionContext.captureMode).toBe("manual-upload");
+    expect(result.collectionContext?.captureMode).toBe("manual-upload");
   });
   it("omits optional fields when not provided", () => {
     const result = buildBaseMetadata({ files: [] });
@@ -188,7 +190,7 @@ describe("fileResultBase", () => {
 
 describe("buildImportedResumeCandidate", () => {
   it("builds candidate from file and parsed text", () => {
-    const file = {
+    const file: EnumeratedImportFile = {
       uploadName: "test.zip",
       entryPath: "张三_销售.doc",
       extension: ".doc",
@@ -200,10 +202,10 @@ describe("buildImportedResumeCandidate", () => {
     const result = buildImportedResumeCandidate(file, text, []);
     expect(result.result.status).toBe("imported");
     expect(result.resume).toBeDefined();
-    expect(result.resume.profileType).toBe("51job-manual");
+    expect(result.resume?.profileType).toBe("51job-manual");
   });
   it("uses entryPath basename as fallback name", () => {
-    const file = {
+    const file: EnumeratedImportFile = {
       uploadName: "test.zip",
       entryPath: "unknown.doc",
       extension: ".doc",
@@ -220,7 +222,7 @@ describe("buildSummary", () => {
   it("merges parsed and submit summaries", () => {
     const result = buildSummary(
       { uploadedFiles: 2, discoveredFiles: 5, parsedResumes: 3, imported: 3, skipped: 1, failed: 1 },
-      { submitted: 3, inserted: 2, updated: 1, unchanged: 0, deduped: 0 },
+      { success: true, submitted: 3, inserted: 2, updated: 1, unchanged: 0, deduped: 0 },
     );
     expect(result).toEqual({
       uploadedFiles: 2,

--- a/apps/api/src/services/__tests__/resume-candidate-prep.test.ts
+++ b/apps/api/src/services/__tests__/resume-candidate-prep.test.ts
@@ -486,6 +486,7 @@ describe("resume-candidate-prep", () => {
         mode: "AND" as const,
         groups: [{ original: "JS", variants: ["javascript", "js"] }],
         sourceMapping: { js: "javascript" },
+        originalKeyword: "javascript",
       };
       const result = buildKeywordExpansionSummary(expansion);
       expect(result).toEqual({
@@ -974,7 +975,7 @@ describe("resume-candidate-prep", () => {
         name: "Alice",
         location: "London",
         education: "Master",
-        workHistory: [{ companyName: "Tech Corp", jobTitle: "Dev", startDate: "2020-01", endDate: "2023-01" }],
+        workHistory: [{ raw: "", companyName: "Tech Corp", jobTitle: "Dev", startDate: "2020-01", endDate: "2023-01" }],
       });
       const result = prepareResumeCandidate({ resume, resumeId: "res-fallback" });
       expect(result.indexData.searchText).toContain("alice");
@@ -1067,7 +1068,7 @@ describe("resume-candidate-prep", () => {
         education: "Master",
         profileType: "seek",
         workHistory: [
-          { companyName: "Tech Corp", jobTitle: "Senior Engineer", startDate: "2020-01", endDate: "2023-01", description: "Built systems" },
+          { raw: "", companyName: "Tech Corp", jobTitle: "Senior Engineer", startDate: "2020-01", endDate: "2023-01", description: "Built systems" },
         ],
       });
       const indexData = makeMinimalIndex({
@@ -1075,7 +1076,7 @@ describe("resume-candidate-prep", () => {
         skills: ["JavaScript", "React"],
         companies: ["Tech Corp"],
       });
-      const item = { resume, resumeId: "res-1", indexData, companyHits: ["Tech Corp"], roleSignals: [{ type: "engineer", matchedSignals: ["problem-solving"], signalCount: 1, occurrences: 1, years: 3, verifyIn: "workHistory" as const }] };
+      const item = { resume, resumeId: "res-1", indexData, companyHits: ["Tech Corp"], roleSignals: [{ type: "engineer", matchedSignals: ["problem-solving"], signalCount: 1, occurrences: 1, years: 3, industryVerifiedYears: 3, verifyIn: "workHistory" as const }] };
       const payload = buildAiResumePayload(item);
       expect(payload.id).toBe("res-1");
       expect(payload.name).toBe("Alice Smith");
@@ -1099,7 +1100,7 @@ describe("resume-candidate-prep", () => {
     it("extracts companies from workHistory when indexData.companies is empty", () => {
       const resume = makeMinimalResume({
         workHistory: [
-          { companyName: "Startup Inc", jobTitle: "Dev", startDate: "2019-01", endDate: "2022-01" },
+          { raw: "", companyName: "Startup Inc", jobTitle: "Dev", startDate: "2019-01", endDate: "2022-01" },
         ],
       });
       const indexData = makeMinimalIndex({ companies: [] });

--- a/apps/api/src/services/__tests__/rule-scoring-service.test.ts
+++ b/apps/api/src/services/__tests__/rule-scoring-service.test.ts
@@ -50,19 +50,14 @@ function makeService(): RuleScoringService {
 function makeIndex(overrides: Partial<ResumeIndex> = {}): ResumeIndex {
   return {
     resumeId: "r_001",
-    externalId: "ext_001",
-    sourceKey: "seek",
-    hash: "abc",
-    tags: [],
-    crawledAt: Date.now(),
-    content: "",
-    searchText: "",
-    evidenceText: "",
     experienceYears: null,
     educationLevel: "",
     locationCity: "",
+    searchText: "",
     skills: [],
     companies: [],
+    industryTags: [],
+    salaryRange: null,
     ...overrides,
   };
 }

--- a/apps/api/src/services/__tests__/scoring-metrics.test.ts
+++ b/apps/api/src/services/__tests__/scoring-metrics.test.ts
@@ -13,17 +13,17 @@ describe("ndcgAtK", () => {
     });
 
     it("returns 1 for perfect ranking", () => {
-        const labels = { a: "shortlist", b: "shortlist", c: "reject" };
+        const labels = { a: "shortlist", b: "shortlist", c: "reject" } as const;
         expect(ndcgAtK(["a", "b", "c"], labels, 3)).toBe(1);
     });
 
     it("returns 0 when no positives in top-k", () => {
-        const labels = { a: "reject", b: "reject", c: "shortlist" };
+        const labels = { a: "reject", b: "reject", c: "shortlist" } as const;
         expect(ndcgAtK(["a", "b"], labels, 2)).toBe(0);
     });
 
     it("penalizes imperfect ranking", () => {
-        const labels = { a: "reject", b: "shortlist", c: "shortlist" };
+        const labels = { a: "reject", b: "shortlist", c: "shortlist" } as const;
         const score = ndcgAtK(["a", "b", "c"], labels, 3);
         expect(score).toBeGreaterThan(0);
         expect(score).toBeLessThan(1);
@@ -41,12 +41,12 @@ describe("shortlistAtK", () => {
     });
 
     it("returns 1 when all top-k are shortlisted", () => {
-        const labels = { a: "shortlist", b: "shortlist", c: "reject" };
+        const labels = { a: "shortlist", b: "shortlist", c: "reject" } as const;
         expect(shortlistAtK(["a", "b"], labels, 2)).toBe(1);
     });
 
     it("returns 0.5 when half are shortlisted", () => {
-        const labels = { a: "shortlist", b: "reject" };
+        const labels = { a: "shortlist", b: "reject" } as const;
         expect(shortlistAtK(["a", "b"], labels, 2)).toBe(0.5);
     });
 

--- a/apps/api/src/services/__tests__/search-event-analyzer.test.ts
+++ b/apps/api/src/services/__tests__/search-event-analyzer.test.ts
@@ -110,9 +110,10 @@ describe("scoreFromBreakdown", () => {
       educationMatch: 15,
       locationMatch: 15,
       industryMatch: 10,
+      brandRelevance: 0,
     };
-    const result = scoreFromBreakdown(noBrand as Record<string, number>, defaultWeights, defaultWeights);
-    expect(result).toBe(90); // brandRelevance defaults to 0, so 10% missing
+    const result = scoreFromBreakdown(noBrand, defaultWeights, defaultWeights);
+    expect(result).toBe(90); // brandRelevance contributes 0, so 10% missing
   });
 
   it("handles missing roleMatch in breakdown (defaults to 0)", () => {
@@ -124,7 +125,7 @@ describe("scoreFromBreakdown", () => {
       industryMatch: 10,
       brandRelevance: 10,
     };
-    const result = scoreFromBreakdown(noRole as Record<string, number>, defaultWeights, defaultWeights);
+    const result = scoreFromBreakdown(noRole, defaultWeights, defaultWeights);
     expect(result).toBe(90); // roleMatch defaults to 0, so 10% missing
   });
 

--- a/apps/api/src/services/__tests__/skills-knowledge.test.ts
+++ b/apps/api/src/services/__tests__/skills-knowledge.test.ts
@@ -23,7 +23,7 @@ describe("normalizeCompanyPatternIdentifier", () => {
 describe("buildCompanyPatternAliasLookup", () => {
     it("maps canonical name to itself", () => {
         const patterns: CompanyPattern[] = [
-            { name: "Fanuc", allNames: ["Fanuc"], category: "cnc", role: "equipment" },
+            { name: "Fanuc", allNames: ["Fanuc"], displayName: "Fanuc-style", aliases: [], displayAliases: [], role: "equipment" },
         ];
         const lookup = buildCompanyPatternAliasLookup(patterns);
         expect(lookup.get("fanuc")).toBe("fanuc");
@@ -31,7 +31,7 @@ describe("buildCompanyPatternAliasLookup", () => {
 
     it("maps aliases to canonical name", () => {
         const patterns: CompanyPattern[] = [
-            { name: "Fanuc", allNames: ["Fanuc", "FANUC", "发那科"], category: "cnc", role: "equipment" },
+            { name: "Fanuc", allNames: ["Fanuc", "FANUC", "发那科"], displayName: "Fanuc-style", aliases: [], displayAliases: [], role: "equipment" },
         ];
         const lookup = buildCompanyPatternAliasLookup(patterns);
         expect(lookup.get("fanuc")).toBe("fanuc");
@@ -40,7 +40,7 @@ describe("buildCompanyPatternAliasLookup", () => {
 
     it("skips empty names", () => {
         const patterns: CompanyPattern[] = [
-            { name: "  ", allNames: ["Fanuc"], category: "cnc", role: "equipment" },
+            { name: "  ", allNames: ["Fanuc"], displayName: "Fanuc-style", aliases: [], displayAliases: [], role: "equipment" },
         ];
         const lookup = buildCompanyPatternAliasLookup(patterns);
         expect(lookup.has("")).toBe(false);
@@ -49,8 +49,8 @@ describe("buildCompanyPatternAliasLookup", () => {
 
     it("handles multiple patterns without collision", () => {
         const patterns: CompanyPattern[] = [
-            { name: "Fanuc", allNames: ["Fanuc"], category: "cnc", role: "equipment" },
-            { name: "Mazak", allNames: ["Mazak", "山崎马扎克"], category: "cnc", role: "equipment" },
+            { name: "Fanuc", allNames: ["Fanuc"], displayName: "Fanuc-style", aliases: [], displayAliases: [], role: "equipment" },
+            { name: "Mazak", allNames: ["Mazak", "山崎马扎克"], displayName: "Fanuc-style", aliases: [], displayAliases: [], role: "equipment" },
         ];
         const lookup = buildCompanyPatternAliasLookup(patterns);
         expect(lookup.get("fanuc")).toBe("fanuc");

--- a/apps/api/src/services/__tests__/verify-critical-path.test.ts
+++ b/apps/api/src/services/__tests__/verify-critical-path.test.ts
@@ -8,6 +8,7 @@ import {
   toJsonOutput,
   type StageResult,
 } from "../../../../../scripts/verify-critical-path";
+import type { Id } from "../../../../../packages/convex/convex/_generated/dataModel.js";
 
 function stage(status: StageResult["status"], fallbackUsed: boolean = false): StageResult {
   return {
@@ -116,10 +117,10 @@ describe("verify-critical-path json report schema", () => {
 describe("verify-critical-path search evidence helpers", () => {
   it("computes identity-distinct counts with identityKey/externalId fallback", () => {
     const count = countIdentityDistinctHits([
-      { _id: "resume:1", identityKey: "profileUrl:a", externalId: "ext-a" },
-      { _id: "resume:2", identityKey: "profileUrl:a", externalId: "ext-b" },
-      { _id: "resume:3", externalId: "EXT-C" },
-      { _id: "resume:4", externalId: "ext-c" },
+      { _id: "resume:1" as Id<"resumes">, identityKey: "profileUrl:a", externalId: "ext-a" },
+      { _id: "resume:2" as Id<"resumes">, identityKey: "profileUrl:a", externalId: "ext-b" },
+      { _id: "resume:3" as Id<"resumes">, externalId: "EXT-C" },
+      { _id: "resume:4" as Id<"resumes">, externalId: "ext-c" },
     ]);
 
     expect(count).toBe(2);

--- a/apps/api/src/services/__tests__/weight-history-helpers.test.ts
+++ b/apps/api/src/services/__tests__/weight-history-helpers.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import { isFiniteNumber, parseCategoryWeights, parseEntry } from "../weight-history.js";
 
-import type { RuleCategoryWeights } from "../rule-scoring.js";
+import type { RuleWeightsConfig } from "../rule-scoring.js";
 
-const VALID_WEIGHTS: RuleCategoryWeights = {
+const VALID_WEIGHTS: RuleWeightsConfig["categoryWeights"] = {
   skillMatch: 15,
   roleMatch: 10,
   experienceMatch: 25,

--- a/apps/api/src/services/ai-summary-service.test.ts
+++ b/apps/api/src/services/ai-summary-service.test.ts
@@ -145,7 +145,7 @@ Strong overlap around machine tools and CNC sales backgrounds.
   it("fails before the AI call when the runtime has no API key", async () => {
     loadAIConfigMock.mockReturnValue(createAIConfig({ apiKey: "" }));
     getWorkspaceConfigValueMock.mockResolvedValue(undefined);
-    logger.error.mockClear();
+    vi.mocked(logger.error).mockClear();
 
     const service = new AiSummaryService();
     const result = await service.generateSummary({
@@ -181,7 +181,7 @@ Strong overlap around machine tools and CNC sales backgrounds.
     loadAIConfigMock.mockReturnValue(createAIConfig());
     getWorkspaceConfigValueMock.mockResolvedValue("anthropic/claude-3-5-haiku-20241022");
     callChatCompletionMock.mockRejectedValue(new Error("provider timeout"));
-    logger.error.mockClear();
+    vi.mocked(logger.error).mockClear();
 
     const service = new AiSummaryService();
     const result = await service.generateSummary({

--- a/apps/api/src/services/export-service.test.ts
+++ b/apps/api/src/services/export-service.test.ts
@@ -1,8 +1,10 @@
 import ExcelJS from "exceljs";
 import Papa from "papaparse";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { ExportService } from "./export-service";
+import { BrandDisplayResolver } from "./brand-display-resolver";
+import { config } from "./config";
 
 import type { ResumeExportEntry, ExportBatchMeta } from "./export-service";
 import {
@@ -14,6 +16,10 @@ import {
 
 // Helper: export with all known fields to preserve old test expectations
 const fullFieldsConfig = { fields: [...EXPORT_FIELD_KEYS] };
+
+function bufferToArrayBuffer(content: Buffer): ArrayBuffer {
+  return new Uint8Array(content).buffer;
+}
 
 function buildEntry(age: string | undefined): ResumeExportEntry {
   return {
@@ -51,10 +57,13 @@ function buildEntry(age: string | undefined): ResumeExportEntry {
           {
             type: "sales",
             matchedSignals: ["销售工程师"],
+            signalCount: 1,
+            occurrences: 1,
             years: 4.5,
             industryVerifiedYears: 3.5,
             roleRelevantYears: 4.5,
             industryVerifiedRelevantYears: 3.5,
+            verifyIn: "workHistory",
             matchedWorkEntries: [
               {
                 companyName: "Example Co.",
@@ -98,7 +107,7 @@ describe("ExportService", () => {
     const file = await service.exportResumes("xlsx", [buildEntry("31"), buildEntry("abc")]);
     const workbook = new ExcelJS.Workbook();
 
-    await workbook.xlsx.load(file.content);
+    await workbook.xlsx.load(bufferToArrayBuffer(file.content));
     const sheet = workbook.getWorksheet("Resumes");
 
     expect(file.extension).toBe("xlsx");
@@ -302,7 +311,7 @@ describe("ExportService", () => {
     };
     const file = await service.exportResumes("xlsx", [entry], undefined, undefined, false, fullFieldsConfig);
     const workbook = new ExcelJS.Workbook();
-    await workbook.xlsx.load(file.content);
+    await workbook.xlsx.load(bufferToArrayBuffer(file.content));
     const sheet = workbook.getWorksheet("Resumes");
 
     expect(sheet).toBeDefined();
@@ -388,10 +397,9 @@ describe("ExportService", () => {
   });
 
   it("formats brand hits into a dedicated export column", async () => {
-    const service = new ExportService({
-      resolveZhHans: (brandId: string) => `zh-${brandId.toLowerCase()}`,
-      toJSON: () => ({}),
-    });
+    const resolver = new BrandDisplayResolver(config.projectRoot);
+    vi.spyOn(resolver, "resolveZhHans").mockImplementation((brandId: string) => `zh-${brandId.toLowerCase()}`);
+    const service = new ExportService(resolver);
     const file = await service.exportResumes("csv", [buildEntry("27")], undefined, undefined, false, fullFieldsConfig);
     const csv = file.content.toString("utf8");
     const parsed = Papa.parse<Record<string, string>>(csv, { header: true });
@@ -401,15 +409,14 @@ describe("ExportService", () => {
   });
 
   it("summarizes brand hits as deduped names-only evidence with alias expansion", async () => {
+    const resolver = new BrandDisplayResolver(config.projectRoot);
+    vi.spyOn(resolver, "resolveZhHans").mockImplementation((brandId: string) => {
+      if (brandId.toLowerCase() === "fanuc") return "发那科";
+      if (brandId.toLowerCase() === "mitsubishi") return "三菱";
+      return brandId.toUpperCase();
+    });
     const service = new ExportService(
-      {
-        resolveZhHans: (brandId: string) => {
-          if (brandId.toLowerCase() === "fanuc") return "发那科";
-          if (brandId.toLowerCase() === "mitsubishi") return "三菱";
-          return brandId.toUpperCase();
-        },
-        toJSON: () => ({}),
-      },
+      resolver,
       [
         {
           name: "fanuc",
@@ -458,7 +465,7 @@ describe("ExportService", () => {
     const csvHeaders = csvParsed.meta.fields ?? [];
 
     const workbook = new ExcelJS.Workbook();
-    await workbook.xlsx.load(xlsxFile.content);
+    await workbook.xlsx.load(bufferToArrayBuffer(xlsxFile.content));
     const sheet = workbook.getWorksheet("Resumes");
     const xlsxHeaders = ((sheet?.getRow(1).values as unknown[]) ?? [])
       .filter((value): value is string => typeof value === "string");
@@ -612,7 +619,7 @@ describe("export fields production defaults — core/detail/debug tiers", () => 
     const service = new ExportService();
     const file = await service.exportResumes("xlsx", [buildEntry("25")]);
     const workbook = new ExcelJS.Workbook();
-    await workbook.xlsx.load(file.content);
+    await workbook.xlsx.load(bufferToArrayBuffer(file.content));
     const sheet = workbook.getWorksheet("Resumes");
     const headers = ((sheet?.getRow(1).values as unknown[]) ?? [])
       .filter((v): v is string => typeof v === "string");
@@ -686,7 +693,7 @@ describe("export fields — userRating wiring", () => {
     };
     const file = await service.exportResumes("xlsx", [entry]);
     const workbook = new ExcelJS.Workbook();
-    await workbook.xlsx.load(file.content);
+    await workbook.xlsx.load(bufferToArrayBuffer(file.content));
     const sheet = workbook.getWorksheet("Resumes");
     const headers = ((sheet?.getRow(1).values as unknown[]) ?? [])
       .filter((v): v is string => typeof v === "string");

--- a/apps/api/src/services/feedback-import-service.test.ts
+++ b/apps/api/src/services/feedback-import-service.test.ts
@@ -38,7 +38,7 @@ async function buildXlsxBuffer(rows: string[][]): Promise<Uint8Array> {
   const sheet = workbook.addWorksheet("Feedback");
   rows.forEach((row) => sheet.addRow(row));
   const buffer = await workbook.xlsx.writeBuffer();
-  return new Uint8Array(buffer instanceof ArrayBuffer ? buffer : buffer.buffer);
+  return new Uint8Array(buffer);
 }
 
 describe("FeedbackImportService", () => {

--- a/apps/api/src/services/oidc-provider.test.ts
+++ b/apps/api/src/services/oidc-provider.test.ts
@@ -63,7 +63,7 @@ describe("CasdoorOidcProvider", () => {
       access_token: "access-token",
       claims: () => ({ sub: "casdoor-user-1", email: "hr@example.com" }),
       expiresIn: () => 3600,
-    } as Awaited<ReturnType<typeof client.authorizationCodeGrant>>);
+    } as unknown as Awaited<ReturnType<typeof client.authorizationCodeGrant>>);
     vi.mocked(client.fetchUserInfo).mockResolvedValue({
       sub: "casdoor-user-1",
       name: "HR Manager",

--- a/apps/api/src/services/public-share-storage.test.ts
+++ b/apps/api/src/services/public-share-storage.test.ts
@@ -141,7 +141,7 @@ describe("PublicShareStorage", () => {
     expect(loadedFirst?.payload.results[0]).not.toHaveProperty("candidateStatus");
     expect(loadedFirst?.payload.results[0]).not.toHaveProperty("actions");
     expect(loadedFirst?.payload.results[0]).not.toHaveProperty("notes");
-    expect(loadedFirst?.payload.search.filters).toEqual({ locations: ["Malaysia"] });
+    expect(loadedFirst?.payload.search?.filters).toEqual({ locations: ["Malaysia"] });
   });
 
   it("stores only token hashes and resolves active public shares by raw token", () => {

--- a/apps/api/src/services/resume-import-service.test.ts
+++ b/apps/api/src/services/resume-import-service.test.ts
@@ -11,7 +11,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseConvexCall(input: RequestInfo | URL, init?: RequestInit): ConvexCall {
+function parseConvexCall(input: string | URL | Request, init?: RequestInit): ConvexCall {
   const requestUrl = typeof input === "string"
     ? input
     : input instanceof URL
@@ -69,8 +69,8 @@ describe("resume-import-service", () => {
       },
       data: [
         {
-          resumeId: 1079188,
-          perUserId: 1079188,
+          resumeId: "1079188",
+          perUserId: "1079188",
           name: "骆先生",
           profileUrl: "javascript:;",
           activityStatus: "在线中",
@@ -123,7 +123,7 @@ describe("resume-import-service", () => {
       },
       resumes: [
         {
-          resumeId: 555555,
+          resumeId: "555555",
           name: "空位置候选人",
           profileUrl: "https://hr.job5156.com/resume/view/555555",
           activityStatus: "在线中",
@@ -267,8 +267,8 @@ describe("resume-import-service", () => {
       },
       resumes: [
         {
-          resumeId: 987654,
-          perUserId: 123456,
+          resumeId: "987654",
+          perUserId: "123456",
           name: "李先生",
           profileUrl: "https://hr.job5156.com/resume/view/987654",
           activityStatus: "在线中",
@@ -434,7 +434,7 @@ describe("resume-import-service", () => {
         collectionContext: {
           captureMode: "json-upload",
           operation: "manual-import",
-          jobId: 90842915,
+          jobId: "90842915",
           pageNumber: 2,
           language: "en",
           profileType: "seek",
@@ -442,7 +442,7 @@ describe("resume-import-service", () => {
       },
       resumes: [
         {
-          profileId: 503033454,
+          profileId: "503033454",
           profileType: "seek",
           name: "yap kae wen",
           profileUrl: "https://hk.employer.seek.com/candidates/503033454",

--- a/apps/api/src/services/resume-service.test.ts
+++ b/apps/api/src/services/resume-service.test.ts
@@ -687,7 +687,7 @@ describe("ResumeService", () => {
           selfIntro: "",
           jobIntention: "",
           expectedSalary: "",
-          workHistory: [{ company: "ACME", role: "CNC Operator", years: "3" }],
+          workHistory: [{ companyName: "ACME", jobTitle: "CNC Operator", raw: "ACME CNC Operator 3 years" }],
           extractedAt: "2026-03-20T00:00:00.000Z",
           // searchText includes "fanuc" from earlier workHistory not in latest entry
           searchText: "CNC Resume Dongguan ACME CNC Operator 3 years fanuc experience",

--- a/apps/api/src/services/rule-scoring.test.ts
+++ b/apps/api/src/services/rule-scoring.test.ts
@@ -79,6 +79,7 @@ function createSalesRoleSignal(years: number, matchedSignals: string[] = ["é”€å”
     signalCount: matchedSignals.length,
     occurrences: 1,
     years,
+    industryVerifiedYears: years,
     verifyIn: "workHistory",
   };
 }
@@ -928,6 +929,7 @@ describe("RuleScoringService", () => {
         signalCount: 1,
         occurrences: 1,
         years: 5,
+        industryVerifiedYears: 3,
         roleRelevantYears: 3,
         verifyIn: "workHistory",
       };

--- a/apps/api/src/services/scoring-auto-tuner.test.ts
+++ b/apps/api/src/services/scoring-auto-tuner.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { resetResumeScreeningDb } from "./database";
 import { MatchStorage } from "./match-storage";
-import { loadRuleWeightsConfig } from "./rule-scoring";
+import { loadRuleWeightsConfig, mergeRuleWeights } from "./rule-scoring";
 import { ScoringAutoTuner } from "./scoring-auto-tuner";
 import { WeightHistoryService } from "./weight-history";
 import { workspaceConfigService } from "./workspace-config-service";
@@ -241,14 +241,7 @@ describe("ScoringAutoTuner", () => {
       let runtimeWeights = loadRuleWeightsConfig(root);
       const getRuleWeightsMock = vi.spyOn(workspaceConfigService, "getRuleWeights").mockImplementation(async () => runtimeWeights);
       const setRuleWeightsMock = vi.spyOn(workspaceConfigService, "setWorkspaceRuleWeights").mockImplementation(async (_workspace, config) => {
-        runtimeWeights = {
-          ...runtimeWeights,
-          ...config,
-          categoryWeights: {
-            ...runtimeWeights.categoryWeights,
-            ...config.categoryWeights,
-          },
-        };
+        runtimeWeights = mergeRuleWeights(config);
       });
       const appendLearningMock = vi.spyOn(workspaceConfigService, "appendLearningLogEntry").mockResolvedValue({
         date: "2026-02-25",

--- a/apps/api/src/services/search-profile-service.test.ts
+++ b/apps/api/src/services/search-profile-service.test.ts
@@ -465,7 +465,7 @@ describe('SearchProfileService validateProfile', () => {
   })
 
   it('throws when keywords is empty', () => {
-    expect(() => svc.validateProfile({ id: 'p1', name: 'Test', keywords: [] } as SearchProfile)).toThrow(/keywords/)
+    expect(() => svc.validateProfile({ id: 'p1', name: 'Test', status: 'active', location: '', keywords: [] })).toThrow(/keywords/)
   })
 
   it('does not throw for valid profile', () => {
@@ -872,7 +872,7 @@ describe('matchSearchProfilesByKeywords', () => {
 
   it('caps confidence at 1.0 even with high keyword overlap + location bonus', () => {
     const result = matchSearchProfilesByKeywords(
-      [{ id: 'p1', name: 'Test', status: 'active', keywords: ['a', 'b', 'c'] }],
+      [{ id: 'p1', name: 'Test', status: 'active', location: '', keywords: ['a', 'b', 'c'] }],
       ['a', 'b', 'c'],
       'any',
     )
@@ -881,7 +881,7 @@ describe('matchSearchProfilesByKeywords', () => {
 
   it('handles substring keyword matching (input contains profile keyword)', () => {
     const localProfiles: SearchProfile[] = [
-      { id: 'p1', name: 'Test', status: 'active', keywords: ['CNC'] },
+      { id: 'p1', name: 'Test', status: 'active', location: '', keywords: ['CNC'] },
     ]
     const result = matchSearchProfilesByKeywords(localProfiles, ['CNC机床'])
     expect(result.profile?.id).toBe('p1')
@@ -890,7 +890,7 @@ describe('matchSearchProfilesByKeywords', () => {
 
   it('handles substring keyword matching (profile keyword contains input)', () => {
     const localProfiles: SearchProfile[] = [
-      { id: 'p1', name: 'Test', status: 'active', keywords: ['CNC机床'] },
+      { id: 'p1', name: 'Test', status: 'active', location: '', keywords: ['CNC机床'] },
     ]
     const result = matchSearchProfilesByKeywords(localProfiles, ['CNC'])
     expect(result.profile?.id).toBe('p1')
@@ -903,6 +903,7 @@ describe('matchSearchProfilesByKeywords', () => {
         id: 'p1',
         name: 'Test',
         status: 'active',
+        location: '',
         keywords: ['CNC'],
         jobDescription: 'jd-abc123',
         filterPreset: 'machinery-sales',

--- a/apps/api/src/services/summaries/__tests__/summary-renderer.test.ts
+++ b/apps/api/src/services/summaries/__tests__/summary-renderer.test.ts
@@ -20,20 +20,20 @@ const baseReport: SummaryReport = {
   },
   breakdowns: {
     resumesBySource: [
-      { label: "51job", count: 10 },
-      { label: "Seek", count: 2 },
+      { key: "51job", label: "51job", count: 10 },
+      { key: "Seek", label: "Seek", count: 2 },
     ],
     collectionTasksByStatus: [
-      { label: "completed", count: 8 },
-      { label: "failed", count: 1 },
+      { key: "completed", label: "completed", count: 8 },
+      { key: "failed", label: "failed", count: 1 },
     ],
     candidateStatusByValue: [
-      { label: "shortlisted", count: 3 },
-      { label: "rejected", count: 1 },
+      { key: "shortlisted", label: "shortlisted", count: 3 },
+      { key: "rejected", label: "rejected", count: 1 },
     ],
     actionsByType: [
-      { label: "shortlist", count: 3 },
-      { label: "reject", count: 1 },
+      { key: "shortlist", label: "shortlist", count: 3 },
+      { key: "reject", label: "reject", count: 1 },
     ],
   },
   notes: ["No critical incidents."],
@@ -86,7 +86,7 @@ describe("SummaryRenderer", () => {
       const report: SummaryReport = {
         ...baseReport,
         comparison: {
-          previousWindow: { startAt: "2026-05-23T00:00:00Z", endAt: "2026-05-24T00:00:00Z" },
+          previousWindow: { startAt: "2026-05-23T00:00:00Z", endAt: "2026-05-24T00:00:00Z", timezone: "Asia/Hong_Kong" },
           totalsDelta: {
             sharedIngest: { newResumes: 5, collectionTasksCompleted: -2, collectionTasksFailed: 0 },
             workspaceActivity: { candidateStatusUpdates: 1, shortlistActions: 0, rejectActions: -1, contactActions: 3 },
@@ -106,8 +106,8 @@ describe("SummaryRenderer", () => {
       const report: SummaryReport = {
         ...baseReport,
         newCandidates: [
-          { resumeId: "r1", name: "Alice", source: "51job", location: "Dongguan", experience: 5, score: 85 },
-          { resumeId: "r2", name: "Bob", source: "Seek" },
+          { resumeId: "r1", name: "Alice", source: "51job", location: "Dongguan", experience: "5", score: 85, crawledAt: "2026-05-24T10:00:00Z" },
+          { resumeId: "r2", name: "Bob", source: "Seek", crawledAt: "2026-05-24T11:00:00Z" },
         ],
       };
 
@@ -137,15 +137,15 @@ describe("SummaryRenderer", () => {
           sharedIngest: {
             totals: { newResumes: 20, collectionTasksCompleted: 15, collectionTasksFailed: 2 },
             breakdowns: {
-              resumesBySource: [{ label: "51job", count: 20 }],
-              collectionTasksByStatus: [{ label: "completed", count: 15 }],
+              resumesBySource: [{ key: "51job", label: "51job", count: 20 }],
+              collectionTasksByStatus: [{ key: "completed", label: "completed", count: 15 }],
             },
           },
           workspaceActivity: {
             totals: { candidateStatusUpdates: 10, shortlistActions: 5, rejectActions: 3, contactActions: 2 },
             breakdowns: {
-              candidateStatusByValue: [{ label: "shortlisted", count: 5 }],
-              actionsByType: [{ label: "shortlist", count: 5 }],
+              candidateStatusByValue: [{ key: "shortlisted", label: "shortlisted", count: 5 }],
+              actionsByType: [{ key: "shortlist", label: "shortlist", count: 5 }],
             },
           },
         },
@@ -162,7 +162,7 @@ describe("SummaryRenderer", () => {
       const report: SummaryReport = {
         ...baseReport,
         newCandidates: [
-          { resumeId: "r-unknown", source: "51job", score: 70 },
+          { resumeId: "r-unknown", source: "51job", score: 70, crawledAt: "2026-05-24T12:00:00Z" },
         ],
       };
 

--- a/apps/api/src/services/work-history.test.ts
+++ b/apps/api/src/services/work-history.test.ts
@@ -7,7 +7,7 @@ import {
   parseRoleYears,
 } from './work-history.js'
 
-import type { ResumeWorkHistoryItem } from './ingest-compute-service.js'
+import type { ResumeWorkHistoryItem } from '../types/resume.js'
 
 describe('parseRoleYears', () => {
   it('extracts years from a date range string', () => {
@@ -55,6 +55,7 @@ describe('parseRoleYears', () => {
 describe('computeEntryRoleYears', () => {
   it('computes years from structured date range', () => {
     const entry: ResumeWorkHistoryItem = {
+      raw: '',
       companyName: 'Example Co',
       jobTitle: 'Sales Engineer',
       startDate: '2021-03',
@@ -72,7 +73,7 @@ describe('computeEntryRoleYears', () => {
   })
 
   it('returns 0 for empty entry', () => {
-    expect(computeEntryRoleYears({})).toBe(0)
+    expect(computeEntryRoleYears({ raw: '' })).toBe(0)
   })
 
   it('falls back to raw text when structured dates are absent', () => {
@@ -113,8 +114,8 @@ describe('computeWorkHistoryYears', () => {
 
   it('sums years across non-overlapping entries', () => {
     const entries: ResumeWorkHistoryItem[] = [
-      { companyName: 'A', jobTitle: 'Engineer', startDate: '2018-01', endDate: '2020-01' },
-      { companyName: 'B', jobTitle: 'Sales', startDate: '2021-01', endDate: '2024-01' },
+      { raw: '', companyName: 'A', jobTitle: 'Engineer', startDate: '2018-01', endDate: '2020-01' },
+      { raw: '', companyName: 'B', jobTitle: 'Sales', startDate: '2021-01', endDate: '2024-01' },
     ]
     const result = computeWorkHistoryYears(entries)
     expect(result).not.toBeNull()
@@ -123,8 +124,8 @@ describe('computeWorkHistoryYears', () => {
 
   it('merges overlapping date ranges instead of overcounting', () => {
     const entries: ResumeWorkHistoryItem[] = [
-      { companyName: 'A', jobTitle: 'Engineer', startDate: '2020-01', endDate: '2024-01' },
-      { companyName: 'B', jobTitle: 'Sales', startDate: '2022-01', endDate: '2024-06' },
+      { raw: '', companyName: 'A', jobTitle: 'Engineer', startDate: '2020-01', endDate: '2024-01' },
+      { raw: '', companyName: 'B', jobTitle: 'Sales', startDate: '2022-01', endDate: '2024-06' },
     ]
     // True span: 2020-01 to 2024-06 = ~4.4 years
     // Naive sum would be 4 + 2.5 = 6.5 years (overcounts ~2 years of overlap)
@@ -135,8 +136,8 @@ describe('computeWorkHistoryYears', () => {
 
   it('merges fully nested date ranges', () => {
     const entries: ResumeWorkHistoryItem[] = [
-      { companyName: 'A', jobTitle: 'Engineer', startDate: '2018-01', endDate: '2024-01' },
-      { companyName: 'B', jobTitle: 'Sales', startDate: '2020-01', endDate: '2022-01' },
+      { raw: '', companyName: 'A', jobTitle: 'Engineer', startDate: '2018-01', endDate: '2024-01' },
+      { raw: '', companyName: 'B', jobTitle: 'Sales', startDate: '2020-01', endDate: '2022-01' },
     ]
     // B is fully nested inside A; total span is just A = 6 years
     const result = computeWorkHistoryYears(entries)
@@ -146,8 +147,8 @@ describe('computeWorkHistoryYears', () => {
 
   it('merges adjacent but non-overlapping entries without dedup', () => {
     const entries: ResumeWorkHistoryItem[] = [
-      { companyName: 'A', jobTitle: 'Engineer', startDate: '2018-01', endDate: '2020-01' },
-      { companyName: 'B', jobTitle: 'Sales', startDate: '2021-01', endDate: '2024-01' },
+      { raw: '', companyName: 'A', jobTitle: 'Engineer', startDate: '2018-01', endDate: '2020-01' },
+      { raw: '', companyName: 'B', jobTitle: 'Sales', startDate: '2021-01', endDate: '2024-01' },
     ]
     // No overlap: 2 + 3 = 5 years
     const result = computeWorkHistoryYears(entries)
@@ -164,7 +165,7 @@ describe('computeWorkHistoryYears', () => {
 
   it('computes single entry correctly', () => {
     const entries: ResumeWorkHistoryItem[] = [
-      { companyName: 'A', jobTitle: 'Engineer', startDate: '2020-01', endDate: '2024-01' },
+      { raw: '', companyName: 'A', jobTitle: 'Engineer', startDate: '2020-01', endDate: '2024-01' },
     ]
     const result = computeWorkHistoryYears(entries)
     expect(result).not.toBeNull()
@@ -174,7 +175,7 @@ describe('computeWorkHistoryYears', () => {
   it('resolves 至今 (present) end date against anchorDate', () => {
     const anchor = new Date('2026-04-01')
     const entries: ResumeWorkHistoryItem[] = [
-      { companyName: 'A', jobTitle: 'Engineer', startDate: '2023-06', endDate: '至今' },
+      { raw: '', companyName: 'A', jobTitle: 'Engineer', startDate: '2023-06', endDate: '至今' },
     ]
     const result = computeWorkHistoryYears(entries, anchor)
     expect(result).not.toBeNull()
@@ -185,7 +186,7 @@ describe('computeWorkHistoryYears', () => {
   it('treats missing endDate as ongoing via anchorDate', () => {
     const anchor = new Date('2026-01-01')
     const entries: ResumeWorkHistoryItem[] = [
-      { companyName: 'A', jobTitle: 'Engineer', startDate: '2022-01' },
+      { raw: '', companyName: 'A', jobTitle: 'Engineer', startDate: '2022-01' },
     ]
     const result = computeWorkHistoryYears(entries, anchor)
     expect(result).not.toBeNull()
@@ -205,9 +206,9 @@ describe('computeWorkHistoryYears', () => {
 
   it('merges 3+ overlapping intervals correctly', () => {
     const entries: ResumeWorkHistoryItem[] = [
-      { companyName: 'A', jobTitle: 'Engineer', startDate: '2018-01', endDate: '2024-01' },
-      { companyName: 'B', jobTitle: 'Sales', startDate: '2020-01', endDate: '2023-01' },
-      { companyName: 'C', jobTitle: 'Manager', startDate: '2022-01', endDate: '2024-06' },
+      { raw: '', companyName: 'A', jobTitle: 'Engineer', startDate: '2018-01', endDate: '2024-01' },
+      { raw: '', companyName: 'B', jobTitle: 'Sales', startDate: '2020-01', endDate: '2023-01' },
+      { raw: '', companyName: 'C', jobTitle: 'Manager', startDate: '2022-01', endDate: '2024-06' },
     ]
     // A spans 2018-01..2024-01; C extends to 2024-06; B is nested inside A
     // Merged: 2018-01 to 2024-06 = 6.5 years
@@ -218,7 +219,7 @@ describe('computeWorkHistoryYears', () => {
 
   it('rounds result to one decimal place', () => {
     const entries: ResumeWorkHistoryItem[] = [
-      { companyName: 'A', jobTitle: 'Engineer', startDate: '2020-01', endDate: '2020-07' },
+      { raw: '', companyName: 'A', jobTitle: 'Engineer', startDate: '2020-01', endDate: '2020-07' },
     ]
     // 6 months = 0.5 years — already one decimal
     const result = computeWorkHistoryYears(entries)
@@ -241,8 +242,8 @@ describe('computeWorkHistoryYears', () => {
     // start of B (2023-01 = 24133) <= end of A (2023-01 = 24133)
     // → merged into 2020-01..2026-01 = 6 years (continuous employment)
     const entries: ResumeWorkHistoryItem[] = [
-      { companyName: 'A', jobTitle: 'Engineer', startDate: '2020-01', endDate: '2023-01' },
-      { companyName: 'B', jobTitle: 'Manager', startDate: '2023-01', endDate: '2026-01' },
+      { raw: '', companyName: 'A', jobTitle: 'Engineer', startDate: '2020-01', endDate: '2023-01' },
+      { raw: '', companyName: 'B', jobTitle: 'Manager', startDate: '2023-01', endDate: '2026-01' },
     ]
     const result = computeWorkHistoryYears(entries)
     expect(result).not.toBeNull()
@@ -253,8 +254,8 @@ describe('computeWorkHistoryYears', () => {
     // A: 2020-01 to 2022-01, B: 2024-01 to 2026-01
     // 2-year gap between them → total = 2 + 2 = 4 years
     const entries: ResumeWorkHistoryItem[] = [
-      { companyName: 'A', jobTitle: 'Engineer', startDate: '2020-01', endDate: '2022-01' },
-      { companyName: 'B', jobTitle: 'Engineer', startDate: '2024-01', endDate: '2026-01' },
+      { raw: '', companyName: 'A', jobTitle: 'Engineer', startDate: '2020-01', endDate: '2022-01' },
+      { raw: '', companyName: 'B', jobTitle: 'Engineer', startDate: '2024-01', endDate: '2026-01' },
     ]
     const result = computeWorkHistoryYears(entries)
     expect(result).not.toBeNull()
@@ -265,6 +266,7 @@ describe('computeWorkHistoryYears', () => {
 describe('extractCompanyFromWorkHistory', () => {
   it('extracts company name from companyName field', () => {
     const entry: ResumeWorkHistoryItem = {
+      raw: '',
       companyName: '苏州美科生贸易有限公司',
       jobTitle: 'Sales Engineer',
       startDate: '2020-01',
@@ -281,7 +283,7 @@ describe('extractCompanyFromWorkHistory', () => {
   })
 
   it('returns empty string when no company pattern is found', () => {
-    expect(extractCompanyFromWorkHistory({})).toBe('')
+    expect(extractCompanyFromWorkHistory({ raw: '' })).toBe('')
   })
 
   it('extracts company with 集团 suffix', () => {

--- a/apps/api/src/services/workspace-config-service.ts
+++ b/apps/api/src/services/workspace-config-service.ts
@@ -417,8 +417,8 @@ export function mergeItemsById<T extends { id: string }>(base: T[], overrides: T
   return Array.from(mergedById.values());
 }
 
-export function mergeResolvedItemsById<T extends { id: string; source?: ConfigSourceOrigin }>(base: T[], overrides: T[]): T[] {
-  const mergedById = new Map<string, T>();
+export function mergeResolvedItemsById<T extends { id: string; source?: ConfigSourceOrigin }>(base: T[], overrides: T[]): (T & { source: ConfigSourceOrigin })[] {
+  const mergedById = new Map<string, T & { source: ConfigSourceOrigin }>();
 
   for (const item of base) {
     mergedById.set(item.id, {

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -188,7 +188,10 @@ export async function callLLM(messages: ChatMessage[], apiKey: string) {
         throw new Error(`OpenAI API error: ${response.status} ${response.statusText} - ${text}`);
     }
 
-    const data = await response.json();
+    const data = (await response.json()) as {
+        choices: { message: { content: string } }[];
+        usage: unknown;
+    };
     let content = data.choices[0].message.content;
 
     // Clean markdown code blocks

--- a/packages/convex/convex/ingest_agent.ts
+++ b/packages/convex/convex/ingest_agent.ts
@@ -136,7 +136,10 @@ export const processNewResumes = internalAction({
         return { processed: 0, error };
       }
 
-      const result = await response.json();
+      const result = (await response.json()) as {
+        success?: boolean;
+        results?: unknown[];
+      };
 
       if (!result.success || !Array.isArray(result.results)) {
         const error = `Invalid BFF response: ${JSON.stringify(result)}`;

--- a/scripts/verify-critical-path.ts
+++ b/scripts/verify-critical-path.ts
@@ -16,13 +16,7 @@ type Logger = {
     warn: (message: string) => void;
 };
 
-type SeedResume = {
-    externalId: string;
-    content: Record<string, unknown>;
-    hash: string;
-    source: string;
-    tags: string[];
-};
+type SeedResume = (typeof api.seed.seedResumes)["_args"]["resumes"][number];
 
 export type StageResult = {
     status: VerifyStatus;
@@ -455,13 +449,15 @@ function loadSeedResumes(projectRoot: string): SeedResume[] {
     return resumes.map((resume, index) => {
         const externalId = resolveResumeExternalId(resume, index);
         const hash = createHash("sha256").update(JSON.stringify(resume), "utf8").digest("hex");
+        // `resume` is runtime-parsed JSON from the sample file; trusted to match
+        // the seed mutation's content shape (the script validates behaviorally).
         return {
             externalId,
             content: resume,
             hash,
             source,
             tags: ["sample-initial", "seed"],
-        };
+        } as SeedResume;
     });
 }
 


### PR DESCRIPTION
## What

Final target (T5) of the \`2026-06-16-typecheck-test-files-blindspot\` work item. Completes the apps/api test-file typecheck cleanup to **0 errors globally** and **flips the \`check-node-tests-types\` gate from report-only to hard-blocking**.

| | Before initiative | After T1 | After T2 | After T3 | After T4 | **After T5** |
|---|---|---|---|---|---|---|
| apps/api test-type errors | 551 | 551 (gate added) | 334 | 260 | 210 | **0** |

The Q3 phantom-filter blind spot is now **closed forever**: a new test passing a non-existent field to a typed production function will fail \`make check\`.

## Changes

### apps/api test files — 0 errors
- \`TS18046\` (\`response.json() → unknown\`) across all remaining routes + services: shared \`parseJsonBody<T>\` helper (no \`as any\`/\`@ts-ignore\`).
- **Category-b mock-shape drift** (the valuable catches the gate exists for):
  - \`BrandEntry\` mocks missing \`id/type/origin\`; \`CompanyPattern\` phantom \`category\`.
  - \`RoleSignalSummary\` missing \`industryVerifiedYears\`; \`ResumeWorkHistoryItem\` missing \`raw\`.
  - \`UnifiedKeywordExpansion\` missing \`originalKeyword\`; \`SearchProfile\` missing \`location\`.
  - \`RankingLabel\` literals widened to \`string\` (added \`as const\`).
  - \`createRun\` doesn't accept \`feedbackImportedAt\` (set later by feedback import) — removed no-op field.
  - \`ResumeIndex\` phantom \`sourceKey\`/\`hash\` — rewrote \`makeIndex\` to the real shape.
- **One category-c production fix**: \`mergeResolvedItemsById\` return type now reflects the \`source\` field it always set at runtime (zero runtime change; production typecheck green; callers unaffected).

### Cross-package (transitively compiled — apps/api tests import convex source)
Surfaced by the stricter \`@types/node\`-25 lens (convex's own typecheck treats \`response.json()\` as \`any\`):
- \`packages/convex/convex/analyze.ts\`, \`ingest_agent.ts\`: narrow the \`response.json()\` boundary (\`data.choices\` / \`result.success\` were accessed on \`unknown\` — real latent unsafety). Zero runtime change; convex's own typecheck still green.
- \`scripts/verify-critical-path.ts\`: derive \`SeedResume\` from the \`seedResumes\` mutation input so they cannot drift.

### Gate flip
\`TESTS_TYPES_GATE ?= hard\` in the Makefile. \`make check\` now fails on new test-file type errors (override with \`TESTS_TYPES_GATE=report-only\`).

## No blanket suppression
Zero \`as any\` / \`@ts-ignore\` / \`@ts-expect-error\` introduced anywhere in apps/api tests. Only audited casts at genuine JSON/lib boundaries: \`parseJsonBody<T>\` (test helper), the convex \`response.json()\` narrowing, one \`as SeedResume\` at a JSON-parse boundary in the script, and the repo-convention \`as Id<"resumes">\` / openid \`as unknown as\` bridge (both pre-existing idioms).

## Verification
- \`npm --workspace @trends/api run typecheck:tests\` → **0 errors**.
- \`npm --workspace @trends/convex run typecheck\` → green (convex production unaffected).
- \`npm test\` → **299 files / 5656 passed, 7 skipped, 0 failures**.
- \`make check\` → green (gate hard-blocking, reports 0 errors).

## Follow-ups (out of scope, noted)
- apps/api tests deep-import convex source (\`search-text-builder\`, \`verify-critical-path\`, \`benchmark-critical-path\`) via 5-level relative paths — ideally that shared logic lives in \`@trends/shared\` so the apps/api gate doesn't compile convex source at all.
- Pre-existing \`as any\` in \`packages/convex/convex/analyze.ts:378\` (\`internal as any\`) — not touched here; separate convex concern.

Closes the \`typecheck-test-files-blindspot\` work item (Req 1 + Req 2). Phase 4 Step 3 (hot-field removal) remains human-only — surfaced separately to the user.