### PR TITLE
fix(auth): preserve admin create password on preview routes

### DIFF
--- a/.claude/dev-loop.config.md
+++ b/.claude/dev-loop.config.md
@@ -269,9 +269,10 @@ reactive_debugging:
 
 ## Code review
 
-> v1.15.0: simplify-worker always runs (base). Codex second-opinion is
-> opt-in per intensity. Currently OFF — toggle `enabled_in_high: true`
-> if you want a parallel reviewer on /dev-loop high cycles.
+> REVIEW always runs `simplify:simplify` as the base code-review skill for
+> code changes. Codex second-opinion is opt-in per intensity. Currently OFF —
+> toggle `enabled_in_high: true` if you want a parallel reviewer on
+> /dev-loop high cycles.
 
 ```yaml
 code_review:

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -211,7 +211,7 @@ describe('App routes', () => {
     })
   })
 
-  it('does not enter system UI from hr system routes', async () => {
+  it('shows access denied for hr system routes without entering system UI', async () => {
     authState.user = { id: 'hr-admin', status: 'active', displayName: 'HR Admin' }
     authState.memberships = [{ userId: 'hr-admin', workspaceSlug: 'hr', role: 'admin' }]
     authState.workspaceRole = 'admin'
@@ -220,7 +220,8 @@ describe('App routes', () => {
 
     render(<App />)
 
-    expect(await screen.findByRole('heading', { name: 'Page not found' })).toBeInTheDocument()
+    expect(await screen.findByText('Admin access required')).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Page not found' })).not.toBeInTheDocument()
     expect(screen.queryByText('System layout rendered')).not.toBeInTheDocument()
   })
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -251,6 +251,35 @@ function SystemAccessGate({ children }: { children: ReactNode }) {
   return <>{children}</>
 }
 
+function WorkspaceSystemAccessDeniedRoute() {
+  const auth = useAuth()
+  const location = useLocation()
+
+  if (!auth.isAuthenticated) {
+    const redirectTo = `${location.pathname}${location.search}`
+    const search = new URLSearchParams({ redirectTo }).toString()
+    return <Navigate to={{ pathname: `/${SYSTEM_AUTH_WORKSPACE}/login`, search: `?${search}` }} replace />
+  }
+
+  if (hasSystemAdminAccess(auth.memberships)) {
+    const suffix = location.pathname.replace(/^\/[^/]+\/system/, '')
+    return <Navigate to={{ pathname: `${SYSTEM_ROUTE_PREFIX}${suffix}`, search: location.search }} replace />
+  }
+
+  return (
+    <MainShell>
+      <section className="mx-auto max-w-xl py-12">
+        <div className="rounded-md border border-destructive/30 p-6">
+          <h1 className="text-xl font-semibold tracking-tight">Admin access required</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            System settings require a dev workspace admin account.
+          </p>
+        </div>
+      </section>
+    </MainShell>
+  )
+}
+
 function LegacyDevSystemRedirect() {
   const location = useLocation()
   const suffix = location.pathname.replace(/^\/dev\/system/, '')
@@ -438,6 +467,7 @@ function App() {
 
           <Route path="/:teamSlug" element={<WorkspaceShell />}>
             <Route index element={<PreserveSearchNavigate pathname="resumes" />} />
+            <Route path="system/*" element={<WorkspaceSystemAccessDeniedRoute />} />
 
             <Route element={<MainShell />}>
               <Route path="login" element={<LoginPage />} />

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -105,6 +105,11 @@ const LazySystemSettingsExportFieldsPage = lazy(async () => {
   return { default: module.SystemSettingsExportFieldsPage }
 })
 
+const LazyAccountPage = lazy(async () => {
+  const module = await import('@/pages/AccountPage')
+  return { default: module.AccountPage }
+})
+
 function MainShell({ children }: { children?: ReactNode }) {
   return (
     <div className="min-h-screen bg-background">
@@ -468,6 +473,14 @@ function App() {
                 element={(
                   <RouteSuspense>
                     <LazySystemSettingsExportFieldsPage />
+                  </RouteSuspense>
+                )}
+              />
+              <Route
+                path="account"
+                element={(
+                  <RouteSuspense>
+                    <LazyAccountPage />
                   </RouteSuspense>
                 )}
               />

--- a/apps/web/src/components/SettingsSidebar.tsx
+++ b/apps/web/src/components/SettingsSidebar.tsx
@@ -5,7 +5,7 @@ import {
   type SurfaceNavDefinition,
 } from '@trends/shared'
 import { Link, useLocation } from 'react-router-dom'
-import { Ban, Home, Search, SlidersHorizontal, X } from 'lucide-react'
+import { Ban, Home, Key, Search, SlidersHorizontal, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
@@ -25,6 +25,7 @@ const NAV_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   blocks: Ban,
   profiles: Search,
   'export-fields': SlidersHorizontal,
+  account: Key,
 }
 
 interface SettingsSidebarProps {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -842,6 +842,23 @@
         "bulkUnblockSuccess": "Unblocked {{count}} candidate(s)",
         "bulkUnblockFailed": "Failed to unblock selected candidates"
       }
+    },
+    "account": {
+      "nav": "Account",
+      "title": "Account",
+      "description": "Manage your account settings and change your password.",
+      "changePassword": "Change password",
+      "changePasswordDescription": "Update your password. You will stay logged in after changing it.",
+      "currentPassword": "Current password",
+      "newPassword": "New password",
+      "confirmPassword": "Confirm new password",
+      "changePasswordButton": "Change password",
+      "changing": "Changing...",
+      "passwordChanged": "Password changed successfully",
+      "currentPasswordIncorrect": "Current password is incorrect",
+      "passwordTooShort": "Password must be at least 6 characters",
+      "passwordsDoNotMatch": "Passwords do not match",
+      "changeFailed": "Failed to change password"
     }
   },
   "debug": {

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -1061,6 +1061,23 @@
       "searchPlaceholder": "依候选人识别键或原因搜索...",
       "empty": "目前没有已屏蔽候选人。",
       "nav": "黑名单"
+    },
+    "account": {
+      "nav": "账号",
+      "title": "账号",
+      "description": "管理您的账号设置并更改密码。",
+      "changePassword": "更改密码",
+      "changePasswordDescription": "更新您的密码。更改后您将保持登录状态。",
+      "currentPassword": "当前密码",
+      "newPassword": "新密码",
+      "confirmPassword": "确认新密码",
+      "changePasswordButton": "更改密码",
+      "changing": "更改中...",
+      "passwordChanged": "密码已成功更改",
+      "currentPasswordIncorrect": "当前密码不正确",
+      "passwordTooShort": "密码至少需要 6 个字符",
+      "passwordsDoNotMatch": "密码不匹配",
+      "changeFailed": "更改密码失败"
     }
   },
   "searchAnalytics": {

--- a/apps/web/src/i18n/locales/zh-Hant.json
+++ b/apps/web/src/i18n/locales/zh-Hant.json
@@ -842,6 +842,23 @@
         "bulkUnblockSuccess": "已解除封鎖 {{count}} 位候選人",
         "bulkUnblockFailed": "批次解除封鎖失敗"
       }
+    },
+    "account": {
+      "nav": "帳號",
+      "title": "帳號",
+      "description": "管理您的帳號設定並變更密碼。",
+      "changePassword": "變更密碼",
+      "changePasswordDescription": "更新您的密碼。變更後您將保持登入狀態。",
+      "currentPassword": "目前密碼",
+      "newPassword": "新密碼",
+      "confirmPassword": "確認新密碼",
+      "changePasswordButton": "變更密碼",
+      "changing": "變更中...",
+      "passwordChanged": "密碼已成功變更",
+      "currentPasswordIncorrect": "目前密碼不正確",
+      "passwordTooShort": "密碼至少需要 6 個字元",
+      "passwordsDoNotMatch": "密碼不相符",
+      "changeFailed": "變更密碼失敗"
     }
   },
   "debug": {

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -282,3 +282,27 @@ export function getCasdoorLoginUrl(redirectTo: string = getCurrentRedirectPath()
 export function redirectToCasdoorLogin(redirectTo?: string): void {
   window.location.assign(getCasdoorLoginUrl(redirectTo))
 }
+
+export type ChangePasswordResult =
+  | { success: true }
+  | { success: false; error: string; status?: number }
+
+export async function changePassword(
+  currentPassword: string,
+  newPassword: string,
+): Promise<ChangePasswordResult> {
+  const { data, error, response } = await rawApiClient.POST<{ success: true }>(
+    '/api/auth/change-password',
+    { body: { currentPassword, newPassword } },
+  )
+  if (data?.success === true) {
+    return data
+  }
+  const status = response?.status ?? readStatus(error) ?? readStatus(data)
+  const message = readErrorMessage(data) ?? readErrorMessage(error) ?? defaultErrorForStatus(status, 'Failed to change password')
+  const result: ChangePasswordResult = { success: false, error: message }
+  if (status !== undefined) {
+    result.status = status
+  }
+  return result
+}

--- a/apps/web/src/pages/AccountPage.tsx
+++ b/apps/web/src/pages/AccountPage.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { changePassword } from '@/lib/auth'
+import { Key } from 'lucide-react'
+
+export function AccountPage() {
+  const { t } = useTranslation()
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [currentPasswordError, setCurrentPasswordError] = useState<string | null>(null)
+
+  const mismatch = newPassword.length > 0 && confirmPassword.length > 0 && newPassword !== confirmPassword
+  const tooShort = newPassword.length > 0 && newPassword.length < 6
+  const canSubmit = currentPassword.length > 0 && newPassword.length >= 6 && newPassword === confirmPassword && !submitting
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!canSubmit) return
+
+    setCurrentPasswordError(null)
+    setSubmitting(true)
+    try {
+      const result = await changePassword(currentPassword, newPassword)
+      if (result.success) {
+        toast.success(t('settings.account.passwordChanged', { defaultValue: 'Password changed successfully' }))
+        setCurrentPassword('')
+        setNewPassword('')
+        setConfirmPassword('')
+      } else {
+        if (result.status === 403) {
+          setCurrentPasswordError(t('settings.account.currentPasswordIncorrect', { defaultValue: 'Current password is incorrect' }))
+        } else {
+          toast.error(result.error)
+        }
+      }
+    } catch {
+      toast.error(t('settings.account.changeFailed', { defaultValue: 'Failed to change password' }))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h2 className="text-xl font-semibold tracking-tight">
+          {t('settings.account.title', { defaultValue: 'Account' })}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {t('settings.account.description', { defaultValue: 'Manage your account settings and change your password.' })}
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('settings.account.changePassword', { defaultValue: 'Change password' })}</CardTitle>
+          <CardDescription>
+            {t('settings.account.changePasswordDescription', { defaultValue: 'Update your password. You will stay logged in after changing it.' })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={(e) => { void handleSubmit(e) }} className="space-y-4 max-w-sm">
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="current-password">
+                {t('settings.account.currentPassword', { defaultValue: 'Current password' })}
+              </label>
+              <Input
+                id="current-password"
+                type="password"
+                autoComplete="current-password"
+                value={currentPassword}
+                onChange={(e) => {
+                  setCurrentPassword(e.target.value)
+                  setCurrentPasswordError(null)
+                }}
+                aria-invalid={currentPasswordError !== null}
+              />
+              {currentPasswordError && (
+                <p className="text-sm text-destructive">{currentPasswordError}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="new-password">
+                {t('settings.account.newPassword', { defaultValue: 'New password' })}
+              </label>
+              <Input
+                id="new-password"
+                type="password"
+                autoComplete="new-password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                aria-invalid={tooShort}
+              />
+              {tooShort && (
+                <p className="text-sm text-destructive">
+                  {t('settings.account.passwordTooShort', { defaultValue: 'Password must be at least 6 characters' })}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="confirm-password">
+                {t('settings.account.confirmPassword', { defaultValue: 'Confirm new password' })}
+              </label>
+              <Input
+                id="confirm-password"
+                type="password"
+                autoComplete="new-password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                aria-invalid={mismatch}
+              />
+              {mismatch && (
+                <p className="text-sm text-destructive">
+                  {t('settings.account.passwordsDoNotMatch', { defaultValue: 'Passwords do not match' })}
+                </p>
+              )}
+            </div>
+
+            <Button type="submit" disabled={!canSubmit}>
+              <Key className="mr-2 h-4 w-4" />
+              {submitting
+                ? t('settings.account.changing', { defaultValue: 'Changing...' })
+                : t('settings.account.changePasswordButton', { defaultValue: 'Change password' })}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/web/src/pages/system-settings/admin-users/CreateUserDialog.test.tsx
+++ b/apps/web/src/pages/system-settings/admin-users/CreateUserDialog.test.tsx
@@ -55,6 +55,31 @@ describe('CreateUserDialog', () => {
     expect(screen.getByTestId('copy-temp-password')).toBeInTheDocument()
   })
 
+  it('reports the temporary password to the parent on success', async () => {
+    mockCreateAdminUser.mockResolvedValue({
+      success: true,
+      user: {
+        id: 'user-new',
+        displayName: 'newuser',
+        status: 'active' as const,
+        createdAt: '2026-06-19T00:00:00.000Z',
+        identities: [],
+        memberships: [],
+      },
+      temporaryPassword: 'abc123',
+    })
+    const onCreated = vi.fn()
+    const user = userEvent.setup()
+    render(<CreateUserDialog open={true} onOpenChange={vi.fn()} onCreated={onCreated} />)
+
+    await user.type(screen.getByTestId('create-user-username'), 'newuser')
+    await user.click(screen.getByTestId('create-user-submit'))
+
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledWith('abc123')
+    })
+  })
+
   it('keeps password discoverable after close button is clicked', async () => {
     mockCreateAdminUser.mockResolvedValue({
       success: true,

--- a/apps/web/src/pages/system-settings/admin-users/CreateUserDialog.tsx
+++ b/apps/web/src/pages/system-settings/admin-users/CreateUserDialog.tsx
@@ -20,7 +20,7 @@ import type { WorkspaceRole } from '@/lib/auth'
 type Props = {
   open: boolean
   onOpenChange: (open: boolean) => void
-  onCreated: () => void
+  onCreated: (temporaryPassword: string) => void
 }
 
 export function CreateUserDialog({ open, onOpenChange, onCreated }: Props) {
@@ -79,7 +79,7 @@ export function CreateUserDialog({ open, onOpenChange, onCreated }: Props) {
       setTempPassword(result.temporaryPassword)
       setCreatedUsername(result.user.displayName ?? username.trim())
       toast.success(t('debugConfig.adminUsersCreated', { defaultValue: 'User created' }))
-      onCreated()
+      onCreated(result.temporaryPassword)
     } catch (err) {
       console.error(err)
       setError(t('debugConfig.adminUsersCreateFailed', { defaultValue: 'Failed to create user' }))

--- a/apps/web/src/pages/system-settings/admin-users/UsersPanel.tsx
+++ b/apps/web/src/pages/system-settings/admin-users/UsersPanel.tsx
@@ -23,6 +23,10 @@ type Props = {
   operatorId: string | null
 }
 
+type LoadOptions = {
+  showLoading?: boolean
+}
+
 function formatApiError(error: AdminUsersError): string {
   return error.status === undefined ? error.error : `${error.error} (${error.status})`
 }
@@ -38,8 +42,11 @@ export function UsersPanel({ operatorId }: Props) {
   const [membershipsUser, setMembershipsUser] = useState<AdminUserRecord | null>(null)
   const [auditUser, setAuditUser] = useState<AdminUserRecord | null>(null)
 
-  const load = useCallback(async () => {
-    setLoading(true)
+  const load = useCallback(async (options: LoadOptions = {}) => {
+    const showLoading = options.showLoading ?? true
+    if (showLoading) {
+      setLoading(true)
+    }
     try {
       const result = await listAdminUsers()
       if (result.success === false) {
@@ -57,7 +64,9 @@ export function UsersPanel({ operatorId }: Props) {
       setAccessError(null)
       setAccessDenied(true)
     } finally {
-      setLoading(false)
+      if (showLoading) {
+        setLoading(false)
+      }
     }
   }, [])
 
@@ -329,12 +338,10 @@ export function UsersPanel({ operatorId }: Props) {
         open={createDialogOpen}
         onOpenChange={(open) => {
           setCreateDialogOpen(open)
-          if (!open) {
-            setTempPassword(null)
-          }
         }}
-        onCreated={() => {
-          void load()
+        onCreated={(temporaryPassword) => {
+          setTempPassword(temporaryPassword)
+          void load({ showLoading: false })
         }}
       />
 

--- a/logs/2026-06-19-auth-preview-handoff.md
+++ b/logs/2026-06-19-auth-preview-handoff.md
@@ -1,0 +1,108 @@
+# Handoff: Auth Features Preview Verification (2026-06-19)
+
+**Purpose:** A fresh agent needs to examine all latest auth features on the preview site (`https://preview.pt-mes.com`). This document provides context on what was deployed, how to verify, and known issues.
+
+**Prod status:** Pinned at `v0.4.6-hotfix` (`4ce93b90`). **No prod deploys** — all work is on `main`, deployed to preview only. Step 4 (prod tag cut) is a **human gate** per memory entry `step-4-human-gate.md`.
+
+---
+
+## What shipped to `main` today (4 PRs)
+
+| PR | Commit | Title |
+|---|---|---|
+| #1299 | `5c664b92` | feat(auth): admin user CRUD + memberships UI (scope C) |
+| #1300 | `6e445eca` | fix(auth): default AUTH_ADMIN_RESET_ENABLED to true |
+| #1301 | `640a8b7b` | fix(auth): skip CSRF check on stale session cookie |
+| #1302 | `87a51971` | feat(web): self-service password change page for normal users |
+
+## Preview environment
+
+- **URL:** `https://preview.pt-mes.com`
+- **Admin login:** `admin` / `admin123` (seeded by `setup-preview.sh` step [8/8] via `BOOTSTRAP_ADMIN_USERS` + `AUTH_BOOTSTRAP_PASSWORD` env vars in `.env.preview`)
+- **Convex:** Docker on ptcloud, ports 4210/4211, healthy (HTTP 200)
+- **API:** systemd `trends-preview-api` on port 3002, healthy
+- **Rebuild command:** `ssh ptcloud 'bash /opt/trends/deploy/setup-preview.sh'` then `systemctl restart trends-preview-api`
+- **Seeding:** `setup-preview.sh` step [8/8] auto-seeds the admin. If the DB is empty after rebuild (seeder missed), manually run: `ssh ptcloud 'cd /home/ubuntu/trends-preview && sudo -u ubuntu bash -c "set -a && source .env.preview && set +a && bunx tsx scripts/auth/manage-user.ts --username admin --workspace dev --role admin --password-env AUTH_BOOTSTRAP_PASSWORD --output agent"'`
+
+## Features to verify
+
+### 1. Admin user CRUD UI (PR #1299)
+
+**URL:** `https://preview.pt-mes.com/dev/system/settings/auth` (login as `admin`/`admin123`)
+
+What to check:
+- "用户管理" (Users) heading visible with user table
+- "+ 新增用户" button → opens create-user dialog
+- Create a user (e.g. username=`testuser`, displayName=`Test User`, workspace=`hr`, role=`user`) → modal shows temp password ONCE with copy button
+- Per-row actions: 停用 (Disable), 重置密码 (Reset password), 解除锁定 (Unlock), 查看审计记录 (View audit), 编辑工作区 (Edit memberships)
+- Disable → re-enable round-trip works
+- Edit memberships → add `dev`/`admin` → table updates (onChanged callback)
+- Self-disable blocked (400 toast)
+- Self-demotion blocked (400 toast when removing own `dev`/`admin`)
+- Access denied from `/hr/system/settings/auth` (system-admin gate: `dev` workspace + `admin` role only per ADR D4)
+
+### 2. Admin reset-password default-on (PR #1300)
+
+What to check:
+- Click "重置密码" on any user row → temp password modal appears (NOT "Not found")
+- No `AUTH_ADMIN_RESET_ENABLED` env var needed — default is ON; opt-out only via explicit `=false`
+
+### 3. CSRF stale-cookie fix (PR #1301)
+
+What to check:
+- Open incognito → set a stale `trends_session` cookie (e.g. via DevTools: `document.cookie = "trends_session=stale-fake-token"`)
+- Navigate to `/dev/login`, fill `admin`/`admin123`, click login
+- **Expected:** login succeeds (page navigates to `/admin/system/settings/auth`)
+- **Before fix:** 403 "CSRF token required" + "用户名或密码错误" error
+
+### 4. Self-service password change (PR #1302)
+
+**URL:** `https://preview.pt-mes.com/dev/settings/account` (any logged-in user)
+
+What to check:
+- "Account" page visible in workspace settings sidebar (Key icon)
+- Form: current password + new password + confirm new password
+- Validation: min 6 chars, confirm must match
+- Success: toast "Password changed successfully", fields cleared
+- Wrong current password: inline error "Current password is incorrect"
+- Login with new password works after change
+
+**Known limitation:** OAuth-only users (no local password) see the form but get "current password incorrect" on submit. Deferred followup — should show SSO info message.
+
+### 5. Lockout/unlock (pre-existing, PR #1296)
+
+What to check:
+- Fail login 5x for any username → 6th attempt returns 429 (locked out)
+- Admin clicks "解除锁定" (Unlock) on that user → user can attempt login again
+- `POST /api/admin/auth/unlock` endpoint live and gated (401 without auth, 403 from non-dev workspace)
+
+## Known issues
+
+1. **Preview seeder doesn't reliably populate on every rebuild.** `setup-preview.sh` moves the old preview dir to `.bak` and rsyncs fresh — the `--exclude 'output/*.db'` means the DB starts empty. The seeder block (step [8/8]) sometimes doesn't surface output. Workaround: manually re-seed via `manage-user.ts` (see seeding command above).
+
+2. **OAuth-only users see unusable change-password form.** Casdoor/SSO users with no local password get "current password incorrect" on submit. Should show "Your account uses SSO login" message. Deferred.
+
+## Vault artifacts
+
+| Path | Content |
+|------|---------|
+| `projects/trends/work/2026-06-19-admin-auth-ui-scope-c/spec.md` | Locked spec (8 grill-me decisions) |
+| `projects/trends/work/2026-06-19-admin-auth-ui-scope-c/plan.md` | 12-task TDD implementation plan (all complete) |
+| `projects/trends/compound/2026-06-19-v0.4.6-to-main-lessons.md` | Cycle 4 preview deploy retro |
+| `raw/transcripts/2026-06-19-task-admin-auth-cli-gap.md` | CLI gap capture (no dedicated reset/unlock/disable CLI mode) |
+| `raw/transcripts/2026-06-19-task-self-service-password-change-ui.md` | Self-service password change capture |
+
+## Auto-memory entries (in `~/.claude/projects/.../memory/`)
+
+| File | Key fact |
+|------|----------|
+| `step-4-human-gate.md` | Never autonomously cut prod tags; Step 4 is human gate |
+| `admin-auth-ui-scope.md` | Vault-tracked spec pointer + 8 locked decisions summary |
+| `preview-seeder-gap.md` | `setup-preview.sh` seeder gap + manual seed command |
+
+## Suggested skills
+
+- **`/playwright-cli`** — Drive browser verification of all 5 features above against `https://preview.pt-mes.com`
+- **`/dev-loop`** — If the seeder gap or OAuth UX followup needs implementation
+- **`/wiki-add-task`** — Capture any new findings during verification
+- **`/wiki-query`** — Search vault for related prior art if issues surface

--- a/packages/shared/src/system-debug-metadata.ts
+++ b/packages/shared/src/system-debug-metadata.ts
@@ -321,6 +321,13 @@ export const SETTINGS_NAV_ITEMS: SurfaceNavDefinition[] = [
     hrefSuffix: "/settings/export-fields",
     matchesSuffixes: ["/settings/export-fields"],
   },
+  {
+    id: "account",
+    titleKey: "settings.account.nav",
+    defaultTitle: "Account",
+    hrefSuffix: "/settings/account",
+    matchesSuffixes: ["/settings/account"],
+  },
 ];
 
 export const SYSTEM_SETTINGS_NAV_ITEMS: SurfaceNavDefinition[] = [


### PR DESCRIPTION
## Summary
- Preserve the one-time temporary password in the admin users panel after the create dialog closes.
- Route workspace-scoped `/system/*` URLs to an explicit admin-access-required state or canonical system route instead of workspace 404.
- Update the repo dev-loop config note to require `simplify:simplify` for code-review cleanup.

## Test Plan
- npm --workspace @trends/web test -- CreateUserDialog.test.tsx UsersPanel.test.tsx App.test.tsx
- git diff --check
- make check

## Notes
- Browser verification was completed during the auth preview loop before this merge step: `/hr/system/settings/auth`, `/hr/settings/account`, and admin create-user temp-password persistence were checked locally with no console errors/warnings.