### PR TITLE
feat(auth): admin endpoint to clear login lockouts

### DIFF
--- a/apps/api/src/middleware/login-rate-limit.ts
+++ b/apps/api/src/middleware/login-rate-limit.ts
@@ -127,3 +127,22 @@ export function resetOnSuccess(username: string, clientIp: string): void {
 export function __resetLoginRateLimiterForTests(): void {
   store.clear();
 }
+
+/**
+ * Clear all lockout entries for a username across every IP. Returns the
+ * number of entries removed. Use from the admin-unlock route so a locked-out
+ * user (typically the only admin who fat-fingered their password) can recover
+ * without waiting 15 minutes or restarting the API.
+ */
+export function clearLoginLockout(username: string): number {
+  const normalized = normalize(username);
+  const prefix = `${normalized}:`;
+  let removed = 0;
+  for (const key of store.keys()) {
+    if (key.startsWith(prefix)) {
+      store.delete(key);
+      removed += 1;
+    }
+  }
+  return removed;
+}

--- a/apps/api/src/routes/admin_users.test.ts
+++ b/apps/api/src/routes/admin_users.test.ts
@@ -6,6 +6,12 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createAuthMiddleware } from "../middleware/auth.js";
+import {
+  __resetLoginRateLimiterForTests,
+  recordLoginFailure,
+  LOGIN_MAX_FAILURES,
+  checkLoginAttempt,
+} from "../middleware/login-rate-limit.js";
 import { workspaceMiddleware } from "../middleware/workspace.js";
 import { AuthSessionService } from "../services/auth-session-service.js";
 import { AuthEventStorage } from "../services/auth-event-storage.js";
@@ -331,5 +337,179 @@ describe("POST /api/admin/reset-password", () => {
     // No reset happened
     const events = eventStorage.listRecent({ limit: 50 });
     expect(events.some((e) => e.type === "password_reset_completed")).toBe(false);
+  });
+});
+
+describe("POST /api/admin/auth/unlock", () => {
+  beforeEach(() => {
+    __resetLoginRateLimiterForTests();
+  });
+
+  afterEach(() => {
+    __resetLoginRateLimiterForTests();
+    resetResumeScreeningDb();
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 when caller has no session", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "admin-unlock-401-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(root);
+    const app = createTestApp(storage, eventStorage);
+
+    const res = await app.request("/api/admin/auth/unlock", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Workspace-Slug": "dev",
+        "X-CSRF-Token": "irrelevant-no-session",
+      },
+      body: JSON.stringify({ username: "victim" }),
+    });
+
+    expect([401, 403]).toContain(res.status);
+    const events = eventStorage.listRecent({ limit: 50 });
+    expect(events.some((e) => e.type === "login_lockout_cleared")).toBe(false);
+  });
+
+  it("returns 403 when caller is not in the dev workspace", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "admin-unlock-403-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(root);
+    // hr-admin is admin in 'hr', not 'dev' — must be denied at the workspace gate.
+    const hrAdmin = await seedLocalUser(storage, { username: "hr-admin", workspace: "hr", role: "admin" });
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const session = sessions.createSession(hrAdmin.user.id);
+    const app = createTestApp(storage, eventStorage);
+
+    const res = await app.request("/api/admin/auth/unlock", {
+      method: "POST",
+      headers: authHeaders("hr", session),
+      body: JSON.stringify({ username: "victim" }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("clears lockout for a locked username and emits an audit event", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "admin-unlock-ok-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(root);
+    const devAdmin = await seedDevAdmin(storage);
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const session = sessions.createSession(devAdmin.user.id);
+    const app = createTestApp(storage, eventStorage);
+
+    // Drive a real lockout via the public API so the test exercises the same
+    // path production hits — fake state via __resetLoginRateLimiterForTests
+    // would not assert that the unlock actually maps to the keyed entries.
+    for (let i = 0; i < LOGIN_MAX_FAILURES; i += 1) {
+      recordLoginFailure("locked-user", "203.0.113.7");
+    }
+    expect(checkLoginAttempt("locked-user", "203.0.113.7").allowed).toBe(false);
+
+    const res = await app.request("/api/admin/auth/unlock", {
+      method: "POST",
+      headers: authHeaders("dev", session),
+      body: JSON.stringify({ username: "locked-user" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await parseJsonBody<{ success: unknown; cleared: boolean; removedCount: number }>(res);
+    expect(body.success).toBe(true);
+    expect(body.cleared).toBe(true);
+    expect(body.removedCount).toBe(1);
+
+    // Lockout actually cleared.
+    expect(checkLoginAttempt("locked-user", "203.0.113.7").allowed).toBe(true);
+
+    // Audit event recorded with admin attribution.
+    const events = eventStorage.listRecent({ limit: 50 });
+    const evt = events.find((e) => e.type === "login_lockout_cleared");
+    expect(evt).toBeDefined();
+    expect(evt!.workspaceSlug).toBe("dev");
+    expect(evt!.metadata?.targetUsername).toBe("locked-user");
+    expect(evt!.metadata?.clearedByUserId).toBe(devAdmin.user.id);
+    expect(evt!.metadata?.cleared).toBe(true);
+    expect(evt!.metadata?.removedCount).toBe(1);
+  });
+
+  it("clears every IP-keyed entry for the username (multi-NAT recovery)", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "admin-unlock-multi-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(root);
+    const devAdmin = await seedDevAdmin(storage);
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const session = sessions.createSession(devAdmin.user.id);
+    const app = createTestApp(storage, eventStorage);
+
+    // Same user fat-fingered from laptop AND phone hotspot — two keyed entries.
+    for (let i = 0; i < LOGIN_MAX_FAILURES; i += 1) recordLoginFailure("dual-locked", "1.1.1.1");
+    for (let i = 0; i < LOGIN_MAX_FAILURES; i += 1) recordLoginFailure("dual-locked", "2.2.2.2");
+
+    const res = await app.request("/api/admin/auth/unlock", {
+      method: "POST",
+      headers: authHeaders("dev", session),
+      body: JSON.stringify({ username: "dual-locked" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await parseJsonBody<{ removedCount: number }>(res);
+    expect(body.removedCount).toBe(2);
+    expect(checkLoginAttempt("dual-locked", "1.1.1.1").allowed).toBe(true);
+    expect(checkLoginAttempt("dual-locked", "2.2.2.2").allowed).toBe(true);
+  });
+
+  it("returns success with cleared=false when the username has no active lockout", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "admin-unlock-noop-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(root);
+    const devAdmin = await seedDevAdmin(storage);
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const session = sessions.createSession(devAdmin.user.id);
+    const app = createTestApp(storage, eventStorage);
+
+    const res = await app.request("/api/admin/auth/unlock", {
+      method: "POST",
+      headers: authHeaders("dev", session),
+      body: JSON.stringify({ username: "never-locked" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await parseJsonBody<{ cleared: boolean; removedCount: number }>(res);
+    expect(body.cleared).toBe(false);
+    expect(body.removedCount).toBe(0);
+
+    // Audit event still emitted — operators need to see "unlock attempted, no-op".
+    const events = eventStorage.listRecent({ limit: 50 });
+    const evt = events.find((e) => e.type === "login_lockout_cleared");
+    expect(evt).toBeDefined();
+    expect(evt!.metadata?.cleared).toBe(false);
+    expect(evt!.metadata?.removedCount).toBe(0);
+  });
+
+  it("normalises the username (case-insensitive, trimmed) when matching keys", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "admin-unlock-norm-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(root);
+    const devAdmin = await seedDevAdmin(storage);
+    const sessions = new AuthSessionService(storage, { ttlSeconds: 3600 });
+    const session = sessions.createSession(devAdmin.user.id);
+    const app = createTestApp(storage, eventStorage);
+
+    // Lockout was recorded as "alice" (the rate-limiter normalises on input).
+    for (let i = 0; i < LOGIN_MAX_FAILURES; i += 1) recordLoginFailure("alice", "9.9.9.9");
+
+    // Admin types "  ALICE  " — should still match.
+    const res = await app.request("/api/admin/auth/unlock", {
+      method: "POST",
+      headers: authHeaders("dev", session),
+      body: JSON.stringify({ username: "  ALICE  " }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await parseJsonBody<{ cleared: boolean }>(res);
+    expect(body.cleared).toBe(true);
+    expect(checkLoginAttempt("alice", "9.9.9.9").allowed).toBe(true);
   });
 });

--- a/apps/api/src/routes/admin_users.ts
+++ b/apps/api/src/routes/admin_users.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 
+import { clearLoginLockout } from "../middleware/login-rate-limit.js";
 import { AuthEventStorage } from "../services/auth-event-storage.js";
 import { AuthStorage } from "../services/auth-storage.js";
 import { config } from "../services/config.js";
@@ -15,6 +16,16 @@ const ResetPasswordRequestSchema = z.object({
 const ResetPasswordResponseSchema = z.object({
   success: z.literal(true),
   temporaryPassword: z.string(),
+});
+
+const UnlockRequestSchema = z.object({
+  username: z.string().min(1),
+});
+
+const UnlockResponseSchema = z.object({
+  success: z.literal(true),
+  cleared: z.boolean(),
+  removedCount: z.number().int().nonnegative(),
 });
 
 const ErrorResponseSchema = z.object({
@@ -174,6 +185,84 @@ export function createAdminUserRoutes(options: AdminUserRoutesOptions) {
     });
 
     return c.json({ success: true as const, temporaryPassword }, 200);
+  });
+
+  // POST /api/admin/auth/unlock — clear login lockout for a username.
+  // Required because PR #1259's in-memory rate limiter has no auto-recovery
+  // path other than waiting 15 minutes or restarting the API. For a small-team
+  // product the realistic failure is the only admin fat-fingering their password
+  // — this endpoint exists so a second admin can unlock them without SSH.
+  const unlockRoute = createRoute({
+    method: "post",
+    path: "/api/admin/auth/unlock",
+    tags: ["admin"],
+    request: {
+      body: {
+        content: {
+          "application/json": {
+            schema: UnlockRequestSchema,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Lockout cleared (or no lockout was active)",
+        content: {
+          "application/json": {
+            schema: UnlockResponseSchema,
+          },
+        },
+      },
+      401: {
+        description: "Authentication required",
+        content: {
+          "application/json": {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+      403: {
+        description: "Admin access required",
+        content: {
+          "application/json": {
+            schema: ErrorResponseSchema,
+          },
+        },
+      },
+    },
+  });
+
+  app.openapi(unlockRoute, async (c) => {
+    const auth = c.var.auth;
+    if (!auth) {
+      return c.json({ success: false as const, error: "Authentication required" }, 401);
+    }
+
+    // Same system-admin gate as reset-password (ADR D4): dev-workspace only.
+    if (c.var.workspaceSlug !== "dev") {
+      return c.json({ success: false as const, error: "Admin access required" }, 403);
+    }
+
+    const { username } = c.req.valid("json");
+    const removedCount = clearLoginLockout(username);
+    const cleared = removedCount > 0;
+
+    // Audit trail. We always emit so a successful no-op (already-unlocked user)
+    // is still attributable — useful when investigating "did the unlock fire?"
+    getEventStorage().append({
+      type: "login_lockout_cleared",
+      workspaceSlug: c.var.workspaceSlug,
+      sessionId: auth.sessionId,
+      metadata: {
+        targetUsername: username.trim().toLowerCase(),
+        clearedByUserId: auth.user.id,
+        removedCount,
+        cleared,
+      },
+    });
+
+    return c.json({ success: true as const, cleared, removedCount }, 200);
   });
 
   return app;

--- a/apps/api/src/services/auth-event-types.ts
+++ b/apps/api/src/services/auth-event-types.ts
@@ -5,6 +5,7 @@ export type AuthEventType =
   | "logout"
   | "sessions_revoked"
   | "password_reset_completed"
+  | "login_lockout_cleared"
   | "csrf_reject"
   | "workspace_access_denied"
   | "admin_access_denied"

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -1017,6 +1017,78 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/auth/unlock": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        username: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Lockout cleared (or no lockout was active) */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            cleared: boolean;
+                            removedCount: number;
+                        };
+                    };
+                };
+                /** @description Authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Admin access required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/resumes/search-summary": {
         parameters: {
             query?: never;


### PR DESCRIPTION
## Why

Closes **Blocker 2** of `projects/trends/work/2026-06-18-prod-unpin-auth-readiness/spec.md`.

PR #1259 (login brute-force protection, in `main`) locks an account after 5 failed attempts within 15 min for 15 min. The store is in-memory and there is **no admin unlock path** — recovery is "wait 15 min", "log in from a different IP", or `systemctl restart trends-api`. For a small-team B2B product, the realistic failure mode is the only admin fat-fingering their password and locking themselves out at 3 AM.

## What

- New `POST /api/admin/auth/unlock` endpoint, gated on dev-workspace admin (ADR D4) like `reset-password`.
- Body: `{ username: string }`; response: `{ success: true, cleared: boolean, removedCount: number }`.
- Exports `clearLoginLockout(username)` from `login-rate-limit.ts` — clears every IP-keyed lockout entry for the normalised username (handles laptop + phone-hotspot dual lockout).
- New `login_lockout_cleared` audit event type, always emitted (even on no-op) so operators can see when an unlock was attempted.

## Tests

`bunx vitest run apps/api/src/routes/admin_users.test.ts` → 16 pass (10 existing + 6 new):

1. 401 when caller has no session
2. 403 when caller is not in `dev` workspace
3. 200 + cleared=true + audit event for a locked user
4. multi-IP unlock (clears all keyed entries for the username)
5. 200 + cleared=false when username has no active lockout (still emits audit event)
6. case-insensitive + trimmed username matching

`make check` green.

## Risk

- **Surface**: one new admin route. Same gate stack as `/api/admin/reset-password` (CSRF → optionalAuth → requireAdmin → workspace=dev).
- **Rate limiting**: none on the endpoint itself. A compromised dev-admin session could enumerate usernames via the `removedCount` field, but that's already true for `reset-password` (404 differentiation).
- **No migration / no schema change** — purely additive.

## Pre-deploy

This PR is part of the auth-readiness train. Do **not** deploy main to prod until PR #1259-#1263 are reviewed AND blocker 1 (admin seeding into `workspace_memberships`) is also closed. Prod remains pinned at `v0.4.6-hotfix` (`4ce93b90`).