### PR TITLE
fix(auth): default AUTH_ADMIN_RESET_ENABLED to true

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,7 @@ VITE_DEFAULT_LOCALE=zh-Hans   # Frontend UI / static content default language
 # Auth
 # Local demo auth helper password for `bun run auth:bootstrap-demo`.
 AUTH_BOOTSTRAP_PASSWORD=demo-admin
-# AUTH_ADMIN_RESET_ENABLED=true    # Experimental: admin password reset via POST /api/admin/reset-password. Default off.
+# AUTH_ADMIN_RESET_ENABLED=true    # Admin password reset via POST /api/admin/reset-password. Default ON; set to "false" to disable.
 # AUTH_ALLOWED_ORIGINS=http://localhost:5173  # Comma-separated CORS origins
 # AUTH_SESSION_TTL_SECONDS=604800   # Session lifetime (default 7 days)
 # AUTH_OIDC_ENABLED=true            # Enable Casdoor OIDC login

--- a/apps/api/src/services/config.test.ts
+++ b/apps/api/src/services/config.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// config.ts reads process.env at module load. To exercise the
+// AUTH_ADMIN_RESET_ENABLED default semantics (default true; opt-out
+// only via explicit "false"), reset the module registry between cases
+// so each sees a fresh env on import.
+async function loadConfig() {
+  vi.resetModules();
+  const { config } = await import("./config.js");
+  return config as { auth: { adminResetEnabled: boolean } };
+}
+
+const ENV_KEY = "AUTH_ADMIN_RESET_ENABLED";
+
+describe("AUTH_ADMIN_RESET_ENABLED default", () => {
+  const original = process.env[ENV_KEY];
+
+  beforeEach(() => {
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = original;
+    }
+  });
+
+  it("defaults to true when unset", async () => {
+    const config = await loadConfig();
+    expect(config.auth.adminResetEnabled).toBe(true);
+  });
+
+  it("is true when set to 'true'", async () => {
+    process.env[ENV_KEY] = "true";
+    const config = await loadConfig();
+    expect(config.auth.adminResetEnabled).toBe(true);
+  });
+
+  it("is false only when explicitly set to 'false'", async () => {
+    process.env[ENV_KEY] = "false";
+    const config = await loadConfig();
+    expect(config.auth.adminResetEnabled).toBe(false);
+  });
+
+  it("is true for any non-'false' value (e.g. '1')", async () => {
+    process.env[ENV_KEY] = "1";
+    const config = await loadConfig();
+    expect(config.auth.adminResetEnabled).toBe(true);
+  });
+});

--- a/apps/api/src/services/config.ts
+++ b/apps/api/src/services/config.ts
@@ -36,7 +36,7 @@ export const config = {
     csrfCookieName: process.env.AUTH_CSRF_COOKIE_NAME || "trends_csrf",
     sessionTtlSeconds: parseInt(process.env.AUTH_SESSION_TTL_SECONDS || "604800", 10),
     secureCookies: isProduction,
-    adminResetEnabled: process.env.AUTH_ADMIN_RESET_ENABLED === "true",
+    adminResetEnabled: process.env.AUTH_ADMIN_RESET_ENABLED !== "false",
     allowedOrigins: (process.env.AUTH_ALLOWED_ORIGINS || "")
       .split(",")
       .map((origin) => origin.trim())


### PR DESCRIPTION
## Summary

`POST /api/admin/reset-password` was returning 404 "Not found" on preview because `AUTH_ADMIN_RESET_ENABLED` defaulted to **false** (opt-in). After PR #1299 shipped the admin user CRUD UI, clicking "Reset password" on a user row failed with "Not found" unless the operator had manually set the env var.

Flip the semantics: **admin reset is ON by default; opt-out only via explicit `AUTH_ADMIN_RESET_ENABLED=false`.**

## Changes
- `apps/api/src/services/config.ts:39` — `=== "true"` → `!== "false"`
- `apps/api/src/services/config.test.ts` (new) — locks the 4-way default matrix (unset → true, `"true"` → true, `"false"` → false, other → true) via `vi.resetModules()`
- `.env.example` — comment updated (no longer "Experimental: Default off")

## Why default-true
- The flag was originally opt-in when reset-password was experimental (PR #1263). Post-#1299 it's a core admin op exposed in the UI — opt-in defaults cause the exact "Not found" footgun hit on preview.
- `.env.production` and `.env.preview` already set it `=true` explicitly; the only environment that silently lacked it was fresh preview rebuilds where the var was commented out.

## Test plan
- [x] `make check` green
- [x] `config.test.ts` 4/4 passing (default matrix locked)
- [ ] Preview verification after merge: login as admin → Reset password on a user row → temp password modal appears (not 404)

## Related
- PR #1299 — admin user CRUD + memberships UI (where the "Not found" surfaced)
- Vault capture: `raw/transcripts/2026-06-19-task-admin-auth-cli-gap.md` (CLI gap for these admin ops — separate followup)

Per CLAUDE.md Git Policy: squash auto-merge armed. Step 4 (prod cut) remains a human gate.