### PR TITLE
feat(web): self-service password change page for normal users

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -105,6 +105,11 @@ const LazySystemSettingsExportFieldsPage = lazy(async () => {
   return { default: module.SystemSettingsExportFieldsPage }
 })
 
+const LazyAccountPage = lazy(async () => {
+  const module = await import('@/pages/AccountPage')
+  return { default: module.AccountPage }
+})
+
 function MainShell({ children }: { children?: ReactNode }) {
   return (
     <div className="min-h-screen bg-background">
@@ -468,6 +473,14 @@ function App() {
                 element={(
                   <RouteSuspense>
                     <LazySystemSettingsExportFieldsPage />
+                  </RouteSuspense>
+                )}
+              />
+              <Route
+                path="account"
+                element={(
+                  <RouteSuspense>
+                    <LazyAccountPage />
                   </RouteSuspense>
                 )}
               />

--- a/apps/web/src/components/SettingsSidebar.tsx
+++ b/apps/web/src/components/SettingsSidebar.tsx
@@ -5,7 +5,7 @@ import {
   type SurfaceNavDefinition,
 } from '@trends/shared'
 import { Link, useLocation } from 'react-router-dom'
-import { Ban, Home, Search, SlidersHorizontal, X } from 'lucide-react'
+import { Ban, Home, Key, Search, SlidersHorizontal, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
@@ -25,6 +25,7 @@ const NAV_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   blocks: Ban,
   profiles: Search,
   'export-fields': SlidersHorizontal,
+  account: Key,
 }
 
 interface SettingsSidebarProps {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -842,6 +842,23 @@
         "bulkUnblockSuccess": "Unblocked {{count}} candidate(s)",
         "bulkUnblockFailed": "Failed to unblock selected candidates"
       }
+    },
+    "account": {
+      "nav": "Account",
+      "title": "Account",
+      "description": "Manage your account settings and change your password.",
+      "changePassword": "Change password",
+      "changePasswordDescription": "Update your password. You will stay logged in after changing it.",
+      "currentPassword": "Current password",
+      "newPassword": "New password",
+      "confirmPassword": "Confirm new password",
+      "changePasswordButton": "Change password",
+      "changing": "Changing...",
+      "passwordChanged": "Password changed successfully",
+      "currentPasswordIncorrect": "Current password is incorrect",
+      "passwordTooShort": "Password must be at least 6 characters",
+      "passwordsDoNotMatch": "Passwords do not match",
+      "changeFailed": "Failed to change password"
     }
   },
   "debug": {

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -1061,6 +1061,23 @@
       "searchPlaceholder": "依候选人识别键或原因搜索...",
       "empty": "目前没有已屏蔽候选人。",
       "nav": "黑名单"
+    },
+    "account": {
+      "nav": "账号",
+      "title": "账号",
+      "description": "管理您的账号设置并更改密码。",
+      "changePassword": "更改密码",
+      "changePasswordDescription": "更新您的密码。更改后您将保持登录状态。",
+      "currentPassword": "当前密码",
+      "newPassword": "新密码",
+      "confirmPassword": "确认新密码",
+      "changePasswordButton": "更改密码",
+      "changing": "更改中...",
+      "passwordChanged": "密码已成功更改",
+      "currentPasswordIncorrect": "当前密码不正确",
+      "passwordTooShort": "密码至少需要 6 个字符",
+      "passwordsDoNotMatch": "密码不匹配",
+      "changeFailed": "更改密码失败"
     }
   },
   "searchAnalytics": {

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -842,6 +842,23 @@
         "bulkUnblockSuccess": "已解除封鎖 {{count}} 位候選人",
         "bulkUnblockFailed": "批次解除封鎖失敗"
       }
+    },
+    "account": {
+      "nav": "帳號",
+      "title": "帳號",
+      "description": "管理您的帳號設定並變更密碼。",
+      "changePassword": "變更密碼",
+      "changePasswordDescription": "更新您的密碼。變更後您將保持登入狀態。",
+      "currentPassword": "目前密碼",
+      "newPassword": "新密碼",
+      "confirmPassword": "確認新密碼",
+      "changePasswordButton": "變更密碼",
+      "changing": "變更中...",
+      "passwordChanged": "密碼已成功變更",
+      "currentPasswordIncorrect": "目前密碼不正確",
+      "passwordTooShort": "密碼至少需要 6 個字元",
+      "passwordsDoNotMatch": "密碼不相符",
+      "changeFailed": "變更密碼失敗"
     }
   },
   "debug": {

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -282,3 +282,27 @@ export function getCasdoorLoginUrl(redirectTo: string = getCurrentRedirectPath()
 export function redirectToCasdoorLogin(redirectTo?: string): void {
   window.location.assign(getCasdoorLoginUrl(redirectTo))
 }
+
+export type ChangePasswordResult =
+  | { success: true }
+  | { success: false; error: string; status?: number }
+
+export async function changePassword(
+  currentPassword: string,
+  newPassword: string,
+): Promise<ChangePasswordResult> {
+  const { data, error, response } = await rawApiClient.POST<{ success: true }>(
+    '/api/auth/change-password',
+    { body: { currentPassword, newPassword } },
+  )
+  if (data?.success === true) {
+    return data
+  }
+  const status = response?.status ?? readStatus(error) ?? readStatus(data)
+  const message = readErrorMessage(data) ?? readErrorMessage(error) ?? defaultErrorForStatus(status, 'Failed to change password')
+  const result: ChangePasswordResult = { success: false, error: message }
+  if (status !== undefined) {
+    result.status = status
+  }
+  return result
+}

--- a/apps/web/src/pages/AccountPage.tsx
+++ b/apps/web/src/pages/AccountPage.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { changePassword } from '@/lib/auth'
+import { Key } from 'lucide-react'
+
+export function AccountPage() {
+  const { t } = useTranslation()
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [currentPasswordError, setCurrentPasswordError] = useState<string | null>(null)
+
+  const mismatch = newPassword.length > 0 && confirmPassword.length > 0 && newPassword !== confirmPassword
+  const tooShort = newPassword.length > 0 && newPassword.length < 6
+  const canSubmit = currentPassword.length > 0 && newPassword.length >= 6 && newPassword === confirmPassword && !submitting
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!canSubmit) return
+
+    setCurrentPasswordError(null)
+    setSubmitting(true)
+    try {
+      const result = await changePassword(currentPassword, newPassword)
+      if (result.success) {
+        toast.success(t('settings.account.passwordChanged', { defaultValue: 'Password changed successfully' }))
+        setCurrentPassword('')
+        setNewPassword('')
+        setConfirmPassword('')
+      } else {
+        if (result.status === 403) {
+          setCurrentPasswordError(t('settings.account.currentPasswordIncorrect', { defaultValue: 'Current password is incorrect' }))
+        } else {
+          toast.error(result.error)
+        }
+      }
+    } catch {
+      toast.error(t('settings.account.changeFailed', { defaultValue: 'Failed to change password' }))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h2 className="text-xl font-semibold tracking-tight">
+          {t('settings.account.title', { defaultValue: 'Account' })}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {t('settings.account.description', { defaultValue: 'Manage your account settings and change your password.' })}
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('settings.account.changePassword', { defaultValue: 'Change password' })}</CardTitle>
+          <CardDescription>
+            {t('settings.account.changePasswordDescription', { defaultValue: 'Update your password. You will stay logged in after changing it.' })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={(e) => { void handleSubmit(e) }} className="space-y-4 max-w-sm">
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="current-password">
+                {t('settings.account.currentPassword', { defaultValue: 'Current password' })}
+              </label>
+              <Input
+                id="current-password"
+                type="password"
+                autoComplete="current-password"
+                value={currentPassword}
+                onChange={(e) => {
+                  setCurrentPassword(e.target.value)
+                  setCurrentPasswordError(null)
+                }}
+                aria-invalid={currentPasswordError !== null}
+              />
+              {currentPasswordError && (
+                <p className="text-sm text-destructive">{currentPasswordError}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="new-password">
+                {t('settings.account.newPassword', { defaultValue: 'New password' })}
+              </label>
+              <Input
+                id="new-password"
+                type="password"
+                autoComplete="new-password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                aria-invalid={tooShort}
+              />
+              {tooShort && (
+                <p className="text-sm text-destructive">
+                  {t('settings.account.passwordTooShort', { defaultValue: 'Password must be at least 6 characters' })}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="confirm-password">
+                {t('settings.account.confirmPassword', { defaultValue: 'Confirm new password' })}
+              </label>
+              <Input
+                id="confirm-password"
+                type="password"
+                autoComplete="new-password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                aria-invalid={mismatch}
+              />
+              {mismatch && (
+                <p className="text-sm text-destructive">
+                  {t('settings.account.passwordsDoNotMatch', { defaultValue: 'Passwords do not match' })}
+                </p>
+              )}
+            </div>
+
+            <Button type="submit" disabled={!canSubmit}>
+              <Key className="mr-2 h-4 w-4" />
+              {submitting
+                ? t('settings.account.changing', { defaultValue: 'Changing...' })
+                : t('settings.account.changePasswordButton', { defaultValue: 'Change password' })}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/packages/shared/src/system-debug-metadata.ts
+++ b/packages/shared/src/system-debug-metadata.ts
@@ -321,6 +321,13 @@ export const SETTINGS_NAV_ITEMS: SurfaceNavDefinition[] = [
     hrefSuffix: "/settings/export-fields",
     matchesSuffixes: ["/settings/export-fields"],
   },
+  {
+    id: "account",
+    titleKey: "settings.account.nav",
+    defaultTitle: "Account",
+    hrefSuffix: "/settings/account",
+    matchesSuffixes: ["/settings/account"],
+  },
 ];
 
 export const SYSTEM_SETTINGS_NAV_ITEMS: SurfaceNavDefinition[] = [


### PR DESCRIPTION
## Summary

Adds a self-service "Account" page at `/:workspace/settings/account` where any logged-in user can change their password. The backend endpoint `POST /api/auth/change-password` already exists (auth.ts:530-589) — this PR wires the UI.

## Changes
- `packages/shared/src/system-debug-metadata.ts` — added `account` to `SETTINGS_NAV_ITEMS`
- `apps/web/src/components/SettingsSidebar.tsx` — `Key` icon for account nav
- `apps/web/src/App.tsx` — lazy route at `/:teamSlug/settings/account`
- `apps/web/src/lib/auth.ts` — `changePassword(current, new)` client wrapper
- `apps/web/src/pages/AccountPage.tsx` — change-password form (currentPassword + newPassword + confirmPassword)
- i18n keys in all 3 locales (en, zh-Hant, zh-Hans)

## UX
- Form validates: min 6 chars, confirm-match, current-password 403 → inline error
- Success: toast "Password changed successfully" + fields cleared
- Not admin-gated — any workspace member can access
- Passwords cleared from React state on success; backend revokes other sessions

## Known limitation (deferred)
OAuth-only users (no local password) see the form but get "current password incorrect" on submit. Should show an SSO info message instead. Followup.

## Test plan
- [x] `make check` green (typecheck + lint + governance + i18n parity)
- [x] i18n parity confirmed (all 3 locales, 15 account keys each)
- [ ] Manual: login as normal user → Settings → Account → change password → success
- [ ] Manual: wrong current password → inline error "Current password is incorrect"

Per CLAUDE.md Git Policy: squash auto-merge armed.