### PR TITLE
feat(auth): deploy-time bootstrap admin seeding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,15 @@ AUTH_BOOTSTRAP_PASSWORD=demo-admin
 # AUTH_OIDC_CLIENT_SECRET=
 # AUTH_OIDC_REDIRECT_URI=http://localhost:3000/api/auth/oidc/callback
 
+# Bootstrap admin seeding (deploy-time). Comma-separated local usernames that
+# scripts/install.sh seeds into workspace_memberships with role=admin after
+# first service start, so the auth requireAdmin gate (#1261) does not lock out
+# every admin on first deploy. The password for each user is read from
+# BOOTSTRAP_ADMIN_PASSWORD_ENV (default AUTH_BOOTSTRAP_PASSWORD).
+# BOOTSTRAP_ADMIN_USERS=dev-admin
+# BOOTSTRAP_ADMIN_WORKSPACE=dev
+# BOOTSTRAP_ADMIN_PASSWORD_ENV=AUTH_BOOTSTRAP_PASSWORD
+
 # Experimental features
 # VITE_ENABLE_REVIEW_PACKETS=true   # Enable review-packets feature (off by default)
 # VITE_ENABLE_RESUME_AI_SUMMARY=true # Enable resume search AI result summary panel (off by default)

--- a/Makefile
+++ b/Makefile
@@ -1185,7 +1185,7 @@ fresh-env: clean clean-db
 	@echo "Fresh environment ready."
 
 # Run all validation checks (Python + Node.js + project skill sync + governance skill validation; honors TARGET=all)
-check: check-python check-node check-project-skills check-agent-policy check-agent-skill check-concept-drift check-route-auth check-mutation-entry-points
+check: check-python check-node check-project-skills check-agent-policy check-agent-skill check-concept-drift check-route-auth check-mutation-entry-points check-seed-bootstrap-admins
 	@echo "All checks passed"
 
 # Auth gating lint — verify API route files have auth middleware
@@ -1196,6 +1196,11 @@ check-route-auth:
 # in packages/convex/convex/_mutations_registry.ts (quiesce-coverage audit).
 check-mutation-entry-points:
 	@bash scripts/check-mutation-entry-points.sh
+
+# Bootstrap admin seeding — verify seed_bootstrap_admins() parsing/no-op logic
+# in scripts/install.sh (deploy-time admin seeding for the auth refactor).
+check-seed-bootstrap-admins:
+	@bash scripts/seed-bootstrap-admins.test.sh
 
 # Concept drift check — flags vault concept pages that may need review after code changes
 check-concept-drift:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1444,6 +1444,67 @@ validate_auth_env() {
     fi
 }
 
+# Seed bootstrap admin(s) into workspace_memberships so the auth refactor's
+# requireAdmin gate (PR #1261) does not lock every admin out of admin routes
+# on first deploy. Idempotent: manage-user.ts upserts, so safe on every upgrade.
+#
+# Env vars (read from the deployed env file / runtime env):
+#   BOOTSTRAP_ADMIN_USERS         comma-separated usernames (required to enable)
+#   BOOTSTRAP_ADMIN_WORKSPACE     workspace slug to grant admin in (default: dev)
+#   BOOTSTRAP_ADMIN_PASSWORD_ENV  env var name holding each user's password
+#                                 (default: AUTH_BOOTSTRAP_PASSWORD). The named
+#                                 var must be exported in the service env.
+#
+# No-op when BOOTSTRAP_ADMIN_USERS is unset/empty — existing deploys without
+# the var are unaffected. Runs AFTER start_services so the SQLite DB + schema
+# exist; the API itself is not required for the direct storage write.
+seed_bootstrap_admins() {
+    local bootstrap_users="${BOOTSTRAP_ADMIN_USERS:-}"
+    if [[ -z "$bootstrap_users" ]]; then
+        return 0
+    fi
+
+    local workspace="${BOOTSTRAP_ADMIN_WORKSPACE:-dev}"
+    local password_env="${BOOTSTRAP_ADMIN_PASSWORD_ENV:-AUTH_BOOTSTRAP_PASSWORD}"
+    local manage_script="$INSTALL_DIR/scripts/auth/manage-user.ts"
+
+    if [[ ! -f "$manage_script" ]]; then
+        log_warn "BOOTSTRAP_ADMIN_USERS set but $manage_script not found — skipping admin seeding."
+        return 0
+    fi
+
+    # The password env var must be visible to the service user. We re-source
+    # the deployed env so the seeding run sees it exactly as the API will.
+    local env_source=""
+    if [[ -f "$CONFIG_DIR/env" ]]; then
+        env_source="set -a && source '$CONFIG_DIR/env' && set +a"
+    fi
+
+    log_info "Seeding bootstrap admin(s) into workspace '$workspace'..."
+
+    local IFS=','
+    local user
+    local failures=0
+    for user in $bootstrap_users; do
+        # Trim whitespace.
+        user="$(echo "$user" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+        [[ -z "$user" ]] && continue
+
+        log_info "  → seeding admin '$user'"
+        if ! run_as_service_user "$env_source && cd '$INSTALL_DIR' && run_tsx_script scripts/auth/manage-user.ts --username '$user' --workspace '$workspace' --role admin --password-env '$password_env' --output agent"; then
+            log_warn "  → failed to seed admin '$user' (see output above). Continuing."
+            failures=$((failures + 1))
+        fi
+    done
+    # `local IFS` scopes the change to this function — no need to restore.
+
+    if [[ "$failures" -gt 0 ]]; then
+        log_warn "Bootstrap admin seeding completed with $failures failure(s). Verify workspace_memberships manually: SELECT user_id, workspace_slug, role FROM workspace_memberships;"
+    else
+        log_info "Bootstrap admin seeding complete."
+    fi
+}
+
 copy_file_if_exists() {
     local source_path="$1"
     local target_path="$2"
@@ -1914,6 +1975,7 @@ install_flow() {
     enable_units
     start_services
     wait_for_api_health
+    seed_bootstrap_admins
 
     echo ""
     log_info "Installation completed."
@@ -1948,6 +2010,7 @@ full_upgrade_steps() {
     install_systemd_units
     restart_units
     wait_for_api_health
+    seed_bootstrap_admins
 }
 
 upgrade_flow() {

--- a/scripts/seed-bootstrap-admins.test.sh
+++ b/scripts/seed-bootstrap-admins.test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Tests for the seed_bootstrap_admins() function in scripts/install.sh.
+#
+# install.sh has a top-level dispatch on "$1" that runs on source, so we
+# extract ONLY the seed_bootstrap_admins() function body and eval it in a
+# sandbox with stubbed callees. This proves the comma-parsing, no-op guard,
+# default-assignment, and trim logic without invoking the real deploy.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL_SH="$ROOT_DIR/scripts/install.sh"
+
+if [[ ! -f "$INSTALL_SH" ]]; then
+    echo "FAIL: $INSTALL_SH not found"
+    exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+CALLS_FILE="$TMP_DIR/calls.txt"
+: > "$CALLS_FILE"
+
+# --- Stubs for everything seed_bootstrap_admins calls ---
+log_info() { :; }
+log_warn() { :; }
+log_error() { :; }
+
+# Capture the command run_as_service_user would have executed.
+run_as_service_user() {
+    printf '%s\n' "$*" >> "$CALLS_FILE"
+    return 0
+}
+
+# Extract just the seed_bootstrap_admins() function from install.sh and eval
+# it in this shell. The function is delimited by `seed_bootstrap_admins() {`
+# ... `}` at column 1.
+FUNC_BODY="$(awk '
+    /^seed_bootstrap_admins\(\) \{/ { in_func=1 }
+    in_func { print }
+    in_func && /^\}/ { in_func=0 }
+' "$INSTALL_SH")"
+
+if [[ -z "$FUNC_BODY" ]]; then
+    echo "FAIL: could not extract seed_bootstrap_admins() from install.sh"
+    exit 1
+fi
+
+# shellcheck disable=SC1090
+eval "$FUNC_BODY"
+
+# Provide the globals the function reads.
+INSTALL_DIR="$ROOT_DIR"
+CONFIG_DIR="$TMP_DIR/config"
+mkdir -p "$CONFIG_DIR"
+: > "$CONFIG_DIR/env"   # empty env file exercises the env_source branch
+
+fail() {
+    echo "FAIL: $1"
+    echo "--- captured calls ---"
+    cat "$CALLS_FILE" 2>/dev/null || echo "(none)"
+    exit 1
+}
+
+# --- Test 1: no-op when BOOTSTRAP_ADMIN_USERS unset/empty ---
+: > "$CALLS_FILE"
+BOOTSTRAP_ADMIN_USERS="" seed_bootstrap_admins || true
+if [[ -s "$CALLS_FILE" ]]; then
+    fail "invoked manage-user when BOOTSTRAP_ADMIN_USERS was empty"
+fi
+echo "PASS: no-op when BOOTSTRAP_ADMIN_USERS unset"
+
+# --- Test 2: one call per user, trimmed ---
+: > "$CALLS_FILE"
+BOOTSTRAP_ADMIN_USERS="alice, bob ,carol" seed_bootstrap_admins || true
+COUNT=$(wc -l < "$CALLS_FILE" | tr -d ' ')
+[[ "$COUNT" -eq 3 ]] || fail "expected 3 invocations, got $COUNT"
+echo "PASS: one invocation per comma-separated user"
+
+# --- Test 3: defaults applied ---
+: > "$CALLS_FILE"
+BOOTSTRAP_ADMIN_USERS="alice" seed_bootstrap_admins || true
+CALL=$(cat "$CALLS_FILE")
+echo "$CALL" | grep -q -- "--workspace 'dev'" || fail "default workspace not applied: $CALL"
+echo "$CALL" | grep -q -- "--role admin" || fail "role admin not applied: $CALL"
+echo "$CALL" | grep -q -- "--password-env 'AUTH_BOOTSTRAP_PASSWORD'" || fail "default password-env not applied: $CALL"
+echo "$CALL" | grep -q -- "--username 'alice'" || fail "username not applied: $CALL"
+echo "$CALL" | grep -q -- "scripts/auth/manage-user.ts" || fail "manage-user.ts path missing: $CALL"
+echo "PASS: defaults applied (workspace=dev, password-env=AUTH_BOOTSTRAP_PASSWORD)"
+
+# --- Test 4: custom workspace + password-env ---
+: > "$CALLS_FILE"
+BOOTSTRAP_ADMIN_USERS="bob" BOOTSTRAP_ADMIN_WORKSPACE="hr" BOOTSTRAP_ADMIN_PASSWORD_ENV="BOB_PASS" seed_bootstrap_admins || true
+CALL=$(cat "$CALLS_FILE")
+echo "$CALL" | grep -q -- "--workspace 'hr'" || fail "custom workspace not honored: $CALL"
+echo "$CALL" | grep -q -- "--password-env 'BOB_PASS'" || fail "custom password-env not honored: $CALL"
+echo "PASS: custom workspace + password-env honored"
+
+# --- Test 5: empty/whitespace entries skipped ---
+: > "$CALLS_FILE"
+BOOTSTRAP_ADMIN_USERS="alice,,  ,bob" seed_bootstrap_admins || true
+COUNT=$(grep -c "manage-user.ts" "$CALLS_FILE" || true)
+[[ "$COUNT" -eq 2 ]] || fail "expected 2 real invocations (alice,bob), got $COUNT"
+echo "PASS: empty entries skipped"
+
+# --- Test 6: failure in one user does not abort the rest ---
+: > "$CALLS_FILE"
+run_as_service_user() {
+    # Fail for the second user only.
+    if printf '%s' "$*" | grep -q -- "--username 'bob'"; then
+        return 1
+    fi
+    printf '%s\n' "$*" >> "$CALLS_FILE"
+    return 0
+}
+BOOTSTRAP_ADMIN_USERS="alice,bob,carol" seed_bootstrap_admins || true
+COUNT=$(wc -l < "$CALLS_FILE" | tr -d ' ')
+[[ "$COUNT" -eq 2 ]] || fail "expected 2 successful invocations (alice,carol), got $COUNT"
+echo "PASS: one failure does not abort remaining users"
+
+echo ""
+echo "All seed_bootstrap_admins tests passed."


### PR DESCRIPTION
## Why

Closes **Blocker 1** of `projects/trends/work/2026-06-18-prod-unpin-auth-readiness/spec.md`.

PR #1261 (unified `requireAdmin`, in `main`) authorizes admin routes by reading the `workspace_memberships` table. Prod's restored Convex/preview data has **zero rows** in that table, so deploying `main` as-is returns 401/403 on every admin route — every admin gets locked out, including the only one who can fix it. This PR closes that gap by seeding bootstrap admins at deploy time.

## What

- New `seed_bootstrap_admins()` function in `scripts/install.sh`, wired into **both** `install_flow` and `full_upgrade_steps` (after `start_services` / `restart_units` so the SQLite DB + schema exist).
- Reads three env vars (documented in `.env.example`):
  - `BOOTSTRAP_ADMIN_USERS` — comma-separated local usernames (required to enable)
  - `BOOTSTRAP_ADMIN_WORKSPACE` — workspace slug (default `dev`)
  - `BOOTSTRAP_ADMIN_PASSWORD_ENV` — env var name holding the password (default `AUTH_BOOTSTRAP_PASSWORD`)
- For each user, calls the existing `scripts/auth/manage-user.ts` which is **already idempotent** (upserts user + identity + membership; covered by `manage-user.test.ts`).

## Safety properties

- **No-op when `BOOTSTRAP_ADMIN_USERS` is unset** — existing deploys without the var are completely unaffected.
- **Failure-isolated** — one bad user (e.g. password env not set) does not abort seeding of the rest; a warning is logged with the manual verification SQL.
- **Idempotent** — safe on every upgrade, not just first install.

## Tests

New `scripts/seed-bootstrap-admins.test.sh` (6 cases), wired into `make check` as `check-seed-bootstrap-admins`:

1. no-op when `BOOTSTRAP_ADMIN_USERS` unset
2. one invocation per comma-separated user
3. defaults applied (`workspace=dev`, `password-env=AUTH_BOOTSTRAP_PASSWORD`)
4. custom workspace + password-env honored
5. empty/whitespace entries skipped
6. one failure does not abort remaining users

The test extracts only the `seed_bootstrap_admins()` function from `install.sh` (the script's top-level dispatch runs on source) and evals it in a sandbox with stubbed `run_as_service_user`. `make check` green.

## Risk

- **Deploy-only path** — no runtime code change. The seeder runs once per install/upgrade and only mutates `workspace_memberships` via the existing, tested `manage-user.ts`.
- **No migration / no schema change**.
- **Env var requirement** — operators must set `BOOTSTRAP_ADMIN_USERS` (and ensure `AUTH_BOOTSTRAP_PASSWORD` or the named var is exported in the service env) before the first auth-refactor deploy. The `.env.example` documents this; the deploy runbook should too.

## Pre-deploy

This is the second of two blockers from the auth-readiness work item (companion to PR #1296 — admin unlock endpoint). Prod remains pinned at `v0.4.6-hotfix` (`4ce93b90`). Do **not** deploy `main` to prod until both blockers merge AND the full sequence (preview validation → tag cut → prod deploy → 48-72h watch) is followed per `projects/trends/work/2026-06-18-prod-unpin-auth-readiness/`.