### PR TITLE
fix(deploy): run production API through tsx

### DIFF
--- a/deploy/systemd/trends-api.service
+++ b/deploy/systemd/trends-api.service
@@ -10,7 +10,7 @@ Group=trends
 WorkingDirectory=/opt/trends
 EnvironmentFile=-/etc/trends/env
 Environment=NODE_ENV=production
-ExecStart=/usr/bin/node apps/api/dist/index.js
+ExecStart=/usr/bin/npx tsx apps/api/src/index.ts
 Restart=on-failure
 RestartSec=5
 StandardOutput=journal


### PR DESCRIPTION
## Summary
- update the production API systemd unit to run apps/api/src/index.ts through tsx
- matches the runtime path used by preview and avoids Node v25 ESM dist resolution failures

## Verification
- make check