### PR TITLE
fix(auth): skip CSRF check on stale session cookie

### DIFF
--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -295,4 +295,32 @@ describe("auth middleware event logging", () => {
     expect(events[0].type).toBe("csrf_reject");
     expect(events[0].userId).toBe(user.id);
   });
+
+  it("skips CSRF check when session cookie is stale (invalid token)", async () => {
+    resetResumeScreeningDb();
+    const root = mkdtempSync(path.join(tmpdir(), "trends-auth-mw-stale-"));
+    const storage = new AuthStorage(root);
+    const eventStorage = new AuthEventStorage(root);
+    const middleware = createAuthMiddleware({ storage, ttlSeconds: 3600, eventStorage });
+
+    const app = new Hono();
+    app.use("*", workspaceMiddleware);
+    app.use("*", middleware.optionalAuth);
+    app.use("*", middleware.requireCsrf);
+    app.post("/mutate", (c) => c.json({ ok: true }));
+
+    // Stale cookie — a token that doesn't resolve to any session.
+    const res = await app.request("/mutate", {
+      method: "POST",
+      headers: {
+        "X-Workspace-Slug": "dev",
+        Cookie: `${config.auth.sessionCookieName}=stale-nonexistent-token`,
+      },
+    });
+
+    // Should pass through (not 403) — downstream route handles the unauthenticated request.
+    expect(res.status).toBe(200);
+    const events = eventStorage.listRecent({ limit: 10 });
+    expect(events.some((e) => e.type === "csrf_reject")).toBe(false);
+  });
 });

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -127,6 +127,17 @@ export function createAuthMiddleware(options: AuthMiddlewareOptions = {}) {
       return;
     }
 
+    // Stale-cookie guard: if the cookie is present but resolves to no valid
+    // session, skip CSRF and let the downstream route handle it (e.g. the
+    // login route starts a fresh session).  Without this, a stale session
+    // cookie blocks login with 403 because the login POST carries no CSRF
+    // header — the user must manually clear browser data to recover.
+    const session = getSessions().resolveSession(token);
+    if (!session) {
+      await next();
+      return;
+    }
+
     const csrf = c.req.header(csrfHeaderName);
     if (!csrf || !getSessions().verifyCsrf(token, csrf)) {
       const auth = c.var.auth;


### PR DESCRIPTION
## Summary

Stale `trends_session` cookies (expired, from a different session, or from browser automation sessions) caused `POST /api/auth/login` to return **403 "CSRF token required"** — silently blocking login until the user manually clears browser data. No error message or guidance was shown.

**Root cause:** `requireCsrf` middleware sees the cookie → requires a CSRF header → login POST doesn't carry one → 403. The stale-cookie case was not handled — only the "no cookie" case was skipped.

**Fix:** Resolve the session from the cookie first. If it resolves to no valid session, skip the CSRF check and let the downstream route handle it (e.g. login starts a fresh session). Only enforce CSRF when the cookie resolves to a real session.

## Changes
- `apps/api/src/middleware/auth.ts:118-142` — added `getSessions().resolveSession(token)` check before CSRF validation. Stale cookies skip CSRF (same behavior as no cookie).
- `apps/api/src/middleware/auth.test.ts` — new test: stale-cookie POST returns 200, no `csrf_reject` event.

## Test plan
- [x] `apps/api/src/middleware/auth.test.ts` 15/15 passing
- [x] `apps/api/src/routes/auth.test.ts` 29/29 passing (login tests unaffected)
- [x] `apps/api/src/routes/admin_users.test.ts` 39/39 passing (admin endpoints unaffected)
- [x] `make check` green
- [ ] Preview verification: set stale cookie in browser → POST `/api/auth/login` → login succeeds (not 403)

Per CLAUDE.md Git Policy: squash auto-merge armed. Step 4 (prod cut) remains a human gate.