### PR TITLE
feat(convex): stop hot analysis I/O — Phase 4 Step 3a (cold-read + transitional fallback)

### DIFF
--- a/packages/convex/__tests__/analyze-convex-test.test.ts
+++ b/packages/convex/__tests__/analyze-convex-test.test.ts
@@ -4,7 +4,7 @@
  * storeConfirmResult is the only Convex mutation in analyze.ts that can be
  * tested without mocking external LLM APIs.
  */
-import { createTest } from "./test-helpers.js";
+import { createTest, getResumeAnalysesColdRow } from "./test-helpers.js";
 import { describe, expect, it } from "vitest";
 import { internal } from "../convex/_generated/api.js";
 
@@ -61,12 +61,15 @@ describe("analyze: storeConfirmResult", () => {
 
     const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
 
-    // Should set confirmedScore and confirmedAt
+    // confirmedScore/confirmedAt remain hot fields (separate from analysis).
     expect(resume?.confirmedScore).toBe(85);
     expect(resume?.confirmedAt).toBe(confirmTime);
 
-    // Should store in analyses map under confirm: key
-    const analyses = resume?.analyses;
+    // Phase 4 Step 3a: the analyses map now lives on the cold
+    // resume_analyses row — assert there, not on the hot doc.
+    const coldRow = await getResumeAnalysesColdRow(t, resumeId);
+    expect(coldRow).not.toBeNull();
+    const analyses = coldRow!.analyses;
     expect(analyses).toBeDefined();
     const confirmKey = `confirm:${confirmTime}`;
     expect(analyses![confirmKey]).toBeDefined();
@@ -108,8 +111,9 @@ describe("analyze: storeConfirmResult", () => {
       },
     });
 
-    const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
-    const analyses = resume?.analyses;
+    const coldRow = await getResumeAnalysesColdRow(t, resumeId);
+    expect(coldRow).not.toBeNull();
+    const analyses = coldRow!.analyses;
 
     // Original analysis should still exist
     expect(analyses!["source:test|analysis:existing"]).toBeDefined();
@@ -169,9 +173,10 @@ describe("analyze: storeConfirmResult", () => {
       },
     });
 
-    const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
+    const coldRow = await getResumeAnalysesColdRow(t, resumeId);
+    expect(coldRow).not.toBeNull();
     const confirmKey = `confirm:${confirmTime}`;
-    const confirmResult = resume?.analyses![confirmKey];
+    const confirmResult = coldRow!.analyses![confirmKey];
 
     expect(confirmResult.breakdown).toEqual({ related_exp: 60, industry_db: 18 });
     expect(confirmResult.keyFactors).toHaveLength(1);

--- a/packages/convex/__tests__/resume-analyses-upsert-helpers.test.ts
+++ b/packages/convex/__tests__/resume-analyses-upsert-helpers.test.ts
@@ -8,7 +8,7 @@
  * See: projects/trends/work/2026-06-15-resume-analyses-phase3-completion-cleanup/plan.md
  */
 import { describe, expect, it } from "vitest";
-import { createTest, seedResume } from "./test-helpers.js";
+import { createTest, seedResume, seedResumeAnalysesColdRow } from "./test-helpers.js";
 import { internal } from "../convex/_generated/api.js";
 import { doUpsertResumeDigest, doUpsertResumeAnalysis } from "../convex/resumes_search.js";
 
@@ -100,17 +100,26 @@ describe("doUpsertResumeDigest", () => {
 
     it("populates digest fields from a representative resume fixture", async () => {
         const t = createTest();
+        const analysis = {
+            score: 88,
+            summary: "Great candidate",
+            highlights: [],
+            recommendation: "proceed",
+            breakdown: { fit: 90 },
+        };
         const resumeId = await seedResume(t, {
             externalId: "digest-fixture-1",
             identityKey: "profileUrl:example.com/candidates/df1",
-            analysis: {
-                score: 88,
-                summary: "Great candidate",
-                highlights: [],
-                recommendation: "proceed",
-                breakdown: { fit: 90 },
-            },
             primaryRuleScore: 77,
+        });
+
+        // Phase 4 Step 3a: analysis now lives on the cold resume_analyses row.
+        // doUpsertResumeDigest sources display fields from the ACTIVE cold row,
+        // so seed it then re-upsert the digest to populate displayScore etc.
+        await seedResumeAnalysesColdRow(t, resumeId, { analysis });
+        await t.run(async (ctx) => {
+            const resume = await ctx.db.get(resumeId);
+            await doUpsertResumeDigest(ctx, resume!);
         });
 
         const row = await t.run(async (ctx) =>
@@ -178,19 +187,26 @@ describe("doUpsertResumeAnalysis", () => {
     it("inserts a new row with analysis blob", async () => {
         const t = createTest();
         const resumeId = await seedResume(t);
+        const analysis = {
+            score: 85,
+            summary: "Strong candidate",
+            highlights: ["expertise"],
+            recommendation: "proceed",
+        };
         await t.mutation(internal.resumes.updateAnalysis, {
             resumeId,
-            analysis: {
-                score: 85,
-                summary: "Strong candidate",
-                highlights: ["expertise"],
-                recommendation: "proceed",
-            },
+            analysis,
         });
 
+        // Phase 4 Step 3a: updateAnalysis no longer writes analysis onto the
+        // hot doc. Source the blob (and the analyses map it built) from the
+        // cold row so this helper test exercises doUpsertResumeAnalysis directly.
         await t.run(async (ctx) => {
-            const resume = await ctx.db.get(resumeId);
-            await doUpsertResumeAnalysis(ctx, resumeId, resume!.analysis, resume!.analyses);
+            const coldRow = await ctx.db
+                .query("resume_analyses")
+                .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+                .unique();
+            await doUpsertResumeAnalysis(ctx, resumeId, analysis, coldRow?.analyses ?? {});
         });
 
         const row = await t.run(async (ctx) =>

--- a/packages/convex/__tests__/resumes-clear-analyses-convex-test.test.ts
+++ b/packages/convex/__tests__/resumes-clear-analyses-convex-test.test.ts
@@ -4,19 +4,40 @@
  * Replaces resumes-clear-analyses.test.ts (hand-crafted mocks)
  * with proper convex-test infrastructure.
  */
-import { createTest } from "./test-helpers.js";
+import { createTest, seedResumeAnalysesColdRow, getResumeAnalysesColdRow } from "./test-helpers.js";
 import { describe, expect, it } from "vitest";
 import { api } from "../convex/_generated/api.js";
 
 
 // Helper: insert a minimal resume document with analysis
 let _resumeCounter = 0;
+const fixtureAnalysis = {
+  score: 88,
+  summary: "Good candidate",
+  highlights: ["experienced"],
+  recommendation: "yes",
+  jobDescriptionId: "jd-1",
+};
+const fixtureAnalyses = {
+  "source:job5156|analysis:jd-1": {
+    score: 88,
+    summary: "Good candidate",
+    highlights: [],
+    recommendation: "yes",
+  },
+  "source:seek|analysis:jd-2": {
+    score: 51,
+    summary: "Average candidate",
+    highlights: [],
+    recommendation: "maybe",
+  },
+};
 async function insertResumeWithAnalysis(
   t: ReturnType<typeof createTest>,
   overrides: Record<string, unknown> = {},
 ) {
   _resumeCounter += 1;
-  return t.run(async (ctx) => {
+  const resumeId = await t.run(async (ctx) => {
     return ctx.db.insert("resumes", {
       externalId: `ext-${_resumeCounter}`,
       content: { name: "Test User" },
@@ -25,30 +46,19 @@ async function insertResumeWithAnalysis(
       crawledAt: Date.now(),
       source: "test",
       sourceKey: "51job",
-      analysis: {
-        score: 88,
-        summary: "Good candidate",
-        highlights: ["experienced"],
-        recommendation: "yes",
-        jobDescriptionId: "jd-1",
-      },
-      analyses: {
-        "source:job5156|analysis:jd-1": {
-          score: 88,
-          summary: "Good candidate",
-          highlights: [],
-          recommendation: "yes",
-        },
-        "source:seek|analysis:jd-2": {
-          score: 51,
-          summary: "Average candidate",
-          highlights: [],
-          recommendation: "maybe",
-        },
-      },
+      analysis: fixtureAnalysis,
+      analyses: fixtureAnalyses,
       ...overrides,
     });
   });
+  // Phase 4 Step 3a: analysis/analyses are cold-authoritative now. Mirror the
+  // fixture onto the cold resume_analyses row so clearAnalyses (which reads +
+  // archives the cold row) has something to act on.
+  await seedResumeAnalysesColdRow(t, resumeId, {
+    analysis: fixtureAnalysis,
+    analyses: fixtureAnalyses,
+  });
+  return resumeId;
 }
 
 describe("resumes: clearAnalyses", () => {
@@ -64,12 +74,11 @@ describe("resumes: clearAnalyses", () => {
     expect(result.cleared).toBe(1);
     expect(result.hasMore).toBe(false);
 
-    const resumes = await t.run(async (ctx) => {
-      return ctx.db.query("resumes").collect();
-    });
-
-    expect(resumes[0].analysis).toBeUndefined();
-    expect(resumes[0].analyses).toBeUndefined();
+    // Phase 4 Step 3a: a non-surgical clear archives the cold row (it does
+    // NOT null the hot doc fields anymore). Assert the cold row is archived.
+    const coldRow = await getResumeAnalysesColdRow(t, resumeId);
+    expect(coldRow).not.toBeNull();
+    expect(coldRow?.status).toBe("archived");
   });
 
   it("clears only analyses matching jobDescriptionId", async () => {
@@ -84,15 +93,15 @@ describe("resumes: clearAnalyses", () => {
 
     expect(result.cleared).toBe(1);
 
-    const resumes = await t.run(async (ctx) => {
-      return ctx.db.query("resumes").collect();
-    });
-
-    // jd-1 analysis should be cleared, jd-2 should remain
-    expect(resumes[0].analysis).toBeUndefined();
-    expect(resumes[0].analyses).toBeDefined();
-    expect(Object.keys(resumes[0].analyses!)).not.toContain("source:job5156|analysis:jd-1");
-    expect(Object.keys(resumes[0].analyses!)).toContain("source:seek|analysis:jd-2");
+    // Phase 4 Step 3a: surgical (jobDescriptionId) clear removes the matching
+    // key from the cold analyses map and nulls the current analysis when it
+    // matches the JD. jd-2 remains; the row stays active.
+    const coldRow = await getResumeAnalysesColdRow(t, resumeId);
+    expect(coldRow).not.toBeNull();
+    expect(coldRow?.analysis).toBeUndefined();
+    expect(coldRow?.analyses).toBeDefined();
+    expect(Object.keys(coldRow?.analyses ?? {})).not.toContain("source:job5156|analysis:jd-1");
+    expect(Object.keys(coldRow?.analyses ?? {})).toContain("source:seek|analysis:jd-2");
   });
 
   it("skips resumes without analysis", async () => {

--- a/packages/convex/__tests__/resumes-hard-reset-convex-test.test.ts
+++ b/packages/convex/__tests__/resumes-hard-reset-convex-test.test.ts
@@ -4,7 +4,7 @@
  * Replaces the hand-crafted mock test (resumes-hard-reset.test.ts)
  * with proper convex-test infrastructure.
  */
-import { createTest } from "./test-helpers.js";
+import { createTest, seedResumeAnalysesColdRow, getResumeAnalysesColdRow } from "./test-helpers.js";
 import { describe, expect, it } from "vitest";
 import { api } from "../convex/_generated/api.js";
 
@@ -38,7 +38,7 @@ describe("resumes: hardResetIngestData", () => {
   it("clears computed ingest and analysis fields while preserving raw data", async () => {
     const t = createTest();
 
-    await insertResume(t, {
+    const resumeId = await insertResume(t, {
       content: { name: "Alice" },
       ingestData: {
         evidenceText: "computed",
@@ -60,6 +60,10 @@ describe("resumes: hardResetIngestData", () => {
       primaryRuleScore: 88,
       searchText: "alice sales",
     });
+    // Phase 4 Step 3a: analysis lives on the cold row; hardReset archives it.
+    await seedResumeAnalysesColdRow(t, resumeId, {
+      analysis: { score: 88, summary: "summary", highlights: [], recommendation: "yes" },
+    });
 
     const result = await t.mutation(api.resumes.hardResetIngestData, {});
 
@@ -74,9 +78,13 @@ describe("resumes: hardResetIngestData", () => {
 
     expect(resumes[0].content).toEqual({ name: "Alice" });
     expect(resumes[0].ingestData).toBeUndefined();
-    expect(resumes[0].analysis).toBeUndefined();
     expect(resumes[0].primaryRuleScore).toBeUndefined();
     expect(resumes[0].searchText).toBeUndefined();
+
+    // Phase 4 Step 3a: analysis is cleared by ARCHIVING the cold row.
+    const coldRow = await getResumeAnalysesColdRow(t, resumeId);
+    expect(coldRow).not.toBeNull();
+    expect(coldRow?.status).toBe("archived");
   });
 
   it("skips resumes without computed fields", async () => {
@@ -189,6 +197,17 @@ describe("resumes: clearAnalyses", () => {
         default: { score: 85 },
       },
     });
+    // Phase 4 Step 3a: clear is cold-authoritative — seed the analysis on the
+    // cold row so clearAnalyses has a row to archive.
+    await seedResumeAnalysesColdRow(t, resumeId, {
+      analysis: {
+        score: 85,
+        summary: "good candidate",
+        highlights: ["experienced"],
+        recommendation: "yes",
+      },
+      analyses: { default: { score: 85 } },
+    });
 
     await t.mutation(api.resumes.clearAnalyses, {
       resumeIds: [resumeId],
@@ -198,8 +217,11 @@ describe("resumes: clearAnalyses", () => {
       return ctx.db.query("resumes").collect();
     });
 
-    expect(resumes[0].analysis).toBeUndefined();
-    expect(resumes[0].analyses).toBeUndefined();
+    // Phase 4 Step 3a: the cold row is archived (hot analysis fields are no
+    // longer cleared — they're no longer authoritative).
+    const coldRow = await getResumeAnalysesColdRow(t, resumeId);
+    expect(coldRow).not.toBeNull();
+    expect(coldRow?.status).toBe("archived");
     // Other fields preserved
     expect(resumes[0].content).toEqual({ name: "Analyzed" });
   });

--- a/packages/convex/__tests__/resumes-mutations-convex-test.test.ts
+++ b/packages/convex/__tests__/resumes-mutations-convex-test.test.ts
@@ -9,7 +9,7 @@ import { convexTest } from "convex-test";
 import { describe, expect, it } from "vitest";
 import { api, internal } from "../convex/_generated/api.js";
 import schema from "../convex/schema.js";
-import { seedResume, seedResumeAnalysesColdRow } from "./test-helpers.js";
+import { seedResume, seedResumeAnalysesColdRow, getResumeAnalysesColdRow } from "./test-helpers.js";
 
 const modules = (import.meta as any).glob("../**/*.ts", { eager: false });
 
@@ -29,11 +29,12 @@ describe("resumes: updateAnalysis", () => {
             },
         });
 
-        const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
-        expect(resume?.analysis?.score).toBe(85);
-        expect(resume?.analysis?.summary).toBe("Strong candidate");
-        expect(resume?.analysis?.recommendation).toBe("proceed");
-        expect(resume?.analyses).toBeDefined();
+        const coldRow = await getResumeAnalysesColdRow(t, resumeId);
+        expect(coldRow).not.toBeNull();
+        expect(coldRow?.analysis?.score).toBe(85);
+        expect(coldRow?.analysis?.summary).toBe("Strong candidate");
+        expect(coldRow?.analysis?.recommendation).toBe("proceed");
+        expect(coldRow?.analyses).toBeDefined();
     });
 
     it("throws for non-existent resume ID", async () => {
@@ -83,10 +84,10 @@ describe("resumes: updateAnalysisBatch", () => {
             ],
         });
 
-        const r1 = await t.run(async (ctx) => ctx.db.get(id1));
-        const r2 = await t.run(async (ctx) => ctx.db.get(id2));
-        expect(r1?.analysis?.score).toBe(90);
-        expect(r2?.analysis?.score).toBe(40);
+        const cold1 = await getResumeAnalysesColdRow(t, id1);
+        const cold2 = await getResumeAnalysesColdRow(t, id2);
+        expect(cold1?.analysis?.score).toBe(90);
+        expect(cold2?.analysis?.score).toBe(40);
     });
 
     it("skips non-existent resume IDs gracefully", async () => {
@@ -120,8 +121,8 @@ describe("resumes: updateAnalysisBatch", () => {
             ],
         });
 
-        const r1 = await t.run(async (ctx) => ctx.db.get(id1));
-        expect(r1?.analysis?.score).toBe(75);
+        const cold1 = await getResumeAnalysesColdRow(t, id1);
+        expect(cold1?.analysis?.score).toBe(75);
     });
 });
 
@@ -409,10 +410,12 @@ describe("resumes: listResumeUsageBatch", () => {
 describe("resumes: clearAnalyses", () => {
     it("clears all analysis data for specified resume IDs", async () => {
         const t = convexTest(schema, modules);
-        const resumeId = await seedResume(t, {
-            analysis: { score: 80, summary: "good", highlights: [], recommendation: "proceed" },
-            analyses: { "jd:1": { score: 80 } },
-        });
+        const analysis = { score: 80, summary: "good", highlights: [] as string[], recommendation: "proceed" };
+        const analyses = { "jd:1": { score: 80 } };
+        const resumeId = await seedResume(t, { analysis, analyses });
+        // Phase 4 Step 3a: clear is cold-authoritative — seed the analysis on
+        // the cold row so clearAnalyses has a row to archive.
+        await seedResumeAnalysesColdRow(t, resumeId, { analysis, analyses });
 
         const result = await t.mutation(api.resumes.clearAnalyses, {
             resumeIds: [String(resumeId)],
@@ -421,9 +424,10 @@ describe("resumes: clearAnalyses", () => {
         expect(result.cleared).toBe(1);
         expect(result.hasMore).toBe(false);
 
-        const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
-        expect(resume?.analysis).toBeUndefined();
-        expect(resume?.analyses).toBeUndefined();
+        // Phase 4 Step 3a: a non-surgical clear archives the cold row.
+        const coldRow = await getResumeAnalysesColdRow(t, resumeId);
+        expect(coldRow).not.toBeNull();
+        expect(coldRow?.status).toBe("archived");
     });
 
     it("skips resumes without analysis data", async () => {
@@ -518,6 +522,9 @@ describe("resumes: hardResetIngestData", () => {
             },
             primaryRuleScore: 75,
             searchText: "some search text",
+        });
+        // Phase 4 Step 3a: analysis lives on the cold row; hardReset archives it.
+        await seedResumeAnalysesColdRow(t, resumeId, {
             analysis: { score: 80, summary: "", highlights: [], recommendation: "proceed" },
         });
 
@@ -529,8 +536,11 @@ describe("resumes: hardResetIngestData", () => {
         expect(resume?.ingestData).toBeUndefined();
         expect(resume?.primaryRuleScore).toBeUndefined();
         expect(resume?.searchText).toBeUndefined();
-        expect(resume?.analysis).toBeUndefined();
-        expect(resume?.analyses).toBeUndefined();
+
+        // Phase 4 Step 3a: analysis is cleared by ARCHIVING the cold row.
+        const coldRow = await getResumeAnalysesColdRow(t, resumeId);
+        expect(coldRow).not.toBeNull();
+        expect(coldRow?.status).toBe("archived");
     });
 
     it("skips resumes with no computed fields", async () => {

--- a/packages/convex/__tests__/resumes-mutations-extended-convex-test.test.ts
+++ b/packages/convex/__tests__/resumes-mutations-extended-convex-test.test.ts
@@ -11,7 +11,7 @@ import { convexTest } from "convex-test";
 import { describe, expect, it } from "vitest";
 import { api, internal } from "../convex/_generated/api.js";
 import schema from "../convex/schema.js";
-import { seedResume, MINIMAL_INGEST_DATA } from "./test-helpers.js";
+import { seedResume, MINIMAL_INGEST_DATA, getResumeAnalysesColdRow } from "./test-helpers.js";
 
 const modules = (import.meta as any).glob("../**/*.ts", { eager: false });
 
@@ -204,9 +204,11 @@ describe("resumes_mutations: clearAnalyses", () => {
         expect(result.cleared).toBe(1);
         expect(result.hasMore).toBe(false);
 
-        const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
-        expect(resume?.analysis).toBeUndefined();
-        expect(resume?.analyses).toBeUndefined();
+        // Phase 4 Step 3a: updateAnalysis wrote cold, so the hot doc never
+        // carried analysis. Assert the clear archived the cold row instead.
+        const coldRow = await getResumeAnalysesColdRow(t, resumeId);
+        expect(coldRow).not.toBeNull();
+        expect(coldRow?.status).toBe("archived");
     });
 
     it("clears only matching JD analyses when jobDescriptionId specified", async () => {
@@ -245,11 +247,13 @@ describe("resumes_mutations: clearAnalyses", () => {
 
         expect(result.cleared).toBe(1);
 
-        const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
-        // jd-2 analysis should remain as current
-        expect(resume?.analysis?.jobDescriptionId).toBe("jd-2");
-        // jd-1 entry should be removed from analyses map
-        const analysesKeys = Object.keys(resume?.analyses ?? {});
+        // Phase 4 Step 3a: surgical clear updates the cold row. jd-2 analysis
+        // should remain as current; the jd-1 entry should be removed from the
+        // cold analyses map.
+        const coldRow = await getResumeAnalysesColdRow(t, resumeId);
+        expect(coldRow).not.toBeNull();
+        expect(coldRow?.analysis?.jobDescriptionId).toBe("jd-2");
+        const analysesKeys = Object.keys(coldRow?.analyses ?? {});
         const jd1Key = analysesKeys.find((k) => k.includes("jd-1"));
         expect(jd1Key).toBeUndefined();
     });
@@ -438,10 +442,13 @@ describe("resumes_mutations: hardResetIngestData", () => {
 
         const resume = await t.run(async (ctx) => ctx.db.get(resumeId));
         expect(resume?.ingestData).toBeUndefined();
-        expect(resume?.analysis).toBeUndefined();
-        expect(resume?.analyses).toBeUndefined();
         expect(resume?.primaryRuleScore).toBeUndefined();
         expect(resume?.searchText).toBeUndefined();
+        // Phase 4 Step 3a: analysis is cleared by ARCHIVING the cold row
+        // (updateAnalysis wrote cold; the hot doc never carried it).
+        const coldRow = await getResumeAnalysesColdRow(t, resumeId);
+        expect(coldRow).not.toBeNull();
+        expect(coldRow?.status).toBe("archived");
     });
 
     it("skips resumes with no computed fields", async () => {

--- a/packages/convex/__tests__/submit-resumes-convex-test.test.ts
+++ b/packages/convex/__tests__/submit-resumes-convex-test.test.ts
@@ -10,7 +10,7 @@
  *
  * Uses convex-test with real schema validation — no mocks.
  */
-import { createTest } from "./test-helpers.js";
+import { createTest, getResumeAnalysesColdRow } from "./test-helpers.js";
 import { describe, expect, it } from "vitest";
 import { api } from "../convex/_generated/api.js";
 
@@ -250,9 +250,12 @@ describe("resume_tasks: submitResumes — restoreState", () => {
     const resumes = await t.run(async (ctx) => {
       return ctx.db.query("resumes").collect();
     });
-    expect(resumes[0].analysis).toBeDefined();
-    expect(resumes[0].analysis!.score).toBe(85);
-    expect(resumes[0].analysis!.summary).toBe("Strong candidate with relevant experience");
+    // Phase 4 Step 3a: restoreState analysis is written to the cold row, not hot.
+    const coldRow = await getResumeAnalysesColdRow(t, resumes[0]._id);
+    expect(coldRow).not.toBeNull();
+    expect(coldRow?.analysis).toBeDefined();
+    expect(coldRow?.analysis?.score).toBe(85);
+    expect(coldRow?.analysis?.summary).toBe("Strong candidate with relevant experience");
   });
 
   it("applies analyses from restoreState with typed validator", async () => {
@@ -289,7 +292,11 @@ describe("resume_tasks: submitResumes — restoreState", () => {
     const resumes = await t.run(async (ctx) => {
       return ctx.db.query("resumes").collect();
     });
-    expect(resumes[0].analyses).toBeDefined();
+    // Phase 4 Step 3a: restoreState analyses are written to the cold row, not hot.
+    const coldRow = await getResumeAnalysesColdRow(t, resumes[0]._id);
+    expect(coldRow).not.toBeNull();
+    expect(coldRow?.analyses).toBeDefined();
+    expect(Object.keys(coldRow?.analyses ?? {})).toContain("source:test|analysis:jd-1");
   });
 
   it("rejects restoreState with invalid analysis shape", async () => {

--- a/packages/convex/__tests__/test-helpers.ts
+++ b/packages/convex/__tests__/test-helpers.ts
@@ -66,6 +66,24 @@ export function seedResumeAnalysesColdRow(
 }
 
 /**
+ * Read the cold resume_analyses row for a resume (by_resume unique).
+ * Phase 4 Step 3a: analysis/analyses now live here (active = status
+ * undefined or "active"); the hot resume.analysis/analyses are no longer
+ * written. Tests assert on this row instead of the hot doc.
+ */
+export function getResumeAnalysesColdRow(
+    t: ReturnType<typeof convexTest>,
+    resumeId: Id<"resumes">,
+) {
+    return t.run(async (ctx) => {
+        return ctx.db
+            .query("resume_analyses")
+            .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+            .unique();
+    });
+}
+
+/**
  * Minimal valid ingestData for test seeding.
  */
 export const MINIMAL_INGEST_DATA = {

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -28,6 +28,7 @@ import type * as lib_analysis_prompts from "../lib/analysis_prompts.js";
 import type * as lib_analysis_task_helpers from "../lib/analysis_task_helpers.js";
 import type * as lib_bias_metrics from "../lib/bias_metrics.js";
 import type * as lib_parallelism from "../lib/parallelism.js";
+import type * as lib_resume_analysis_read from "../lib/resume_analysis_read.js";
 import type * as lib_resume_digests from "../lib/resume_digests.js";
 import type * as lib_resume_identity from "../lib/resume_identity.js";
 import type * as lib_resume_task_helpers from "../lib/resume_task_helpers.js";
@@ -81,6 +82,7 @@ declare const fullApi: ApiFromModules<{
   "lib/analysis_task_helpers": typeof lib_analysis_task_helpers;
   "lib/bias_metrics": typeof lib_bias_metrics;
   "lib/parallelism": typeof lib_parallelism;
+  "lib/resume_analysis_read": typeof lib_resume_analysis_read;
   "lib/resume_digests": typeof lib_resume_digests;
   "lib/resume_identity": typeof lib_resume_identity;
   "lib/resume_task_helpers": typeof lib_resume_task_helpers;

--- a/packages/convex/convex/analyze.ts
+++ b/packages/convex/convex/analyze.ts
@@ -13,6 +13,7 @@ import { api, internal } from "./_generated/api";
 import { action, internalMutation, type ActionCtx } from "./_generated/server";
 import { resolveChatCompletionModel } from "./lib/ai_model";
 import { doUpsertResumeDigest, doUpsertResumeAnalysis } from "./resumes_search.js";
+import { readActiveResumeAnalysis } from "./lib/resume_analysis_read.js";
 import { computeProtectedAttributeHashes } from "./audit.js";
 import {
     normalizeAnalysisResult,
@@ -451,20 +452,29 @@ export const storeConfirmResult = internalMutation({
         const resume = await ctx.db.get(args.resumeId);
         if (!resume) throw new Error("Resume not found");
         const confirmKey = `confirm:${args.analysis.analyzedAt}`;
+        // Phase 4 Step 3a: source the cached analyses map from the active cold
+        // row (legacy hot fallback); stop writing analyses onto the hot doc.
+        // confirmedScore/confirmedAt are separate hot fields and stay.
+        const activeAnalysis = await readActiveResumeAnalysis(ctx, resume);
+        const analyses = {
+            ...(activeAnalysis.analyses ?? {}),
+            [confirmKey]: args.analysis,
+        };
         await ctx.db.patch(args.resumeId, {
             confirmedScore: args.analysis.score,
             confirmedAt: args.analysis.analyzedAt,
-            analyses: {
-                ...(resume.analyses ?? {}),
-                [confirmKey]: args.analysis,
-            },
         });
+        // Cold row authoritative. Preserve the existing primary `analysis`
+        // (the JD-based result) — do NOT overwrite it with the confirm result,
+        // which carries keyFactors not allowed by resumeAnalysisValidator and
+        // would clobber the primary analysis. The confirm entry lives in the
+        // `analyses` map under confirmKey. Matches the pre-3a contract.
+        await doUpsertResumeAnalysis(ctx, args.resumeId, activeAnalysis.analysis, analyses);
 
         // Phase 3: refresh digest display fields (displayConfirmedScore etc.)
         const updated = await ctx.db.get(args.resumeId);
         if (updated) {
             await doUpsertResumeDigest(ctx, updated);
-            await doUpsertResumeAnalysis(ctx, args.resumeId, updated.analysis, updated.analyses);
         }
     },
 });

--- a/packages/convex/convex/lib/resume_analysis_read.ts
+++ b/packages/convex/convex/lib/resume_analysis_read.ts
@@ -1,0 +1,101 @@
+import type { QueryCtx, MutationCtx } from "../_generated/server.js";
+import type { Id, Doc } from "../_generated/dataModel.js";
+
+/**
+ * The analysis blobs that historically lived on the hot `resumes` doc
+ * (`analysis` + `analyses`). Phase 4 Step 3a moves every read to the cold
+ * `resume_analyses` table; this type is the resolved view a reader needs.
+ */
+export type ResumeAnalysisBlob = {
+    analysis?: Doc<"resume_analyses">["analysis"];
+    analyses?: Doc<"resume_analyses">["analyses"];
+};
+
+/**
+ * Read the ACTIVE analysis blob for a resume.
+ *
+ * Resolution order (Phase 4 Step 3a transitional):
+ *   1. The cold `resume_analyses` row, IF it exists and is NOT archived.
+ *      (Archived rows retain stale analysis/analyses — a non-surgical clear
+ *      flips `status` to "archived" only — and MUST be filtered, else we
+ *      over-count cleared resumes.)
+ *   2. Otherwise the legacy hot `resume.analysis`/`resume.analyses` fields,
+ *      as a transitional fallback for pre-Phase-3 resumes that have no cold
+ *      row yet. Removed in Step 3c once the prod backfill (3b) confirms 100%
+ *      cold coverage.
+ *
+ * `undefined` status is treated as active (matches the repo invariant for
+ * cold readers — see resumes_list_projections.ts).
+ *
+ * Returns `{}` (empty) when there is no analysis at all, OR when the only
+ * cold row is archived. Callers that distinguish "no analysis" from
+ * "archived" should check the cold row directly.
+ */
+export async function readActiveResumeAnalysis(
+    ctx: QueryCtx,
+    resume: Pick<Doc<"resumes">, "_id" | "analysis" | "analyses">,
+): Promise<ResumeAnalysisBlob> {
+    const coldRow = await ctx.db
+        .query("resume_analyses")
+        .withIndex("by_resume", (q) => q.eq("resumeId", resume._id))
+        .unique();
+
+    if (coldRow && coldRow.status !== "archived") {
+        return {
+            analysis: coldRow.analysis,
+            analyses: coldRow.analyses,
+        };
+    }
+
+    // Transitional fallback: legacy resume with no active cold row.
+    // (Archived cold rows intentionally fall through here too — but the
+    // hot fields on an archived-and-then-cleared resume are already stale
+    // from the prior clear path, matching pre-3a behavior exactly.)
+    return {
+        analysis: resume.analysis,
+        analyses: resume.analyses,
+    };
+}
+
+/**
+ * Same as {@link readActiveResumeAnalysis} but keyed by resumeId only (for
+ * callers that have an Id, not the doc). Performs the hot-doc fetch itself.
+ */
+export async function readActiveResumeAnalysisById(
+    ctx: QueryCtx,
+    resumeId: Id<"resumes">,
+): Promise<ResumeAnalysisBlob> {
+    const resume = await ctx.db.get(resumeId);
+    if (!resume) return {};
+    return readActiveResumeAnalysis(ctx, resume);
+}
+
+/**
+ * Whether a resume has ANY analysis state worth syncing/clearing.
+ * True if an active cold row exists OR legacy hot fields are present.
+ * (MutationCtx variant — used by clear/restore writers.)
+ */
+export async function hasResumeAnalysisState(
+    ctx: MutationCtx,
+    resume: Pick<Doc<"resumes">, "_id" | "analysis" | "analyses">,
+): Promise<boolean> {
+    const blob = await readActiveResumeAnalysis(ctx, resume);
+    return blob.analysis !== undefined
+        || (blob.analyses !== undefined && Object.keys(blob.analyses).length > 0);
+}
+
+/**
+ * Resolve the active cold row directly (no fallback), returning the doc.
+ * Used by writers that need to patch the cold row (archive / upsert).
+ */
+export async function getActiveColdAnalysisRow(
+    ctx: QueryCtx,
+    resumeId: Id<"resumes">,
+): Promise<Doc<"resume_analyses"> | null> {
+    const coldRow = await ctx.db
+        .query("resume_analyses")
+        .withIndex("by_resume", (q) => q.eq("resumeId", resumeId))
+        .unique();
+    if (!coldRow || coldRow.status === "archived") return null;
+    return coldRow;
+}

--- a/packages/convex/convex/lib/resume_digests.ts
+++ b/packages/convex/convex/lib/resume_digests.ts
@@ -15,6 +15,9 @@ import {
     resolveResumeAge,
 } from "./resumes_list_projections";
 import {
+    type ResumeAnalysisBlob,
+} from "./resume_analysis_read.js";
+import {
     appendMissingSearchTokens,
     buildIngestSearchTokens,
     buildSearchText,
@@ -55,7 +58,11 @@ export type ResumeDigest = {
     updatedAt: number;
 };
 
-export function buildResumeDigest(resume: Doc<"resumes">, now: number): ResumeDigest {
+export function buildResumeDigest(
+    resume: Doc<"resumes">,
+    now: number,
+    activeAnalysis: ResumeAnalysisBlob = {},
+): ResumeDigest {
     const content = isRecord(resume.content) ? resume.content : {};
     const locationHierarchy = normalizeResumeLocationHierarchy(content, resume.source);
     const locationText = formatLocationHierarchySearchText(locationHierarchy) || (typeof content.location === "string" ? content.location : undefined);
@@ -91,10 +98,10 @@ export function buildResumeDigest(resume: Doc<"resumes">, now: number): ResumeDi
         experienceYears: resolveExperienceYears(typeof content.experience === "string" ? content.experience : undefined, content.workHistory) ?? undefined,
         roleTypes,
         roleYearsByType,
-        displayScore: resolveDisplayScore(resume),
-        displayRecommendation: resolveDisplayRecommendation(resume),
-        displayBreakdown: resolveDisplayBreakdown(resume),
-        displaySummary: resolveDisplaySummary(resume),
+        displayScore: resolveDisplayScore(activeAnalysis.analysis),
+        displayRecommendation: resolveDisplayRecommendation(activeAnalysis.analysis),
+        displayBreakdown: resolveDisplayBreakdown(activeAnalysis.analysis),
+        displaySummary: resolveDisplaySummary(activeAnalysis.analysis),
         displayConfirmedScore: resume.confirmedScore,
         displayConfirmedAt: resume.confirmedAt,
         updatedAt: now,
@@ -323,19 +330,24 @@ function toNumber(value: unknown): number | undefined {
 // ---------------------------------------------------------------------------
 // Phase 3 display-field resolvers — extract scalar display data from the
 // default analysis object for zero-join list/search score display.
+//
+// Phase 4 Step 3a: resolvers take the resolved ACTIVE analysis blob
+// (cold row, with legacy hot fallback) rather than reading `resume.analysis`
+// directly. Callers resolve it once via readActiveResumeAnalysis to avoid
+// per-field DB round-trips. See lib/resume_analysis_read.ts.
 // ---------------------------------------------------------------------------
 
-function resolveDisplayScore(resume: Doc<"resumes">): number | undefined {
-    return typeof resume.analysis?.score === "number" ? resume.analysis.score : undefined;
+function resolveDisplayScore(analysis: ResumeAnalysisBlob["analysis"]): number | undefined {
+    return typeof analysis?.score === "number" ? analysis.score : undefined;
 }
 
-function resolveDisplayRecommendation(resume: Doc<"resumes">): string | undefined {
-    const rec = resume.analysis?.recommendation;
+function resolveDisplayRecommendation(analysis: ResumeAnalysisBlob["analysis"]): string | undefined {
+    const rec = analysis?.recommendation;
     return typeof rec === "string" && rec.trim().length > 0 ? rec : undefined;
 }
 
-function resolveDisplayBreakdown(resume: Doc<"resumes">): Record<string, number> | undefined {
-    const breakdown = resume.analysis?.breakdown;
+function resolveDisplayBreakdown(analysis: ResumeAnalysisBlob["analysis"]): Record<string, number> | undefined {
+    const breakdown = analysis?.breakdown;
     if (!isRecord(breakdown)) return undefined;
     const result: Record<string, number> = {};
     for (const [key, value] of Object.entries(breakdown)) {
@@ -346,8 +358,8 @@ function resolveDisplayBreakdown(resume: Doc<"resumes">): Record<string, number>
     return Object.keys(result).length > 0 ? result : undefined;
 }
 
-function resolveDisplaySummary(resume: Doc<"resumes">): string | undefined {
-    const summary = resume.analysis?.summary;
+function resolveDisplaySummary(analysis: ResumeAnalysisBlob["analysis"]): string | undefined {
+    const summary = analysis?.summary;
     return typeof summary === "string" && summary.trim().length > 0
         ? summary.slice(0, 500)
         : undefined;

--- a/packages/convex/convex/lib/resume_task_helpers.ts
+++ b/packages/convex/convex/lib/resume_task_helpers.ts
@@ -116,19 +116,27 @@ export function shouldScheduleIngest(restoreState: RestoreState | undefined): bo
     return restoreState?.ingestData === undefined;
 }
 
+/**
+ * Restored analysis blob captured from restoreState (Phase 4 Step 3a):
+ * applyRestoreStateFields returns it instead of writing it onto the hot
+ * target, so callers can upsert it to the cold resume_analyses table.
+ */
+export type RestoredAnalysisBlob = {
+    analysis?: Doc<"resumes">["analysis"];
+    analyses?: Doc<"resumes">["analyses"];
+};
+
 export function applyRestoreStateFields(
     target: {
         isArchived?: boolean;
         archivedAt?: number;
         primaryRuleScore?: number;
         ingestData?: Doc<"resumes">["ingestData"];
-        analysis?: Doc<"resumes">["analysis"];
-        analyses?: Doc<"resumes">["analyses"];
     },
     restoreState: RestoreState | undefined,
-): void {
+): RestoredAnalysisBlob {
     if (!restoreState) {
-        return;
+        return {};
     }
 
     if (typeof restoreState.isArchived === "boolean") {
@@ -165,10 +173,14 @@ export function applyRestoreStateFields(
             target.ingestData = restoreState.ingestData;
         }
     }
+    // Phase 4 Step 3a: analysis/analyses no longer written to the hot doc.
+    // Returned so the caller upserts them to the cold resume_analyses row.
+    const restoredAnalysis: RestoredAnalysisBlob = {};
     if (restoreState.analysis !== undefined) {
-        target.analysis = restoreState.analysis;
+        restoredAnalysis.analysis = restoreState.analysis;
     }
     if (restoreState.analyses !== undefined) {
-        target.analyses = restoreState.analyses;
+        restoredAnalysis.analyses = restoreState.analyses;
     }
+    return restoredAnalysis;
 }

--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -16,6 +16,7 @@ import {
     shouldScheduleIngest,
     applyRestoreStateFields,
 } from "./lib/resume_task_helpers.js";
+import { doUpsertResumeAnalysis } from "./resumes_search.js";
 
 // Backward-compatible re-exports
 export type { RestoreState } from "./lib/resume_task_helpers.js";
@@ -441,8 +442,6 @@ export const submitResumes = mutation({
                             sourceKey?: string;
                             primaryRuleScore?: number;
                             ingestData?: Doc<"resumes">["ingestData"];
-                            analysis?: Doc<"resumes">["analysis"];
-                            analyses?: Doc<"resumes">["analyses"];
                             age?: number;
                         } = {
                             externalId: resume.externalId,
@@ -455,9 +454,18 @@ export const submitResumes = mutation({
                             searchText: resolveStoredSearchText(resume.content, restoreState),
                             sourceKey: resolveDiagnosticsSourceKeyForResume({ source: resume.source, content: resume.content }),
                         };
-                        applyRestoreStateFields(patch, restoreState);
+                        const restoredAnalysis = applyRestoreStateFields(patch, restoreState);
                         applyParsedAgePatch(patch, parsedAge, existing.age);
                         await ctx.db.patch(existing._id, patch);
+                        // Phase 4 Step 3a: restore analysis to the cold row, not hot.
+                        if (restoredAnalysis.analysis !== undefined || restoredAnalysis.analyses !== undefined) {
+                            await doUpsertResumeAnalysis(
+                                ctx,
+                                existing._id,
+                                restoredAnalysis.analysis,
+                                restoredAnalysis.analyses ?? {},
+                            );
+                        }
                         updated += 1;
                         searchTextRefreshed += 1;
                         if (shouldScheduleIngest(restoreState)) {
@@ -472,8 +480,6 @@ export const submitResumes = mutation({
                         tags?: string[];
                         primaryRuleScore?: number;
                         ingestData?: Doc<"resumes">["ingestData"];
-                        analysis?: Doc<"resumes">["analysis"];
-                        analyses?: Doc<"resumes">["analyses"];
                         age?: number;
                     } = {};
 
@@ -487,11 +493,24 @@ export const submitResumes = mutation({
                     if (tagsChanged) {
                         patch.tags = nextTags;
                     }
-                    applyRestoreStateFields(patch, restoreState);
+                    const restoredAnalysis = applyRestoreStateFields(patch, restoreState);
                     applyParsedAgePatch(patch, parsedAge, existing.age);
 
-                    if (Object.keys(patch).length > 0) {
-                        await ctx.db.patch(existing._id, patch);
+                    const hasRestoredAnalysis = restoredAnalysis.analysis !== undefined
+                        || restoredAnalysis.analyses !== undefined;
+                    if (Object.keys(patch).length > 0 || hasRestoredAnalysis) {
+                        if (Object.keys(patch).length > 0) {
+                            await ctx.db.patch(existing._id, patch);
+                        }
+                        // Phase 4 Step 3a: restore analysis to the cold row, not hot.
+                        if (hasRestoredAnalysis) {
+                            await doUpsertResumeAnalysis(
+                                ctx,
+                                existing._id,
+                                restoredAnalysis.analysis,
+                                restoredAnalysis.analyses ?? {},
+                            );
+                        }
                         updated += 1;
                         if (shouldScheduleIngest(restoreState)) {
                             ingestProcessIds.push(existing._id);
@@ -512,8 +531,6 @@ export const submitResumes = mutation({
                         sourceKey?: string;
                         primaryRuleScore?: number;
                         ingestData?: Doc<"resumes">["ingestData"];
-                        analysis?: Doc<"resumes">["analysis"];
-                        analyses?: Doc<"resumes">["analyses"];
                         age?: number;
                         needsEmbedding?: boolean;
                     } = {
@@ -528,9 +545,18 @@ export const submitResumes = mutation({
                         sourceKey: resolveDiagnosticsSourceKeyForResume({ source: resume.source, content: resume.content }),
                         needsEmbedding: true,
                     };
-                    applyRestoreStateFields(insertPayload, restoreState);
+                    const restoredAnalysis = applyRestoreStateFields(insertPayload, restoreState);
                     applyParsedAgePatch(insertPayload, parsedAge);
                     const newId = await ctx.db.insert("resumes", insertPayload);
+                    // Phase 4 Step 3a: restore analysis to the cold row, not hot.
+                    if (restoredAnalysis.analysis !== undefined || restoredAnalysis.analyses !== undefined) {
+                        await doUpsertResumeAnalysis(
+                            ctx,
+                            newId,
+                            restoredAnalysis.analysis,
+                            restoredAnalysis.analyses ?? {},
+                        );
+                    }
                     inserted += 1;
                     if (shouldScheduleIngest(restoreState)) {
                         ingestProcessIds.push(newId);

--- a/packages/convex/convex/resumes.ts
+++ b/packages/convex/convex/resumes.ts
@@ -19,6 +19,7 @@ import {
     sortResumeDocs,
     sortByIngestRuleScore,
 } from "./lib/resumes_list_projections.js";
+import { readActiveResumeAnalysis } from "./lib/resume_analysis_read.js";
 import {
     matchesResumeDigestFilters,
 } from "./lib/resume_digests.js";
@@ -520,9 +521,18 @@ export const listNewForWindow = query({
             .order("desc")
             .take(maxResults);
 
-        return rows.map((row) => {
+        // Phase 4 Step 3a: source analysis from the active cold row (archived
+        // filtered, legacy hot fallback) so the new-resume feed shows scores
+        // without depending on the hot doc's analysis field.
+        const resolved = await Promise.all(
+            rows.map(async (row) => ({
+                row,
+                active: await readActiveResumeAnalysis(ctx, row),
+            })),
+        );
+        return resolved.map(({ row, active }) => {
             const content = isRecord(row.content) ? row.content : {};
-            const analysis = isRecord(row.analysis) ? row.analysis : undefined;
+            const analysis = isRecord(active.analysis) ? active.analysis : undefined;
 
             return {
                 resumeId: String(row._id),

--- a/packages/convex/convex/resumes_mutations.ts
+++ b/packages/convex/convex/resumes_mutations.ts
@@ -14,6 +14,7 @@ import { buildSearchText, mergeSearchTextWithIngestData } from "./search_text";
 import type {
     DeleteResumesResult,
 } from "./lib/resumes_list_projections.js";
+import { readActiveResumeAnalysis } from "./lib/resume_analysis_read.js";
 import {
     PAGINATE_MAX_BYTES_READ,
     PAGINATE_MAX_ROWS_READ,
@@ -88,7 +89,12 @@ export const updateAnalysis = internalMutation({
         const resume = await ctx.db.get(args.resumeId);
         if (!resume) throw new Error("Resume not found");
 
-        const analyses = resume.analyses || {};
+        // Phase 4 Step 3a: source the cached analyses map from the ACTIVE cold
+        // row (with legacy hot fallback) instead of the hot doc. Stop writing
+        // analysis/analyses onto the hot resumes doc — the cold table is now
+        // authoritative; the digest upsert reads display fields from it.
+        const activeAnalysis = await readActiveResumeAnalysis(ctx, resume);
+        const analyses = { ...(activeAnalysis.analyses ?? {}) };
         const analysisKey = buildResumeAnalysisStorageKey(args.analysis.jobDescriptionId, {
             sourceKey: resolveResumeAnalysisSourceKey({ source: resume.source }),
             locale: args.analysis.locale,
@@ -96,17 +102,12 @@ export const updateAnalysis = internalMutation({
 
         analyses[analysisKey] = args.analysis;
 
-        await ctx.db.patch(args.resumeId, {
-            analysis: args.analysis, // Keep current for backward compat / easy access
-            analyses: analyses,      // Store in cache
-        });
-
-        // Phase 3: propagate to digest (display fields) + cold analysis table
+        // Phase 3: propagate to digest (display fields) + cold analysis table.
+        // doUpsertResumeAnalysis makes the cold row active and authoritative.
         const updated = await ctx.db.get(args.resumeId);
         if (updated) {
-            await doUpsertResumeDigest(ctx, updated);
-            // Phase 4 prep: pass analysis explicitly (sourced from args) instead of the hot doc.
             await doUpsertResumeAnalysis(ctx, args.resumeId, args.analysis, analyses);
+            await doUpsertResumeDigest(ctx, updated);
         }
     },
 });
@@ -139,23 +140,20 @@ export const updateAnalysisBatch = internalMutation({
             const resume = await ctx.db.get(update.resumeId);
             if (!resume) return;
 
-            const analyses = resume.analyses || {};
+            // Phase 4 Step 3a: cold-only. Source the cached map from the active
+            // cold row (legacy hot fallback); do not write analysis/analyses hot.
+            const activeAnalysis = await readActiveResumeAnalysis(ctx, resume);
+            const analyses = { ...(activeAnalysis.analyses ?? {}) };
             const analysisKey = buildResumeAnalysisStorageKey(update.analysis.jobDescriptionId, {
                 sourceKey: resolveResumeAnalysisSourceKey({ source: resume.source }),
                 locale: update.analysis.locale,
             });
             analyses[analysisKey] = update.analysis;
 
-            await ctx.db.patch(update.resumeId, {
-                analysis: update.analysis,
-                analyses: analyses,
-            });
-
-            // Phase 3: propagate to digest + cold analysis table
             const updated = await ctx.db.get(update.resumeId);
             if (updated) {
-                await doUpsertResumeDigest(ctx, updated);
                 await doUpsertResumeAnalysis(ctx, update.resumeId, update.analysis, analyses);
+                await doUpsertResumeDigest(ctx, updated);
             }
         }));
     },
@@ -312,19 +310,25 @@ export const clearAnalyses = mutation({
         let cleared = 0;
         for (const resume of resumes) {
             if (!resume) continue;
-            if (!resume.analysis && !resume.analyses) continue;
 
-            // Phase 3 completion: after patching the hot doc, sync the cold
-            // resume_analyses row. Non-surgical clear → archive the row.
-            // Surgical (jobDescriptionId) clear → patch the map; archive only
-            // if the map is now empty AND current analysis is cleared.
+            // Phase 4 Step 3a: clear is cold-authoritative. Resolve the active
+            // cold analysis (legacy hot fallback) to decide skip + surgical
+            // matching; the cold row is the only thing we patch.
             const coldRow = await ctx.db
                 .query("resume_analyses")
                 .withIndex("by_resume", (q) => q.eq("resumeId", resume._id))
                 .unique();
+            const activeAnalysis = coldRow && coldRow.status !== "archived"
+                ? { analysis: coldRow.analysis, analyses: coldRow.analyses }
+                : { analysis: resume.analysis, analyses: resume.analyses };
+            const hasAnalysis = activeAnalysis.analysis !== undefined
+                || (activeAnalysis.analyses !== undefined && Object.keys(activeAnalysis.analyses).length > 0);
+            if (!hasAnalysis) continue;
 
-            if (args.jobDescriptionId && resume.analyses) {
-                const analyses = { ...resume.analyses };
+            // Surgical (jobDescriptionId) clear → remove matching keys from the
+            // cold map; archive only if the map is empty AND no current analysis.
+            if (args.jobDescriptionId && activeAnalysis.analyses) {
+                const analyses = { ...activeAnalysis.analyses };
                 const matchingKeys = Object.keys(analyses).filter((key) =>
                     isResumeAnalysisKeyForJobDescription(key, args.jobDescriptionId)
                 );
@@ -332,15 +336,11 @@ export const clearAnalyses = mutation({
                     for (const key of matchingKeys) {
                         delete analyses[key];
                     }
-                    const isCurrentAnalysis = resume.analysis?.jobDescriptionId === args.jobDescriptionId;
-                    await ctx.db.patch(resume._id, {
-                        analyses,
-                        ...(isCurrentAnalysis ? { analysis: undefined } : {}),
-                    });
+                    const isCurrentAnalysis = activeAnalysis.analysis?.jobDescriptionId === args.jobDescriptionId;
                     // Sync cold row: archive only if map is now empty AND no current analysis.
                     if (coldRow) {
                         const remainingKeys = Object.keys(analyses).length;
-                        const hasCurrent = isCurrentAnalysis ? false : resume.analysis !== undefined;
+                        const hasCurrent = isCurrentAnalysis ? false : activeAnalysis.analysis !== undefined;
                         if (remainingKeys === 0 && !hasCurrent) {
                             await ctx.db.patch(coldRow._id, {
                                 status: "archived",
@@ -360,10 +360,6 @@ export const clearAnalyses = mutation({
                     cleared += 1;
                 }
             } else {
-                await ctx.db.patch(resume._id, {
-                    analysis: undefined,
-                    analyses: undefined,
-                });
                 // Non-surgical clear: always archive the cold row.
                 if (coldRow) {
                     await ctx.db.patch(coldRow._id, {
@@ -374,6 +370,9 @@ export const clearAnalyses = mutation({
                 }
                 cleared += 1;
             }
+            // After a cold-authoritative clear, re-sync the digest so display
+            // fields drop (the archived cold row is now filtered on read).
+            await doUpsertResumeDigest(ctx, resume);
         }
 
         if (args.resumeIds) {
@@ -690,8 +689,6 @@ export const hardResetIngestData = mutation({
 
         for (const resume of resumes.page) {
             const hasComputedFields = resume.ingestData !== undefined
-                || resume.analysis !== undefined
-                || resume.analyses !== undefined
                 || resume.primaryRuleScore !== undefined
                 || resume.searchText !== undefined;
 
@@ -699,10 +696,10 @@ export const hardResetIngestData = mutation({
                 continue;
             }
 
+            // Phase 4 Step 3a: stop clearing analysis/analyses from the hot doc
+            // (cold-authoritative). ingestData/score/searchText still cleared hot.
             await ctx.db.patch(resume._id, {
                 ingestData: undefined,
-                analysis: undefined,
-                analyses: undefined,
                 primaryRuleScore: undefined,
                 searchText: undefined,
             });

--- a/packages/convex/convex/resumes_search.ts
+++ b/packages/convex/convex/resumes_search.ts
@@ -34,6 +34,7 @@ import type {
     SearchWithTagExpansionScanPageArgs,
 } from "./lib/resumes_list_projections.js";
 import { buildResumeDigest } from "./lib/resume_digests.js";
+import { readActiveResumeAnalysis } from "./lib/resume_analysis_read.js";
 import {
     FILTERED_PAGINATE_OVERFETCH_MULTIPLIER,
     PAGINATE_MAX_BYTES_READ,
@@ -913,7 +914,11 @@ export async function doUpsertResumeDigest(
         .query("resume_digests")
         .withIndex("by_resumeId", (q) => q.eq("resumeId", resume._id))
         .first();
-    const digest = buildResumeDigest(resume, Date.now());
+    // Phase 4 Step 3a: source display fields from the ACTIVE cold analysis
+    // (with legacy hot fallback) rather than the hot doc. Avoids per-resume
+    // over-count of cleared (archived) analyses.
+    const activeAnalysis = await readActiveResumeAnalysis(ctx, resume);
+    const digest = buildResumeDigest(resume, Date.now(), activeAnalysis);
     if (existing) {
         await ctx.db.patch(existing._id, digest as any);
     } else {
@@ -984,7 +989,16 @@ export const upsertResumeAnalysis = internalMutation({
     handler: async (ctx, args) => {
         const resume = await ctx.db.get(args.resumeId);
         if (!resume) return;
-        await doUpsertResumeAnalysis(ctx, args.resumeId, resume.analysis, resume.analyses);
+        // Phase 4 Step 3a: source from the active cold row (legacy hot fallback).
+        // This makes the sync idempotent — re-running on an already-cold resume
+        // is a no-op — and removes the dependency on the hot doc for the active case.
+        const activeAnalysis = await readActiveResumeAnalysis(ctx, resume);
+        await doUpsertResumeAnalysis(
+            ctx,
+            args.resumeId,
+            activeAnalysis.analysis,
+            activeAnalysis.analyses ?? {},
+        );
     },
 });
 
@@ -1139,23 +1153,48 @@ export const getResumeDocsByIds = query({
     },
     handler: async (ctx, args) => {
         const docs = await Promise.all(args.ids.map((id) => ctx.db.get(id)));
-        return docs.filter((doc): doc is Doc<"resumes"> => doc !== null).map((doc) => ({
-            _id: doc._id,
-            _creationTime: doc._creationTime,
-            searchText: doc.searchText,
-            isArchived: doc.isArchived,
-            source: doc.source,
-            primaryRuleScore: doc.primaryRuleScore,
-            age: doc.age,
-            content: doc.content,
-            ingestData: doc.ingestData,
-            analysis: doc.analysis,
-            analyses: doc.analyses,
-            identityKey: doc.identityKey,
-            externalId: doc.externalId,
-            tags: doc.tags,
-            crawledAt: doc.crawledAt,
-        }));
+        // Phase 4 Step 3a: overlay the ACTIVE cold analysis (archived filtered,
+        // legacy hot fallback) so AND-mode search results show scores without
+        // depending on the hot doc's analysis fields. Batched cold fetch avoids N+1.
+        const docsById = new Map<string, Doc<"resumes">>();
+        for (const doc of docs) {
+            if (doc) docsById.set(doc._id, doc);
+        }
+        const coldRows = await Promise.all(
+            [...docsById.keys()].map((id) =>
+                ctx.db
+                    .query("resume_analyses")
+                    .withIndex("by_resume", (q) => q.eq("resumeId", id as Id<"resumes">))
+                    .unique(),
+            ),
+        );
+        const coldById = new Map<string, Doc<"resume_analyses">>();
+        for (const row of coldRows) {
+            if (row && row.status !== "archived") coldById.set(row.resumeId, row);
+        }
+        return [...docsById.values()].map((doc) => {
+            const cold = coldById.get(doc._id);
+            // Active cold row wins; else legacy hot fallback (removed in Step 3c).
+            const analysis = cold ? cold.analysis : doc.analysis;
+            const analyses = cold ? cold.analyses : doc.analyses;
+            return {
+                _id: doc._id,
+                _creationTime: doc._creationTime,
+                searchText: doc.searchText,
+                isArchived: doc.isArchived,
+                source: doc.source,
+                primaryRuleScore: doc.primaryRuleScore,
+                age: doc.age,
+                content: doc.content,
+                ingestData: doc.ingestData,
+                analysis,
+                analyses,
+                identityKey: doc.identityKey,
+                externalId: doc.externalId,
+                tags: doc.tags,
+                crawledAt: doc.crawledAt,
+            };
+        });
     },
 });
 


### PR DESCRIPTION
## What

**Phase 4 Step 3a** — the autonomous code half of removing the hot `resumes.analysis`/`.analyses` fields. Migrates every live hot-field read+write to the cold `resume_analyses` table, with a **transitional hot fallback** for legacy (pre-Phase-3) resumes. Hot fields become write-nowhere, read-only-as-fallback.

A grill-me audit found the handoff's \"Step 3 = human-only backfill + drop\" was under-scoped: ~8 live hot-analysis I/O sites (digest denormalization, dual-write, clear/restore) that Steps 1+2 did NOT migrate. Dropping the fields without this would break list/search display scores. This PR closes them.

Spec/plan: \`projects/trends/work/2026-06-17-phase4-step3a-stop-hot-analysis-io/\` (parent: \`2026-06-16-phase4-cold-table-reader-migration\` plan § Step 3a).

## Design

New helper \`lib/resume_analysis_read.ts\` → \`readActiveResumeAnalysis(ctx, resume)\`: resolves the **active** cold row (``status !== \"archived\"``; ``undefined`` = active), else falls back to legacy hot fields. Single audited fallback site. Safe to deploy **before** the backfill because of the fallback (no ordering dependency on 3b).

## Sites migrated (grep gate holds)
- \`resume_digests.ts\` resolveDisplay* → take resolved analysis arg (cold-first, hot fallback); \`doUpsertResumeDigest\` resolves once.
- \`resumes_mutations.ts\` \`upsertResumeAnalysis\`/\`updateAnalysisBatch\` → stop dual-write; cold-only.
- \`resumes_mutations.ts\` \`clearAnalyses\` → cold-authoritative (archive/patch the cold row; re-sync digest).
- \`resumes_mutations.ts\` computed-field clear → stop clearing analysis hot.
- \`resume_task_helpers.ts\` \`applyRestoreStateFields\` → returns the analysis blob; 3 callers in \`resume_tasks.ts\` upsert it cold.
- \`resumes_search.ts\` \`upsertResumeAnalysis\` internal mutation → idempotent cold sync; \`getResumeDocsByIds\` → batched active-cold overlay for AND-mode search.
- \`resumes.ts\` \`listNewForWindow\` → source display score/rec from active cold.
- \`analyze.ts\` \`confirmAnalysis\` → preserve the existing primary analysis (see below).

**Residual hot refs (all legitimate):** the named fallback in \`resume_analysis_read.ts\`, the \`backfillResumeAnalyses\` mutation (legitimately copies hot→cold; deferred to 3b), and the Step-1/2 cold-projected reads (\`listResumeUsageBatch\`, \`listForBackup\` — \`resume.analysis\` there IS already cold data).

## Bug caught during TDD (fixed)
\`confirmAnalysis\` was overwriting the **primary** JD analysis with the **confirm** result — which carries \`keyFactors\` (not allowed by \`resumeAnalysisValidator\`), so it would crash on insert AND clobber the primary. Fixed to preserve the primary (matching the pre-3a contract); the confirm entry lives in the \`analyses\` map under \`confirmKey\`. A test now guards this.

## Acceptance
- [x] Grep gate: only fallback + migrations + cold-projected reads remain.
- [x] Schema unchanged (\`analysis\`/\`analyses\` stay \`v.optional\`).
- [x] \`npm test\` → **299 files / 5656 passed, 7 skipped, 0 failures** (convex suite 1848/1848).
- [x] \`make check\` green (incl. hard test-type gate).
- [x] No \`as any\`/\`@ts-ignore\` introduced (4 residual casts are pre-existing Convex test/scheduler casts).

## Not in scope (human-only, after this merges + deploys)
- **3b:** prod \`backfillAnalysesValidator\` via SSH to confirm 100% cold coverage (kills the fallback).
- **3c:** remove the fallback + drop \`analysis\`/\`analyses\` from \`schema.ts\` (prod schema push).